### PR TITLE
Fixed #13: const disappeared in case of auto.

### DIFF
--- a/InsightsHelpers.cpp
+++ b/InsightsHelpers.cpp
@@ -189,7 +189,6 @@ static std::string GetScope(const DeclContext* declCtx)
 static std::string GetNameInternal(const QualType& t, const Unqualified unqualified)
 {
     if(t.getTypePtrOrNull()) {
-        const std::string cvqStr{t.getQualifiers().getAsString()};
         std::string       refOrPointer{};
         const RecordType* recordType = [&]() -> const RecordType* {
             const auto& ct  = t.getCanonicalType();
@@ -213,6 +212,13 @@ static std::string GetNameInternal(const QualType& t, const Unqualified unqualif
 
         if(recordType) {
             if(const auto* decl = recordType->getDecl()) {
+                const std::string cvqStr{[&]() {
+                    if(const auto* refType = dyn_cast_or_null<ReferenceType>(t.getTypePtrOrNull())) {
+                        return refType->getPointeeTypeAsWritten().getLocalQualifiers().getAsString();
+                    }
+
+                    return t.getLocalQualifiers().getAsString();
+                }()};
 
                 if(const auto* tt = dyn_cast_or_null<ClassTemplateSpecializationDecl>(decl)) {
                     if(const auto* x = t.getBaseTypeIdentifier()) {

--- a/tests/ClassOperatorHandler9Test.expect
+++ b/tests/ClassOperatorHandler9Test.expect
@@ -60,7 +60,7 @@ MyVector<T> operator*(const MyVector<T>& a, const MyVector<T>& b)
 /* First instantiated from: ClassOperatorHandler9Test.cpp:68 */
 #ifdef INSIGHTS_USE_TEMPLATE
 template<>
-MyVector<int> operator*<int>(MyVector<int> & a, MyVector<int> & b)
+MyVector<int> operator*<int>(const MyVector<int> & a, const MyVector<int> & b)
 {
   MyVector<int> result = MyVector<int>(a.size()) /* NRVO variable */;
   for(std::size_t s = 0;

--- a/tests/Issue13.cpp
+++ b/tests/Issue13.cpp
@@ -1,0 +1,18 @@
+#include <iostream>
+#include <memory>
+
+std::shared_ptr<int> create() {
+    return std::make_shared<int>(42);
+}
+
+int main()
+{
+  const auto& car = create(); 
+  const auto&& cart = create();
+  auto&& carte = create();
+
+  const auto& vcar = create(); 
+  const volatile auto&& cvcart = create();
+  volatile auto&& vcart = create();
+  volatile auto&& vcarte = create();
+}

--- a/tests/Issue13.expect
+++ b/tests/Issue13.expect
@@ -1,0 +1,18 @@
+#include <iostream>
+#include <memory>
+
+std::shared_ptr<int> create() {
+    return std::make_shared<int>(42);
+}
+
+int main()
+{
+  const std::shared_ptr<int> & car = create(); 
+  const std::shared_ptr<int> && cart = create();
+  std::shared_ptr<int> && carte = create();
+
+  const std::shared_ptr<int> & vcar = create(); 
+  const volatile std::shared_ptr<int> && cvcart = create();
+  volatile std::shared_ptr<int> && vcart = create();
+  volatile std::shared_ptr<int> && vcarte = create();
+}

--- a/tests/TemplateArgumentsTest.expect
+++ b/tests/TemplateArgumentsTest.expect
@@ -39,7 +39,7 @@ inline static const int & Normalize<int>(const int & arg)
 /* First instantiated from: TemplateArgumentsTest.cpp:16 */
 #ifdef INSIGHTS_USE_TEMPLATE
 template<>
-inline static const char * Normalize<std::basic_string<char> >(std::basic_string<char> & arg)
+inline static const char * Normalize<std::basic_string<char> >(const std::basic_string<char> & arg)
 {
   if constexpr( std::is_same_v<std::basic_string<char>, std::basic_string<char>> ) {
     return arg.c_str();
@@ -77,7 +77,7 @@ void Log<int>(const char * fmt, const int & ts)
 /* First instantiated from: TemplateArgumentsTest.cpp:28 */
 #ifdef INSIGHTS_USE_TEMPLATE
 template<>
-void Log<std::basic_string<char> >(const char * fmt, std::basic_string<char> & ts)
+void Log<std::basic_string<char> >(const char * fmt, const std::basic_string<char> & ts)
 {
   printf(fmt, Normalize(ts));
 }


### PR DESCRIPTION
Due to lambdas there is special handling for QualType in case it is a
RecordDecl or a ClassTemplateSpecializationDecl. It appears that, if the
type is a ReferenceType the CV qualifiers come from the reference type
getPointeeTypeAsWritten(). Ohterwise they are empty. This fix adds
special handling for that, nearly the same way as TypePrinter.cpp does
it.