### PR TITLE
Fixed std::initializer_list.

### DIFF
--- a/ImplicitCastHandler.cpp
+++ b/ImplicitCastHandler.cpp
@@ -52,6 +52,7 @@ ImplicitCastHandler::ImplicitCastHandler(Rewriter& rewrite, MatchFinder& matcher
         /* exclude if/switch init, that will be handeled by them */
         hasAncestor(ifStmt()),
         hasAncestor(switchStmt()),
+        hasAncestor(cxxConstructExpr(hasArgument(0, cxxStdInitializerListExpr()))),
         hasAncestor(cxxOperatorCallExpr()));
 
     matcher.addMatcher(

--- a/tests/InitializerList2Test.cpp
+++ b/tests/InitializerList2Test.cpp
@@ -1,0 +1,14 @@
+#include <initializer_list>
+
+class Foo
+{
+public:
+    Foo(std::initializer_list<int> x, const bool b=false, const int z=2){}
+};
+
+int main()
+{
+  Foo f{1};
+  Foo f2{1, true};
+  Foo f3{1, true, 4};
+}

--- a/tests/InitializerList2Test.expect
+++ b/tests/InitializerList2Test.expect
@@ -1,0 +1,16 @@
+#include <initializer_list>
+
+class Foo
+{
+public:
+    Foo(std::initializer_list<int> x, const bool b=false, const int z=2){}
+/* public: inline constexpr Foo(const Foo &); */
+/* public: inline constexpr Foo(Foo &&); */
+};
+
+int main()
+{
+  Foo f{ std::initializer_list<int>{ 1 } };
+  Foo f2{ std::initializer_list<int>{ 1, static_cast<const int>(true) } };
+  Foo f3{ std::initializer_list<int>{ 1, static_cast<const int>(true), 4 } };
+}


### PR DESCRIPTION
Take more places and cases into account, for example a constructor with
a std::initializer_list and a default argument like std::map.