### PR TITLE
Fixed #28: Multiple matchers rewrote a statement.

### DIFF
--- a/UserDefinedLiteralHandler.cpp
+++ b/UserDefinedLiteralHandler.cpp
@@ -23,12 +23,12 @@ UserDefinedLiteralHandler::UserDefinedLiteralHandler(Rewriter& rewrite, MatchFin
     matcher.addMatcher(
         userDefinedLiteral(unless(anyOf(isExpansionInSystemHeader(),
                                         isMacroOrInvalidLocation(),
-                                        hasAncestor(cxxOperatorCallExpr()),
                                         hasAncestor(userDefinedLiteral()),
                                         isTemplate,
                                         /* if we match the top-most CXXOperatorCallExpr we will see all
                                            descendants. So filter them here to avoid getting them multiple times */
                                         hasAncestor(cxxOperatorCallExpr()),
+                                        hasAncestor(cxxStdInitializerListExpr()),
                                         hasLambdaAncestor,
                                         hasAncestor(ifStmt()),
                                         hasAncestor(switchStmt()),

--- a/tests/Issue28.cpp
+++ b/tests/Issue28.cpp
@@ -1,0 +1,9 @@
+#include <string>
+#include <vector>
+
+int main()
+{
+  using namespace std::string_literals;
+ 
+  std::vector<std::string> foo{"foo"s, "bar"s};
+}

--- a/tests/Issue28.expect
+++ b/tests/Issue28.expect
@@ -1,0 +1,9 @@
+#include <string>
+#include <vector>
+
+int main()
+{
+  using namespace std::string_literals;
+ 
+  std::vector<std::string> foo{ std::initializer_list<std::basic_string<char> >{ std::operator""s("foo", 3ul), std::operator""s("bar", 3ul) } };
+}


### PR DESCRIPTION
The user-defined literal matcher conflicted with the std initializer
list matcher.