### PR TITLE
Fixed #15: UDL with libstdc++.

### DIFF
--- a/CodeGenerator.cpp
+++ b/CodeGenerator.cpp
@@ -525,10 +525,11 @@ void CodeGenerator::InsertArg(const CallExpr* stmt)
                     mOutputFormatHelper.Append('<');
 
                     const TemplateArgument& Pack = Args->get(0);
-                    for(const auto& P : Pack.pack_elements()) {
-                        char C{static_cast<char>(P.getAsIntegral().getZExtValue())};
-                        mOutputFormatHelper.Append(C);
-                    }
+
+                    ForEachArg(Pack.pack_elements(), [&](const auto& arg) {
+                        char C{static_cast<char>(arg.getAsIntegral().getZExtValue())};
+                        mOutputFormatHelper.Append("'", std::string{C}, "'");
+                    });
 
                     mOutputFormatHelper.Append('>');
                 }

--- a/tests/Issue15.cpp
+++ b/tests/Issue15.cpp
@@ -1,28 +1,37 @@
 #include <chrono>
 #include <string>
 
-std::chrono::seconds operator"" _s(unsigned long long s) {
+std::chrono::seconds operator"" _s(unsigned long long s)
+{
     return std::chrono::seconds(s);
 }
 
-std::string operator"" _str(const char *s, std::size_t len) {
+std::string operator"" _str(const char* s, std::size_t len)
+{
     return std::string(s, len);
 }
 
+template<char... _Digits>
+constexpr int operator""_cs()
+{
+    return 0;
+}
 
 template<typename T, T... C>
 constexpr int operator""_x()
 {
-  return 0;
+    return 0;
 }
 
 int main()
 {
     using namespace std::literals;
     std::chrono::seconds t = 98291919s;
-    
+
     auto t4 = "12345"_x;
 
     auto str = "abcd"_str;
     auto sec = 4_s;
+
+   auto cookedTemplateLiteral = 4567_cs; // g++: int cookedTemplateLiteral = operator""_cs<'4', '5', '6', '7'>();
 }

--- a/tests/Issue15.expect
+++ b/tests/Issue15.expect
@@ -1,22 +1,39 @@
 #include <chrono>
 #include <string>
 
-std::chrono::seconds operator"" _s(unsigned long long s) {
+std::chrono::seconds operator"" _s(unsigned long long s)
+{
     return std::chrono::seconds(s);
 }
 
-std::string operator"" _str(const char *s, std::size_t len) {
+std::string operator"" _str(const char* s, std::size_t len)
+{
     return std::string(s, len);
 }
+
+template<char... _Digits>
+constexpr int operator""_cs()
+{
+    return 0;
+}
+
+/* First instantiated from: Issue15.cpp:36 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+inline constexpr int operator""_cs<52, 53, 54, 55>()
+{
+  return 0;
+}
+#endif
 
 
 template<typename T, T... C>
 constexpr int operator""_x()
 {
-  return 0;
+    return 0;
 }
 
-/* First instantiated from: Issue15.cpp:24 */
+/* First instantiated from: Issue15.cpp:31 */
 #ifdef INSIGHTS_USE_TEMPLATE
 template<>
 inline constexpr int operator""_x<char, 49, 50, 51, 52, 53>()
@@ -30,9 +47,11 @@ int main()
 {
     using namespace std::literals;
     std::chrono::seconds t = std::operator""s(98291919ull);
-    
+
     int t4 = operator""_x<char, 49, 50, 51, 52, 53>();
 
     std::basic_string<char> str = operator""_str("abcd", 4ul);
     std::chrono::duration<long long, std::ratio<1, 1> > sec = operator""_s(4ull);
+
+   int cookedTemplateLiteral = operator""_cs<'4', '5', '6', '7'>(); // g++: int cookedTemplateLiteral = operator""_cs<'4', '5', '6', '7'>();
 }

--- a/tests/TemplateExpansionTest.expect
+++ b/tests/TemplateExpansionTest.expect
@@ -55,7 +55,7 @@ void foo2() {
   template<int fp(void)> class testDecl { };
   /* First instantiated from: TemplateExpansionTest.cpp:45 */
   #ifdef INSIGHTS_USE_TEMPLATE
-  class testDecl</* INSIGHTS-TODO: CodeGenerator.cpp:985 stmt: Function */>
+  class testDecl</* INSIGHTS-TODO: CodeGenerator.cpp:986 stmt: Function */>
   {
     
   };


### PR DESCRIPTION
With libstc++ the UDL parameter of a cooked literal is passed as char
template arguments to the operator. In the initial fix the comma
separation and the ' where missing.