### PR TITLE
Fixed #15: user defined literal with template argument.

### DIFF
--- a/tests/Issue15.cpp
+++ b/tests/Issue15.cpp
@@ -1,0 +1,28 @@
+#include <chrono>
+#include <string>
+
+std::chrono::seconds operator"" _s(unsigned long long s) {
+    return std::chrono::seconds(s);
+}
+
+std::string operator"" _str(const char *s, std::size_t len) {
+    return std::string(s, len);
+}
+
+
+template<typename T, T... C>
+constexpr int operator""_x()
+{
+  return 0;
+}
+
+int main()
+{
+    using namespace std::literals;
+    std::chrono::seconds t = 98291919s;
+    
+    auto t4 = "12345"_x;
+
+    auto str = "abcd"_str;
+    auto sec = 4_s;
+}

--- a/tests/Issue15.expect
+++ b/tests/Issue15.expect
@@ -1,0 +1,38 @@
+#include <chrono>
+#include <string>
+
+std::chrono::seconds operator"" _s(unsigned long long s) {
+    return std::chrono::seconds(s);
+}
+
+std::string operator"" _str(const char *s, std::size_t len) {
+    return std::string(s, len);
+}
+
+
+template<typename T, T... C>
+constexpr int operator""_x()
+{
+  return 0;
+}
+
+/* First instantiated from: Issue15.cpp:24 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+inline constexpr int operator""_x<char, 49, 50, 51, 52, 53>()
+{
+  return 0;
+}
+#endif
+
+
+int main()
+{
+    using namespace std::literals;
+    std::chrono::seconds t = std::operator""s(98291919ull);
+    
+    int t4 = operator""_x<char, 49, 50, 51, 52, 53>();
+
+    std::basic_string<char> str = operator""_str("abcd", 4ul);
+    std::chrono::duration<long long, std::ratio<1, 1> > sec = operator""_s(4ull);
+}

--- a/tests/TemplateExpansionTest.expect
+++ b/tests/TemplateExpansionTest.expect
@@ -55,7 +55,7 @@ void foo2() {
   template<int fp(void)> class testDecl { };
   /* First instantiated from: TemplateExpansionTest.cpp:45 */
   #ifdef INSIGHTS_USE_TEMPLATE
-  class testDecl</* INSIGHTS-TODO: CodeGenerator.cpp:964 stmt: Function */>
+  class testDecl</* INSIGHTS-TODO: CodeGenerator.cpp:985 stmt: Function */>
   {
     
   };


### PR DESCRIPTION
There is special handling required for user defined literals which are
templated. The libstdc++ under Linux seems to be implemented that way
for seconds. Without this change the parameter list was empty.