### PR TITLE
Make std::initializer_list visible.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -281,6 +281,7 @@ add_clang_executable(insights
     RangeForStmtHandler.cpp
     StaticAssertHandler.cpp
     StaticHandler.cpp
+    StdInitializerListHandler.cpp
     StructuredBindingsHandler.cpp
     TemplateHandler.cpp
     UserDefinedLiteralHandler.cpp

--- a/CodeGenerator.cpp
+++ b/CodeGenerator.cpp
@@ -899,6 +899,9 @@ void CodeGenerator::InsertArg(const CXXDefaultArgExpr* stmt)
 
 void CodeGenerator::InsertArg(const CXXStdInitializerListExpr* stmt)
 {
+    // No qualifiers like const or volatile here. This appears in  function calls or operators as a parameter. CV's are
+    // not allowed there.
+    mOutputFormatHelper.Append(GetName(stmt->getType(), Unqualified::Yes));
     InsertArg(stmt->getSubExpr());
 }
 //-----------------------------------------------------------------------------

--- a/Insights.cpp
+++ b/Insights.cpp
@@ -42,6 +42,7 @@
 #include "RangeForStmtHandler.h"
 #include "StaticAssertHandler.h"
 #include "StaticHandler.h"
+#include "StdInitializerListHandler.h"
 #include "StructuredBindingsHandler.h"
 #include "TemplateHandler.h"
 #include "UserDefinedLiteralHandler.h"
@@ -86,6 +87,7 @@ public:
     , mAutoStmtHandler{rewriter, mMatcher}
     , mNrvoHandler{rewriter, mMatcher}
     , mUserDefinedLiteralHandler{rewriter, mMatcher}
+    , mStdInitializerListHandler{rewriter, mMatcher}
     {
     }
 
@@ -106,6 +108,7 @@ private:
     AutoStmtHandler           mAutoStmtHandler;
     NRVOHandler               mNrvoHandler;
     UserDefinedLiteralHandler mUserDefinedLiteralHandler;
+    StdInitializerListHandler mStdInitializerListHandler;
 };
 //-----------------------------------------------------------------------------
 

--- a/StdInitializerListHandler.cpp
+++ b/StdInitializerListHandler.cpp
@@ -1,0 +1,74 @@
+/******************************************************************************
+ *
+ * C++ Insights, copyright (C) by Andreas Fertig
+ * Distributed under an MIT license. See LICENSE for details
+ *
+ ****************************************************************************/
+
+#include "StdInitializerListHandler.h"
+#include "CodeGenerator.h"
+#include "InsightsHelpers.h"
+#include "InsightsMatchers.h"
+#include "InsightsStaticStrings.h"
+#include "OutputFormatHelper.h"
+//-----------------------------------------------------------------------------
+
+using namespace clang;
+using namespace clang::ast_matchers;
+//-----------------------------------------------------------------------------
+
+namespace clang::insights {
+
+StdInitializerListHandler::StdInitializerListHandler(Rewriter& rewrite, MatchFinder& matcher)
+: InsightsBase(rewrite)
+{
+    const auto operatorMatcher = anyOf(isExpansionInSystemHeader(),
+                                       isMacroOrInvalidLocation(),
+                                       isTemplate,
+                                       hasAncestor(ifStmt()),
+                                       hasAncestor(switchStmt()),
+                                       /* if we match the top-most CXXOperatorCallExpr we will see all
+                                          descendants. So filter them here to avoid getting them multiple times */
+                                       hasAncestor(cxxOperatorCallExpr()),
+                                       hasLambdaAncestor,
+                                       hasAncestor(implicitCastExpr(hasMatchingCast())),
+                                       hasAncestor(userDefinedLiteral()),
+                                       hasAncestor(cxxForRangeStmt())
+#ifdef MATCH_CXX_MEM_CEXPR
+                                           ,
+                                       hasAncestor(cxxMemberCallExpr())
+#endif
+    );
+
+    matcher.addMatcher(
+        cxxStdInitializerListExpr(unless(operatorMatcher), hasParent(expr().bind("expr"))).bind("initializer"), this);
+}
+//-----------------------------------------------------------------------------
+
+void StdInitializerListHandler::run(const MatchFinder::MatchResult& result)
+{
+    if(const auto* initList = result.Nodes.getNodeAs<CXXStdInitializerListExpr>("initializer")) {
+        OutputFormatHelper outputFormatHelper{};
+        CodeGenerator      codeGenerator{outputFormatHelper};
+
+        const auto* expr = result.Nodes.getNodeAs<CXXConstructExpr>("expr");
+        const bool isCtorInit{expr && (1 == expr->getNumArgs())};  // If an initializer list appears in a constructor as
+                                                                   // a single argument we need to add braces.
+
+        if(isCtorInit) {
+            outputFormatHelper.Append("{ ");
+        }
+
+        codeGenerator.InsertArg(initList);
+
+        if(isCtorInit) {
+            outputFormatHelper.Append(" }");
+        }
+
+        DPrint("replacementInit: %s\n", outputFormatHelper.GetString());
+        mRewrite.ReplaceText(initList->getSourceRange(), outputFormatHelper.GetString());
+    }
+}
+//-----------------------------------------------------------------------------
+
+}  // namespace clang::insights

--- a/StdInitializerListHandler.h
+++ b/StdInitializerListHandler.h
@@ -1,0 +1,50 @@
+/******************************************************************************
+ *
+ * C++ Insights, copyright (C) by Andreas Fertig
+ * Distributed under an MIT license. See LICENSE for details
+ *
+ ****************************************************************************/
+
+#ifndef INSIGHTS_STD_INITIALIZER_LIST_HANDLER_H
+#define INSIGHTS_STD_INITIALIZER_LIST_HANDLER_H
+
+#include "clang/AST/AST.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+#include "clang/ASTMatchers/ASTMatchers.h"
+#include "clang/Rewrite/Core/Rewriter.h"
+
+#include "InsightsBase.h"
+//-----------------------------------------------------------------------------
+
+namespace clang::insights {
+
+/// \brief Show where \c std::initializer_list is used.
+///
+/// With C++11 uniform initialization and  initializer lists we cannot
+/// longer easily see whether we are calling a normal constructor or one
+/// which takes a initializer_list. For example:
+///
+/// \begincode
+/// struct V {
+///   V(int x) {}
+///   V(std::initializer_list<int> x) {}
+/// };
+///
+/// V v{1};
+/// V vv{1, 2};
+/// \endcode
+///
+/// Surprisingly to some people, in both cases the second constructor, taking
+/// a std::initializer_list, is used.
+class StdInitializerListHandler final : public ast_matchers::MatchFinder::MatchCallback, public InsightsBase
+{
+public:
+    StdInitializerListHandler(Rewriter& rewrite, ast_matchers::MatchFinder& matcher);
+    void run(const ast_matchers::MatchFinder::MatchResult& result) override;
+};
+//-----------------------------------------------------------------------------
+
+}  // namespace clang::insights
+
+#endif /* INSIGHTS_STD_INITIALIZER_LIST_HANDLER_H */

--- a/tests/InitalizerListTest.expect
+++ b/tests/InitalizerListTest.expect
@@ -1,9 +1,9 @@
 #include <vector>
 
 int main(){
-  std::vector<int> myVec{1,2,3,4,5,6,7,8,9};
+  std::vector<int> myVec{ std::initializer_list<int>{ 1, 2, 3, 4, 5, 6, 7, 8, 9 } };
 
-  myVec.operator=({ 1, 2, 3, 4, 5, 6, 7, 8, 9 });
+  myVec.operator=(std::initializer_list<int>{ 1, 2, 3, 4, 5, 6, 7, 8, 9 });
   
 }
 

--- a/tests/InitializerListTest.cpp
+++ b/tests/InitializerListTest.cpp
@@ -1,0 +1,63 @@
+#include <utility>
+
+class X {
+public:
+  ~X() {}
+  
+  X(std::initializer_list<int> x) {}
+
+  X(int z, std::initializer_list<int> x) {}
+
+  X(std::initializer_list<int> x, int z) {}
+  
+  X(void *x, int y) {}
+
+  X& operator+=(const std::initializer_list<int>& x)
+  {
+     return *this;
+  }
+};
+
+struct V {
+  V(int x) {}
+  V(std::initializer_list<int> x) {}
+
+};
+
+struct Y { int x, y; };
+
+void takes_y(Y y);
+
+void bar(std::initializer_list<int> x) {}
+
+
+template<typename T>
+void something(std::initializer_list<T>) {}
+
+void foo() {
+    X{1, 2, 3};
+    X{nullptr, 0};
+
+    X x{3, 4, 5};
+    X b{1};
+
+    X{1, {2, 3}};
+    X c{1, {2, 3}};
+
+    X{{1, 2}, 3};
+    X d{{1, 2}, 3};
+    
+    b += {2 ,4};
+
+    takes_y({1, 2});
+
+    bar( {1, 2} );
+
+    something( {1 , 2} );
+
+    something( {1.0f , 2.0f} );
+
+    V v{1};
+    V vv{1, 2};
+}
+

--- a/tests/InitializerListTest.expect
+++ b/tests/InitializerListTest.expect
@@ -1,0 +1,85 @@
+#include <utility>
+
+class X {
+public:
+  ~X() {}
+  
+  X(std::initializer_list<int> x) {}
+
+  X(int z, std::initializer_list<int> x) {}
+
+  X(std::initializer_list<int> x, int z) {}
+  
+  X(void *x, int y) {}
+
+  X& operator+=(const std::initializer_list<int>& x)
+  {
+     return *this;
+  }
+/* public: inline constexpr X(const X &); */
+};
+
+struct V {
+  V(int x) {}
+  V(std::initializer_list<int> x) {}
+
+/* public: inline constexpr V(const V &); */
+/* public: inline constexpr V(V &&); */
+};
+
+struct Y { int x, y; /* public: inline ~Y() noexcept; */
+};
+
+void takes_y(Y y);
+
+void bar(std::initializer_list<int> x) {}
+
+
+template<typename T>
+void something(std::initializer_list<T>) {}
+
+/* First instantiated from: InitializerListTest.cpp:56 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+void something<int>(std::initializer_list<int>)
+{
+}
+#endif
+
+
+/* First instantiated from: InitializerListTest.cpp:58 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+void something<float>(std::initializer_list<float>)
+{
+}
+#endif
+
+
+void foo() {
+    X{ std::initializer_list<int>{ 1, 2, 3 } };
+    X{nullptr, 0};
+
+    X x{ std::initializer_list<int>{ 3, 4, 5 } };
+    X b{ std::initializer_list<int>{ 1 } };
+
+    X{1, std::initializer_list<int>{ 2, 3 }};
+    X c{1, std::initializer_list<int>{ 2, 3 }};
+
+    X{std::initializer_list<int>{ 1, 2 }, 3};
+    X d{std::initializer_list<int>{ 1, 2 }, 3};
+    
+    b.operator+=(std::initializer_list<int>{ 2, 4 });
+
+    takes_y({1, 2});
+
+    bar( std::initializer_list<int>{ 1, 2 } );
+
+    something( std::initializer_list<int>{ 1, 2 } );
+
+    something( std::initializer_list<float>{ 1.0f, 2.0f } );
+
+    V v{ std::initializer_list<int>{ 1 } };
+    V vv{ std::initializer_list<int>{ 1, 2 } };
+}
+

--- a/tests/LambdaHandler7Test.expect
+++ b/tests/LambdaHandler7Test.expect
@@ -3,7 +3,7 @@
 
 int main()
 {
-  std::vector<int> myVec{1,2,3,4,5};
+  std::vector<int> myVec{ std::initializer_list<int>{ 1, 2, 3, 4, 5 } };
 
 
    class __lambda_8_57

--- a/tests/RangeForStmtHandler2Test.expect
+++ b/tests/RangeForStmtHandler2Test.expect
@@ -19,7 +19,7 @@ int main()
        }
      }
 
-    std::vector<int> v{1, 2, 3, 5};
+    std::vector<int> v{ std::initializer_list<int>{ 1, 2, 3, 5 } };
 
     {
        std::vector<int, std::allocator<int> > & __range1 = v;

--- a/tests/RangeForStmtHandlerTest.expect
+++ b/tests/RangeForStmtHandlerTest.expect
@@ -108,7 +108,7 @@ int main()
        }
      }
 
-    std::vector<int> v{1, 2, 3, 5};
+    std::vector<int> v{ std::initializer_list<int>{ 1, 2, 3, 5 } };
 
     {
        std::vector<int, std::allocator<int> > & __range1 = v;

--- a/tests/TemplateExpansionTest.expect
+++ b/tests/TemplateExpansionTest.expect
@@ -55,7 +55,7 @@ void foo2() {
   template<int fp(void)> class testDecl { };
   /* First instantiated from: TemplateExpansionTest.cpp:45 */
   #ifdef INSIGHTS_USE_TEMPLATE
-  class testDecl</* INSIGHTS-TODO: CodeGenerator.cpp:927 stmt: Function */>
+  class testDecl</* INSIGHTS-TODO: CodeGenerator.cpp:931 stmt: Function */>
   {
     
   };


### PR DESCRIPTION
With C++11 uniform initialization and  initializer lists we cannot
longer easily see whether we are calling a normal constructor or one
which takes a initializer_list. For example:

struct V {
  V(int x) {}
  V(std::initializer_list<int> x) {}

};

V v{1};
V vv{1, 2};

Surprisingly to some people, in both cases the second constructor, taking
a std::initializer_list, is used.

This change shows the difference by putting the name
std::initializer_list<T> in front of an initializer list.