### PR TITLE
Fixed user defined literals as subexpression.

### DIFF
--- a/UserDefinedLiteralHandler.cpp
+++ b/UserDefinedLiteralHandler.cpp
@@ -29,6 +29,8 @@ UserDefinedLiteralHandler::UserDefinedLiteralHandler(Rewriter& rewrite, MatchFin
                                            descendants. So filter them here to avoid getting them multiple times */
                                         hasAncestor(cxxOperatorCallExpr()),
                                         hasLambdaAncestor,
+                                        hasAncestor(ifStmt()),
+                                        hasAncestor(switchStmt()),
                                         hasAncestor(implicitCastExpr(hasMatchingCast())),
 #ifdef MATCH_CXX_MEM_CEXPR
                                         hasAncestor(cxxMemberCallExpr()),

--- a/tests/UserDefinedLiteral2Test.cpp
+++ b/tests/UserDefinedLiteral2Test.cpp
@@ -1,0 +1,15 @@
+#include <chrono>
+
+using seconds_t      = std::chrono::seconds;
+
+constexpr seconds_t operator ""_s(unsigned long long s)
+{
+    return seconds_t(s);
+}
+
+int main()
+{
+    if(true) {
+        auto s = 1_s;
+    }
+}

--- a/tests/UserDefinedLiteral2Test.expect
+++ b/tests/UserDefinedLiteral2Test.expect
@@ -1,0 +1,16 @@
+#include <chrono>
+
+using seconds_t      = std::chrono::seconds;
+
+constexpr seconds_t operator ""_s(unsigned long long s)
+{
+    return seconds_t(s);
+}
+
+int main()
+{
+    if( true ) {
+       std::chrono::duration<long long, std::ratio<1, 1> > s = operator""_s(1ull);
+     }
+     
+}


### PR DESCRIPTION
Adjust the UDL matcher to exclude if and switch statements, as they are
handled separately.