### PR TITLE
Added support for expansion of class templates.

### DIFF
--- a/CodeGenerator.h
+++ b/CodeGenerator.h
@@ -105,6 +105,8 @@ public:
 
     virtual ~CodeGenerator() = default;
 
+#define IGNORED_DECL(type)                                                                                             \
+    virtual void InsertArg(const type*) {}
 #define IGNORED_STMT(type)                                                                                             \
     virtual void InsertArg(const type*) {}
 #define SUPPORTED_DECL(type) virtual void InsertArg(const type* stmt);
@@ -126,10 +128,12 @@ public:
     }
 
     STRONG_BOOL(SkipConstexpr);
+    STRONG_BOOL(SkipAccess);
 
     static void InsertAccessModifierAndNameWithReturnType(OutputFormatHelper&  outputFormatHelper,
                                                           const CXXMethodDecl& decl,
-                                                          SkipConstexpr        skipConstexpr = SkipConstexpr::No);
+                                                          const SkipConstexpr  skipConstexpr = SkipConstexpr::No,
+                                                          const SkipAccess     skipAccess    = SkipAccess::No);
 
 protected:
     void HandleCharacterLiteral(const CharacterLiteral& stmt);
@@ -159,6 +163,22 @@ protected:
     void InsertSuffix(const QualType& type);
     void InsertTemplateArgs(const ArrayRef<TemplateArgument>& array);
     void InsertTemplateArg(const TemplateArgument& arg);
+
+    /// \brief Check whether or not this statement will add curlys or parentheses and add them only if required.
+    void InsertCurlysIfRequired(const Stmt* stmt);
+
+    STRONG_BOOL(AddSpaceAtTheEnd);
+
+    enum class BraceKind
+    {
+        Parens,
+        Curlys
+    };
+
+    template<typename T>
+    void WrapInParensOrCurlys(const BraceKind        curlys,
+                              T&&                    lambda,
+                              const AddSpaceAtTheEnd addSpaceAtTheEnd = AddSpaceAtTheEnd::No);
 
     static const char* GetKind(const UnaryExprOrTypeTraitExpr& uk);
     static const char* GetOpcodeName(const int kind);

--- a/CodeGeneratorTypes.h
+++ b/CodeGeneratorTypes.h
@@ -17,13 +17,22 @@
 IGNORED_STMT(OMPOrderedDirective)
 IGNORED_STMT(OMPParallelForDirective)
 
-IGNORED_DECL(StaticAssertDecl)
+IGNORED_DECL(UsingShadowDecl)
+IGNORED_DECL(UsingPackDecl)
 
 SUPPORTED_DECL(DecompositionDecl)
 SUPPORTED_DECL(VarDecl)
 SUPPORTED_DECL(TypeAliasDecl)
 SUPPORTED_DECL(TypedefDecl)
+SUPPORTED_DECL(StaticAssertDecl)
+SUPPORTED_DECL(FieldDecl)
+SUPPORTED_DECL(AccessSpecDecl)
+SUPPORTED_DECL(CXXMethodDecl)
+SUPPORTED_DECL(UsingDecl)
+SUPPORTED_DECL(CXXRecordDecl)
 
+SUPPORTED_STMT(CXXDeleteExpr)
+SUPPORTED_STMT(CXXDefaultInitExpr)
 SUPPORTED_STMT(MemberExpr)
 SUPPORTED_STMT(IntegerLiteral)
 SUPPORTED_STMT(StringLiteral)

--- a/InsightsBase.h
+++ b/InsightsBase.h
@@ -33,8 +33,10 @@ protected:
 
     STRONG_BOOL(SkipConstexpr);
 
+public:
     static void GenerateFunctionPrototype(OutputFormatHelper& outputFormatHelper, const FunctionDecl& FD);
 
+protected:
     bool SkipIfAlreadySeen(const Stmt* stmt);
 
 private:

--- a/NumberIterator.h
+++ b/NumberIterator.h
@@ -1,0 +1,34 @@
+#ifndef INSIGHTS_NUMBER_ITERATOR_H
+#define INSIGHTS_NUMBER_ITERATOR_H
+
+template<typename T>
+class NumberIterator
+{
+public:
+    NumberIterator(const T num)
+    : mNum{num}
+    , mCount{0}
+    {
+    }
+
+    const T& operator*() const { return mCount; }
+
+    NumberIterator& operator++()
+    {
+        ++mCount;
+
+        return *this;
+    }
+
+    bool operator!=(const NumberIterator&) const { return mCount < mNum; }
+
+    const NumberIterator& begin() const { return *this; }
+    const NumberIterator& end() const { return *this; }
+
+private:
+    const T mNum;
+    T       mCount;
+};
+//-----------------------------------------------------------------------------
+
+#endif /* INSIGHTS_NUMBER_ITERATOR_H */

--- a/TemplateHandler.cpp
+++ b/TemplateHandler.cpp
@@ -44,6 +44,10 @@ void TemplateHandler::run(const MatchFinder::MatchResult& result)
         InsertInstantiatedTemplate(*functionDecl, result);
 
     } else if(const auto* clsTmplSpecDecl = result.Nodes.getNodeAs<ClassTemplateSpecializationDecl>("class")) {
+        // skip classes/struct's without a definition
+        if(!clsTmplSpecDecl->hasDefinition()) {
+            return;
+        }
 
         OutputFormatHelper outputFormatHelper{};
         outputFormatHelper.AppendNewLine();
@@ -53,19 +57,9 @@ void TemplateHandler::run(const MatchFinder::MatchResult& result)
 
         outputFormatHelper.AppendNewLine("#ifdef INSIGHTS_USE_TEMPLATE");
 
-        outputFormatHelper.Append(kwClassSpace, GetName(*clsTmplSpecDecl));
-
         CodeGenerator codeGenerator{outputFormatHelper};
-        codeGenerator.InsertTemplateArgs(*clsTmplSpecDecl);
+        codeGenerator.InsertArg(clsTmplSpecDecl);
 
-        outputFormatHelper.AppendNewLine();
-
-        outputFormatHelper.OpenScope();
-
-        outputFormatHelper.CloseScopeWithSemi();
-        outputFormatHelper.AppendNewLine();
-
-        outputFormatHelper.AppendNewLine();
         outputFormatHelper.AppendNewLine("#endif");
 
         const auto* clsTmplDecl = result.Nodes.getNodeAs<ClassTemplateDecl>("decl");

--- a/scripts/travis_install.sh
+++ b/scripts/travis_install.sh
@@ -2,6 +2,7 @@
 
 if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
    export HOMEBREW_NO_AUTO_UPDATE=1
+   brew update > /dev/null
    brew install cmake || brew upgrade cmake
    brew install xz || brew upgrade xz
 

--- a/tests/AutoHandler5Test.cpp
+++ b/tests/AutoHandler5Test.cpp
@@ -1,0 +1,10 @@
+int foo(int a,int b){ return a+b; }
+
+int main(){
+  if(true) {
+    int (*add)(int,int)= foo;
+    // auto within a function pointer
+    auto add1= foo;         
+  }
+}
+

--- a/tests/AutoHandler5Test.expect
+++ b/tests/AutoHandler5Test.expect
@@ -1,0 +1,12 @@
+int foo(int a,int b){ return a+b; }
+
+int main(){
+  if(true) {
+     using FuncPtr_5 = int (*)(int, int);
+     FuncPtr_5 add = foo;
+     using FuncPtr_7 = int (*)(int, int);
+     FuncPtr_7 add1 = foo;
+   }
+   
+}
+

--- a/tests/CXXDefaultInitExprTest.cpp
+++ b/tests/CXXDefaultInitExprTest.cpp
@@ -1,0 +1,18 @@
+template<typename T, bool array>
+class Alloc
+{
+    const int z;
+    T* data{nullptr};    
+    const bool x{false};
+    
+public:
+    Alloc() : z{2}
+    {
+    }
+};
+
+int main()
+{
+    Alloc<int, false> a;
+    Alloc<char, true> b;
+}

--- a/tests/CXXDefaultInitExprTest.expect
+++ b/tests/CXXDefaultInitExprTest.expect
@@ -1,0 +1,64 @@
+template<typename T, bool array>
+class Alloc
+{
+    const int z;
+    T* data{nullptr};    
+    const bool x{false};
+    
+public:
+    Alloc() : z{2}
+    {
+    }
+};
+/* First instantiated from: CXXDefaultInitExprTest.cpp:16 */
+#ifdef INSIGHTS_USE_TEMPLATE
+class Alloc<int, 0>
+{
+  const int z;
+  int * data;
+  const bool x;
+  
+  public: 
+  inline Alloc()
+  : z{2}
+  , data{nullptr}
+  , x{false}
+  {
+  }
+  
+  inline constexpr Alloc(const Alloc<int, 0> &) = default;
+  inline constexpr Alloc(Alloc<int, 0> &&) = default;
+  
+};
+
+#endif
+
+/* First instantiated from: CXXDefaultInitExprTest.cpp:17 */
+#ifdef INSIGHTS_USE_TEMPLATE
+class Alloc<char, 1>
+{
+  const int z;
+  char * data;
+  const bool x;
+  
+  public: 
+  inline Alloc()
+  : z{2}
+  , data{nullptr}
+  , x{false}
+  {
+  }
+  
+  inline constexpr Alloc(const Alloc<char, 1> &) = default;
+  inline constexpr Alloc(Alloc<char, 1> &&) = default;
+  
+};
+
+#endif
+
+
+int main()
+{
+    Alloc<int, false> a;
+    Alloc<char, true> b;
+}

--- a/tests/CXXDestructorTest.cpp
+++ b/tests/CXXDestructorTest.cpp
@@ -1,0 +1,31 @@
+template<typename T, bool array>
+class Alloc
+{
+    T* data;
+    
+public:
+    Alloc() {
+        if( array ) {
+            data = new T[10];
+            data = new T[10]{1,2,3};
+        } else {
+            data = new T;
+            data = new T(2);
+            data = new T{2};
+        }
+    }
+
+    ~Alloc() {
+        if( array ) {
+            delete[] data;
+        } else {
+            delete data;
+        }
+    }
+};
+
+int main()
+{
+    Alloc<int, false> a;
+    Alloc<char, true> b;
+}

--- a/tests/CXXDestructorTest.expect
+++ b/tests/CXXDestructorTest.expect
@@ -1,0 +1,99 @@
+template<typename T, bool array>
+class Alloc
+{
+    T* data;
+    
+public:
+    Alloc() {
+        if( array ) {
+            data = new T[10];
+            data = new T[10]{1,2,3};
+        } else {
+            data = new T;
+            data = new T(2);
+            data = new T{2};
+        }
+    }
+
+    ~Alloc() {
+        if( array ) {
+            delete[] data;
+        } else {
+            delete data;
+        }
+    }
+};
+/* First instantiated from: CXXDestructorTest.cpp:29 */
+#ifdef INSIGHTS_USE_TEMPLATE
+class Alloc<int, 0>
+{
+  int * data;
+  
+  public: 
+  inline Alloc()
+  {
+    if(false) {
+      this->data = new int[10];
+      this->data = new int[10]{1, 2, 3};
+    } else {
+      this->data = new int;
+      this->data = new int{2};
+      this->data = new int{2};
+    }
+  }
+  
+  inline ~Alloc() noexcept
+  {
+    if(false) {
+      delete[] this->data;
+    } else {
+      delete this->data;
+    }
+  }
+  
+  inline constexpr Alloc(const Alloc<int, 0> &) = default;
+  
+};
+
+#endif
+
+/* First instantiated from: CXXDestructorTest.cpp:30 */
+#ifdef INSIGHTS_USE_TEMPLATE
+class Alloc<char, 1>
+{
+  char * data;
+  
+  public: 
+  inline Alloc()
+  {
+    if(true) {
+      this->data = new char[10];
+      this->data = new char[10]{1, 2, 3};
+    } else {
+      this->data = new char;
+      this->data = new char{2};
+      this->data = new char{2};
+    }
+  }
+  
+  inline ~Alloc() noexcept
+  {
+    if(true) {
+      delete[] this->data;
+    } else {
+      delete this->data;
+    }
+  }
+  
+  inline constexpr Alloc(const Alloc<char, 1> &) = default;
+  
+};
+
+#endif
+
+
+int main()
+{
+    Alloc<int, false> a;
+    Alloc<char, true> b;
+}

--- a/tests/CharLiteralTest.expect
+++ b/tests/CharLiteralTest.expect
@@ -21,8 +21,25 @@ struct Foo
 };
 /* First instantiated from: CharLiteralTest.cpp:61 */
 #ifdef INSIGHTS_USE_TEMPLATE
-class Foo<int>
+struct Foo<int>
 {
+  int raw;
+  inline Foo() noexcept = default;
+  inline constexpr Foo(const Foo<int> & v) noexcept = default;
+  inline constexpr Foo(int v);
+  
+  using retType = int;
+  inline constexpr operator retType () const
+  {
+    return this->raw;
+  }
+  
+  inline constexpr Foo<int> & operator=(const Foo<int> & rhs) = default;
+  inline Foo<int> & operator=(int v);
+  
+  inline volatile void operator=(int v);
+  
+  inline ~Foo() noexcept = default;
   
 };
 
@@ -30,8 +47,26 @@ class Foo<int>
 
 /* First instantiated from: CharLiteralTest.cpp:60 */
 #ifdef INSIGHTS_USE_TEMPLATE
-class Foo<char>
+struct Foo<char>
 {
+  char raw;
+  inline Foo() noexcept = default;
+  inline constexpr Foo(const Foo<char> & v) = default;
+  inline constexpr Foo(char v);
+  
+  using retType = char;
+  inline constexpr operator retType () const;
+  
+  inline constexpr Foo<char> & operator=(const Foo<char> & rhs) = default;
+  inline Foo<char> & operator=(char v)
+  {
+    this->raw = v;
+    return *this;
+  }
+  
+  inline volatile void operator=(char v);
+  
+  inline ~Foo() = default;
   
 };
 

--- a/tests/ClassOpInTemplateFunctionTest.expect
+++ b/tests/ClassOpInTemplateFunctionTest.expect
@@ -29,7 +29,7 @@ public:
    template<>
    inline constexpr int get<1>() noexcept
    {
-     if constexpr( 1 == 1 ) {
+     if constexpr(1 == 1) {
        return this->mX;
      }
    }

--- a/tests/ClassOperatorHandler2Test.expect
+++ b/tests/ClassOperatorHandler2Test.expect
@@ -65,7 +65,7 @@ int main()
          int n = 10;
          f(n);
          f(42);
-         f(int{  });
+         f(int{});
          Foo f = Foo(1);
          f.operator++();
          f.operator++(0);

--- a/tests/ClassOperatorHandler4Test.expect
+++ b/tests/ClassOperatorHandler4Test.expect
@@ -24,7 +24,7 @@ int main()
 
     const bool b = operator==(f1, f2);
 
-    if( b ) {
+    if(b) {
        return 0;
      } else {
        return 1;

--- a/tests/ClassOperatorHandler5Test.expect
+++ b/tests/ClassOperatorHandler5Test.expect
@@ -2,7 +2,7 @@
 
 std::string trim(const std::string& input)
 {
-    if( input.length() == 0 ) {
+    if(input.length() == 0) {
        return std::basic_string<char>("");
      }
      
@@ -14,12 +14,12 @@ std::string trim(const std::string& input)
         i++;
     }
 
-    if( i >= reinterpret_cast<int>(static_cast<int>(input.length())) ) {
+    if(i >= reinterpret_cast<int>(static_cast<int>(input.length()))) {
        return std::basic_string<char>("");
      }
      
 
-    if( i > 0 ) {
+    if(i > 0) {
        final.operator=(input.substr(static_cast<unsigned long>(i), input.length() - static_cast<unsigned long>(i)));
      }
      

--- a/tests/ClassOperatorHandler6Test.expect
+++ b/tests/ClassOperatorHandler6Test.expect
@@ -99,7 +99,7 @@ int main()
     const bool b = f1.operator==(f2);
     void *t;
 
-    if( b ) {
+    if(b) {
        return 0;
      } else {
        return 1;
@@ -131,14 +131,14 @@ int main()
 
     // ExplicitCastExpr
     const bool b9 = f1.operator==(new char[2]);
-    const bool b10 = f1.operator==(new char[2]{ 1, 2 });
+    const bool b10 = f1.operator==(new char[2]{1, 2});
     
     char buffer[1024];
-    const bool b11 = f1.operator==(new (static_cast<void *>(buffer))char[2]{ 1, 2 });
+    const bool b11 = f1.operator==(new (static_cast<void *>(buffer))char[2]{1, 2});
 
-    const bool b12 = f1.operator==(new Woo(1, 'a'));
+    const bool b12 = f1.operator==(new Woo{1, 'a'});
     
-    const bool b13 = f1.operator==(Woo(1, 'a'));
+    const bool b13 = f1.operator==(Woo{1, 'a'});
 
     // thould trigger thisExpr
     Foo f3{'c'};

--- a/tests/ClassOperatorHandler7Test.expect
+++ b/tests/ClassOperatorHandler7Test.expect
@@ -8,8 +8,13 @@ struct A
 };
 /* First instantiated from: ClassOperatorHandler7Test.cpp:20 */
 #ifdef INSIGHTS_USE_TEMPLATE
-class A<int>
+struct A<int>
 {
+  void foo(int);
+  
+  inline constexpr A() noexcept = default;
+  inline constexpr A(const A<int> &) = default;
+  inline constexpr A(A<int> &&) = default;
   
 };
 
@@ -17,8 +22,23 @@ class A<int>
 
 /* First instantiated from: ClassOperatorHandler7Test.cpp:20 */
 #ifdef INSIGHTS_USE_TEMPLATE
-class A<int *>
+struct A<int *>
 {
+  struct B
+  {
+    void operator()(int);
+    
+    inline constexpr B() noexcept = default;
+    inline ~B() = default;
+    inline constexpr B(const A<int *>::B &) = default;
+    inline constexpr B(A<int *>::B &&) = default;
+    
+  };
+  
+  A<int *>::B foo;
+  inline constexpr A() noexcept = default;
+  inline constexpr A(const A<int *> &) = default;
+  inline constexpr A(A<int *> &&) = default;
   
 };
 

--- a/tests/ClassOperatorHandler9Test.expect
+++ b/tests/ClassOperatorHandler9Test.expect
@@ -30,6 +30,38 @@ public:
 #ifdef INSIGHTS_USE_TEMPLATE
 class MyVector<int>
 {
+  std::vector<int, std::allocator<int> > v;
+  
+  public: 
+  inline MyVector(const std::size_t n)
+  : v{std::vector<int, std::allocator<int> >(n)}
+  {
+  }
+  
+  inline MyVector(const std::size_t n, const double initialValue)
+  : v{std::vector<int, std::allocator<int> >(n, static_cast<const int>(initialValue))}
+  {
+  }
+  
+  inline std::size_t size() const
+  {
+    return this->v.size();
+  }
+  
+  inline int operator[](const std::size_t i) const
+  {
+    return this->v.operator[](i);
+  }
+  
+  inline int & operator[](const std::size_t i)
+  {
+    return this->v.operator[](i);
+  }
+  
+  inline MyVector(const MyVector<int> &) = default;
+  inline MyVector(MyVector<int> &&) noexcept = default;
+  inline MyVector<int> & operator=(MyVector<int> &&) = default;
+  inline ~MyVector() noexcept = default;
   
 };
 
@@ -64,7 +96,7 @@ MyVector<int> operator*<int>(const MyVector<int> & a, const MyVector<int> & b)
 {
   MyVector<int> result = MyVector<int>(a.size()) /* NRVO variable */;
   for(std::size_t s = 0;
-  s <= a.size(); ++s)
+  s <= a.size(); ++s) 
   {
     result.operator[](s) = a.operator[](s) + b.operator[](s);
   }

--- a/tests/ClassOperatorHandlerTest.expect
+++ b/tests/ClassOperatorHandlerTest.expect
@@ -137,12 +137,12 @@ int main()
 
     t1.operator+=(t2);
 
-    if( t1.operator>(t2) ) {
+    if(t1.operator>(t2)) {
        return 1;
      }
      
 
-    if( t1.operator>=(t2) ) {
+    if(t1.operator>=(t2)) {
        return 3;
      }
      
@@ -163,7 +163,7 @@ int main()
     Fest f1{2};
     Fest f2{3};
 
-    if( operator<(f1, f2) ) {
+    if(operator<(f1, f2)) {
        return 22;
      }
      
@@ -171,7 +171,7 @@ int main()
     Hello::Bello::Fest f3{3};
     Hello::Bello::Fest f4{3};
 
-    if( Hello::Bello::operator<(f3, f4) ) {
+    if(Hello::Bello::operator<(f3, f4)) {
        return 44;
      }
      

--- a/tests/DoStmtTest.expect
+++ b/tests/DoStmtTest.expect
@@ -8,7 +8,7 @@ int main()
          int x = 1;
          do {
            ++x;
-         } while( true );
+         } while(true) ;
        }
        
      } __lambda_3_5{};

--- a/tests/EmptyLambda.cpp
+++ b/tests/EmptyLambda.cpp
@@ -1,0 +1,9 @@
+void foo() {
+[]() {
+ // (void)X{1, 2, 3}; // => X(std::initializer_list<int>{1, 2, 3})
+ // (void)X{nullptr, 0}; // => X(nullptr, 0)
+//  takes_y({1, 2}); // => Y _tmp = {1, 2}; takes_y(_tmp);
+}();
+}
+
+

--- a/tests/EmptyLambda.expect
+++ b/tests/EmptyLambda.expect
@@ -1,0 +1,14 @@
+void foo() {
+ 
+ class __lambda_2_1
+ {
+   public: inline /*constexpr */ void operator()() const
+   {
+   }
+   
+ } __lambda_2_1{};
+ 
+ __lambda_2_1.operator()();
+}
+
+

--- a/tests/FunctionalCast2Test.expect
+++ b/tests/FunctionalCast2Test.expect
@@ -31,7 +31,7 @@ constexpr bool Compare(const T (&ar)[N], const TTo& to)
 template<>
 inline constexpr bool Compare<unsigned char, 6, int>(const unsigned char (&ar)[6], const int & to)
 {
-  return details::array_single_compare::Compare(ar, to, std::integer_sequence<unsigned long, 0, 1, 2, 3, 4, 5>{  });
+  return details::array_single_compare::Compare(ar, to, std::integer_sequence<unsigned long, 0, 1, 2, 3, 4, 5>{});
 }
 #endif
 
@@ -65,7 +65,7 @@ constexpr bool Compare(const T (&ar)[N], const T (&to)[N])
 template<>
 inline constexpr bool Compare<unsigned char, 6>(const unsigned char (&ar)[6], const unsigned char (&to)[6])
 {
-  return details::array_compare::Compare(ar, to, std::integer_sequence<unsigned long, 0, 1, 2, 3, 4, 5>{  });
+  return details::array_compare::Compare(ar, to, std::integer_sequence<unsigned long, 0, 1, 2, 3, 4, 5>{});
 }
 #endif
 

--- a/tests/IfStmtHandler2Test.expect
+++ b/tests/IfStmtHandler2Test.expect
@@ -2,7 +2,7 @@ int main()
 {
     {
        char * ptr = nullptr;
-       if( ptr ) {
+       if(ptr) {
        } else {
          *ptr = 2;
        }
@@ -11,7 +11,7 @@ int main()
      
 
     const char* ptr2;
-    if( ptr2 ) {
+    if(ptr2) {
      }
      
 }

--- a/tests/IfStmtHandler3Test.expect
+++ b/tests/IfStmtHandler3Test.expect
@@ -3,7 +3,7 @@ int Test()
     int ret;
     char buffer[2];
 
-    if( static_cast<int>(buffer[0]) == static_cast<int>('0') ) ret = 1;
+    if(static_cast<int>(buffer[0]) == static_cast<int>('0')) ret = 1;
      else ret = 2
      ;
     

--- a/tests/IfStmtHandlerTest.expect
+++ b/tests/IfStmtHandlerTest.expect
@@ -2,29 +2,29 @@
 
 int main()
 {
-    if constexpr( false ) {
+    if constexpr(false) {
        printf("False\n");
      } else /* constexpr */ {
-       if( true ) {
+       if(true) {
          printf("true");
        }
        
      }
      
 
-    if constexpr( false ) {
+    if constexpr(false) {
        printf("False\n");
      } else /* constexpr */ {
-       if constexpr( true ) {
+       if constexpr(true) {
          printf("true");
        }
        
      }
          
 
-    if constexpr( false ) printf("False\n");
+    if constexpr(false) printf("False\n");
      else /* constexpr */ {
-       if( true ) printf("true");
+       if(true) printf("true");
        
        
      }
@@ -32,14 +32,14 @@ int main()
 
 
     int x = 1;
-    if( 1 == x ) printf("a");
+    if(1 == x) printf("a");
      else {
-       if( 2 == x ) {
+       if(2 == x) {
          printf("b");
-         if( x == 5 ) printf("5");
+         if(x == 5) printf("5");
          
        } else {
-         if( x == 3 ) printf("r");
+         if(x == 3) printf("r");
          
        }
        

--- a/tests/IfSwitchInitHandler3Test.expect
+++ b/tests/IfSwitchInitHandler3Test.expect
@@ -8,8 +8,8 @@ int Foo()
     // normal if but with an DeclStmt. No rewrite expected
     {
        int ret = Open();
-       if( static_cast<bool>(ret) ) {
-         if( 1 != ret ) {
+       if(static_cast<bool>(ret)) {
+         if(1 != ret) {
            return ret;
          }
        }

--- a/tests/IfSwitchInitHandler5Test.expect
+++ b/tests/IfSwitchInitHandler5Test.expect
@@ -7,7 +7,7 @@ int main(){
   
   {
      std::shared_ptr<int> sharedPtr1 = weakPtr.lock();
-     if( static_cast<bool>(sharedPtr1.operator bool()) ) {
+     if(static_cast<bool>(sharedPtr1.operator bool())) {
        std::operator<<(std::cout, "*sharedPtr: ").operator<<(sharedPtr.operator*()).operator<<(std::endl);
      } else {
      }

--- a/tests/IfSwitchInitHandlerTest.expect
+++ b/tests/IfSwitchInitHandlerTest.expect
@@ -7,12 +7,12 @@ int Foo()
 {
     {
        int ret = Open();
-       if( 1 != ret ) {
+       if(1 != ret) {
          return ret;
        } else {
          {
            int ret = Write();
-           if( 1 != ret ) {
+           if(1 != ret) {
              return ret;
            }
            

--- a/tests/ImplicitCastHandlerTest.expect
+++ b/tests/ImplicitCastHandlerTest.expect
@@ -2,12 +2,12 @@ int main()
 {
     char c = 1;
 
-    if( static_cast<int>(c) == static_cast<int>(true) ) {
+    if(static_cast<int>(c) == static_cast<int>(true)) {
        return 1;
      }
      
 
-    if( static_cast<int>(c) == 100 ) {
+    if(static_cast<int>(c) == 100) {
        return 2;
      }
      

--- a/tests/InitalizerListTest.expect
+++ b/tests/InitalizerListTest.expect
@@ -1,9 +1,9 @@
 #include <vector>
 
 int main(){
-  std::vector<int> myVec{ std::initializer_list<int>{ 1, 2, 3, 4, 5, 6, 7, 8, 9 } };
+  std::vector<int> myVec{ std::initializer_list<int>{1, 2, 3, 4, 5, 6, 7, 8, 9} };
 
-  myVec.operator=(std::initializer_list<int>{ 1, 2, 3, 4, 5, 6, 7, 8, 9 });
+  myVec.operator=(std::initializer_list<int>{1, 2, 3, 4, 5, 6, 7, 8, 9});
   
 }
 

--- a/tests/InitializerList2Test.expect
+++ b/tests/InitializerList2Test.expect
@@ -10,7 +10,7 @@ public:
 
 int main()
 {
-  Foo f{ std::initializer_list<int>{ 1 } };
-  Foo f2{ std::initializer_list<int>{ 1, static_cast<const int>(true) } };
-  Foo f3{ std::initializer_list<int>{ 1, static_cast<const int>(true), 4 } };
+  Foo f{ std::initializer_list<int>{1} };
+  Foo f2{ std::initializer_list<int>{1, static_cast<const int>(true)} };
+  Foo f3{ std::initializer_list<int>{1, static_cast<const int>(true), 4} };
 }

--- a/tests/InitializerListTest.expect
+++ b/tests/InitializerListTest.expect
@@ -57,29 +57,29 @@ void something<float>(std::initializer_list<float>)
 
 
 void foo() {
-    X{ std::initializer_list<int>{ 1, 2, 3 } };
+    X{ std::initializer_list<int>{1, 2, 3} };
     X{nullptr, 0};
 
-    X x{ std::initializer_list<int>{ 3, 4, 5 } };
-    X b{ std::initializer_list<int>{ 1 } };
+    X x{ std::initializer_list<int>{3, 4, 5} };
+    X b{ std::initializer_list<int>{1} };
 
-    X{1, std::initializer_list<int>{ 2, 3 }};
-    X c{1, std::initializer_list<int>{ 2, 3 }};
+    X{1, std::initializer_list<int>{2, 3}};
+    X c{1, std::initializer_list<int>{2, 3}};
 
-    X{std::initializer_list<int>{ 1, 2 }, 3};
-    X d{std::initializer_list<int>{ 1, 2 }, 3};
+    X{std::initializer_list<int>{1, 2}, 3};
+    X d{std::initializer_list<int>{1, 2}, 3};
     
-    b.operator+=(std::initializer_list<int>{ 2, 4 });
+    b.operator+=(std::initializer_list<int>{2, 4});
 
     takes_y({1, 2});
 
-    bar( std::initializer_list<int>{ 1, 2 } );
+    bar( std::initializer_list<int>{1, 2} );
 
-    something( std::initializer_list<int>{ 1, 2 } );
+    something( std::initializer_list<int>{1, 2} );
 
-    something( std::initializer_list<float>{ 1.0f, 2.0f } );
+    something( std::initializer_list<float>{1.0f, 2.0f} );
 
-    V v{ std::initializer_list<int>{ 1 } };
-    V vv{ std::initializer_list<int>{ 1, 2 } };
+    V v{ std::initializer_list<int>{1} };
+    V vv{ std::initializer_list<int>{1, 2} };
 }
 

--- a/tests/Issue1.expect
+++ b/tests/Issue1.expect
@@ -16,7 +16,7 @@ template<typename T> T fooGood() {return T{42}; }
 template<>
 int fooGood<int>()
 {
-  return int{ 42 };
+  return int{42};
 }
 #endif
  

--- a/tests/Issue20.expect
+++ b/tests/Issue20.expect
@@ -2,7 +2,7 @@
 
 int main()
 {
-    std::map<int, int> map{ std::initializer_list<std::pair<const int, int> >{ std::pair<const int, int>(1, 2) } };
+    std::map<int, int> map{ std::initializer_list<std::pair<const int, int> >{std::pair<const int, int>{1, 2}} };
     std::pair<const int, int> __operator6 = std::pair<const int, int>(map.begin().operator*());
     std::tuple_element<0, std::pair<const int, int> >::type& key = std::get<0ul>(__operator6);
     std::tuple_element<1, std::pair<const int, int> >::type& value = std::get<1ul>(__operator6);

--- a/tests/Issue28.expect
+++ b/tests/Issue28.expect
@@ -5,5 +5,5 @@ int main()
 {
   using namespace std::string_literals;
  
-  std::vector<std::string> foo{ std::initializer_list<std::basic_string<char> >{ std::operator""s("foo", 3ul), std::operator""s("bar", 3ul) } };
+  std::vector<std::string> foo{ std::initializer_list<std::basic_string<char> >{std::operator""s("foo", 3ul), std::operator""s("bar", 3ul)} };
 }

--- a/tests/LambdaHandler7Test.expect
+++ b/tests/LambdaHandler7Test.expect
@@ -3,7 +3,7 @@
 
 int main()
 {
-  std::vector<int> myVec{ std::initializer_list<int>{ 1, 2, 3, 4, 5 } };
+  std::vector<int> myVec{ std::initializer_list<int>{1, 2, 3, 4, 5} };
 
         
    class __lambda_8_57

--- a/tests/LambdaHandler9Test.expect
+++ b/tests/LambdaHandler9Test.expect
@@ -75,7 +75,7 @@ int main()
        {
          volatile char buffer[10];
          for(int i = 0;
-         static_cast<unsigned long>(i) < sizeof(buffer); ++i)
+         static_cast<unsigned long>(i) < sizeof(buffer); ++i) 
          {
            buffer[i] = 1;
          }
@@ -95,7 +95,7 @@ int main()
        {
          volatile char buffer[10];
          int i = 0;
-         for(; static_cast<unsigned long>(i) < sizeof(buffer); ++i)
+         for(; static_cast<unsigned long>(i) < sizeof(buffer); ++i) 
          {
            buffer[i] = 1;
          }

--- a/tests/LambdaHandlerVLATest.cerr
+++ b/tests/LambdaHandlerVLATest.cerr
@@ -1,7 +1,7 @@
-.tmp.cpp:63:17: error: invalid use of 'this' outside of a non-static member function
+.tmp.cpp:89:17: error: invalid use of 'this' outside of a non-static member function
      float (&e)[this->nt];
                 ^
-.tmp.cpp:65:40: error: invalid use of 'this' outside of a non-static member function
+.tmp.cpp:91:40: error: invalid use of 'this' outside of a non-static member function
      public: __lambda_36_8(float (&_e)[this->nt])
                                        ^
 2 errors generated.

--- a/tests/LambdaHandlerVLATest.expect
+++ b/tests/LambdaHandlerVLATest.expect
@@ -24,8 +24,34 @@ struct SA
 };
 /* First instantiated from: LambdaHandlerVLATest.cpp:42 */
 #ifdef INSIGHTS_USE_TEMPLATE
-class SA<2>
+struct SA<2>
 {
+  inline SA(const int & PA)
+  {
+    float e[this->nt];
+        
+    class __lambda_36_8
+    {
+      public: inline /*constexpr */ bool operator()(int i, int j) const
+      {
+        return e[i] < e[j];
+      }
+      
+      private:
+      float (&e)[this->nt];
+      
+      public: __lambda_36_8(float (&_e)[this->nt])
+      : e{_e}
+      {}
+      
+    };
+    
+    test(__lambda_36_8{e});
+  }
+  
+  int nt;
+  inline constexpr SA(const SA<2> &) = default;
+  inline constexpr SA(SA<2> &&) = default;
   
 };
 

--- a/tests/LambdaPackExpansionTest.cpp
+++ b/tests/LambdaPackExpansionTest.cpp
@@ -1,0 +1,23 @@
+template<class... Args>
+int g(Args ...)
+{
+    return 1;
+}
+
+template<class... Args>
+void f(Args... args) {
+    auto lm = [&] { return g(args...); };
+    lm();
+}
+
+template<class... Args>
+void f2(Args... args) {
+    auto lm = [&, args...] { return g(args...); };
+    lm();
+}
+
+int main()
+{
+    f(1, 2, 3 , 4, 5);
+    f2(1, 2, 3 , 4, 5);
+}

--- a/tests/RangeForStmtHandler2Test.expect
+++ b/tests/RangeForStmtHandler2Test.expect
@@ -19,7 +19,7 @@ int main()
        }
      }
 
-    std::vector<int> v{ std::initializer_list<int>{ 1, 2, 3, 5 } };
+    std::vector<int> v{ std::initializer_list<int>{1, 2, 3, 5} };
 
     {
        std::vector<int, std::allocator<int> > & __range1 = v;

--- a/tests/RangeForStmtHandler3Test.expect
+++ b/tests/RangeForStmtHandler3Test.expect
@@ -34,7 +34,7 @@
       template<>
       inline bool operator!=<const char *, 0>(const char *const & ptr, null_sentinal_t)
       {
-        return !(operator==(ptr, null_sentinal_t{  }));
+        return !(operator==(ptr, null_sentinal_t{}));
       }
       #endif
       
@@ -70,8 +70,20 @@ struct str_view {
 };
 /* First instantiated from: RangeForStmtHandler3Test.cpp:49 */
 #ifdef INSIGHTS_USE_TEMPLATE
-class str_view<char>
+struct str_view<char>
 {
+  const char * ptr;
+  inline const char * begin() const
+  {
+    return this->ptr;
+  }
+  
+  inline null_sentinal_t end() const
+  {
+    return {};
+  }
+  
+  inline ~str_view() noexcept = default;
   
 };
 
@@ -80,7 +92,7 @@ class str_view<char>
 int main() {
     
     {
-       str_view<char> && __range1 = str_view<char>{ "hello world\n" };
+       str_view<char> && __range1 = str_view<char>{"hello world\n"};
        const char * __begin1 = __range1.begin();
        null_sentinal_t __end1 = __range1.end();
        

--- a/tests/RangeForStmtHandler4Test.expect
+++ b/tests/RangeForStmtHandler4Test.expect
@@ -12,6 +12,23 @@ public:
 #ifdef INSIGHTS_USE_TEMPLATE
 class MyArrayWrapper<int>
 {
+  int * data;
+  int size;
+  
+  public: 
+  inline int * begin()
+  {
+    return this->size > 0 ? &this->data[0] : nullptr;
+  }
+  
+  inline int * end()
+  {
+    return this->size > 0 ? &this->data[this->size - 1] : nullptr;
+  }
+  
+  inline MyArrayWrapper() noexcept = default;
+  inline constexpr MyArrayWrapper(const MyArrayWrapper<int> &) = default;
+  inline constexpr MyArrayWrapper(MyArrayWrapper<int> &&) = default;
   
 };
 

--- a/tests/RangeForStmtHandlerTest.expect
+++ b/tests/RangeForStmtHandlerTest.expect
@@ -108,7 +108,7 @@ int main()
        }
      }
 
-    std::vector<int> v{ std::initializer_list<int>{ 1, 2, 3, 5 } };
+    std::vector<int> v{ std::initializer_list<int>{1, 2, 3, 5} };
 
     {
        std::vector<int, std::allocator<int> > & __range1 = v;

--- a/tests/StaticAssertTest.expect
+++ b/tests/StaticAssertTest.expect
@@ -2,7 +2,8 @@ struct S {
   int x;
 };
 
-/* PASSED: static_assert(sizeof(S) == sizeof(int))*/;
+/* PASSED: static_assert(sizeof(S) == sizeof(int)); */
+
 
 //static_assert(sizeof(S) != sizeof(int));
 

--- a/tests/StaticHandlerTest.expect
+++ b/tests/StaticHandlerTest.expect
@@ -84,7 +84,7 @@ Bingleton* B(bool c)
     }
     ;
 
-    if( c ) {
+    if(c) {
        return nullptr;
      }
      
@@ -105,7 +105,7 @@ Bingleton& BB(bool c)
     }
     ;
 
-    if( c ) {
+    if(c) {
        return *reinterpret_cast<Bingleton*>(__bb);
      }
      

--- a/tests/StaticInLambdaTest.expect
+++ b/tests/StaticInLambdaTest.expect
@@ -74,7 +74,7 @@ int main()
            new (&__bb) Bingleton;
            __bbB = true;
          }
-         if( c ) {
+         if(c) {
            return Bingleton(*reinterpret_cast<Bingleton*>(__bb));
          }
          return Bingleton(*reinterpret_cast<Bingleton*>(__bb));
@@ -99,7 +99,7 @@ int main()
            new (&__bb) Bingleton;
            __bbB = true;
          }
-         if( c ) {
+         if(c) {
            return &*reinterpret_cast<Bingleton*>(__bb);
          }
          return &*reinterpret_cast<Bingleton*>(__bb);

--- a/tests/StructuredBindingsHandler3Test.cerr
+++ b/tests/StructuredBindingsHandler3Test.cerr
@@ -1,61 +1,61 @@
-.tmp.cpp:78:48: error: no matching function for call to 'get'
+.tmp.cpp:81:48: error: no matching function for call to 'get'
   std::tuple_element<0, constant::Q>::type a = constant::get<0ul>(constant::__q17);
                                                ^~~~~~~~~~~~~~~~~~
-.tmp.cpp:40:33: note: candidate function not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
+.tmp.cpp:43:33: note: candidate function not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
   template<int N> constexpr int get(Q &&) { return N * N; }
                                 ^
-.tmp.cpp:79:48: error: no matching function for call to 'get'
+.tmp.cpp:82:48: error: no matching function for call to 'get'
   std::tuple_element<1, constant::Q>::type b = constant::get<1ul>(constant::__q17);
                                                ^~~~~~~~~~~~~~~~~~
-.tmp.cpp:40:33: note: candidate function not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
+.tmp.cpp:43:33: note: candidate function not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
   template<int N> constexpr int get(Q &&) { return N * N; }
                                 ^
-.tmp.cpp:80:48: error: no matching function for call to 'get'
+.tmp.cpp:83:48: error: no matching function for call to 'get'
   std::tuple_element<2, constant::Q>::type c = constant::get<2ul>(constant::__q17);
                                                ^~~~~~~~~~~~~~~~~~
-.tmp.cpp:40:33: note: candidate function not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
+.tmp.cpp:43:33: note: candidate function not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
   template<int N> constexpr int get(Q &&) { return N * N; }
                                 ^
-.tmp.cpp:85:50: error: no matching function for call to 'get'
+.tmp.cpp:88:50: error: no matching function for call to 'get'
     std::tuple_element<0, constant::Q>::type a = constant::get<0ul>(__q20);
                                                  ^~~~~~~~~~~~~~~~~~
-.tmp.cpp:40:33: note: candidate function not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
+.tmp.cpp:43:33: note: candidate function not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
   template<int N> constexpr int get(Q &&) { return N * N; }
                                 ^
-.tmp.cpp:86:50: error: no matching function for call to 'get'
+.tmp.cpp:89:50: error: no matching function for call to 'get'
     std::tuple_element<1, constant::Q>::type b = constant::get<1ul>(__q20);
                                                  ^~~~~~~~~~~~~~~~~~
-.tmp.cpp:40:33: note: candidate function not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
+.tmp.cpp:43:33: note: candidate function not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
   template<int N> constexpr int get(Q &&) { return N * N; }
                                 ^
-.tmp.cpp:87:50: error: no matching function for call to 'get'
+.tmp.cpp:90:50: error: no matching function for call to 'get'
     std::tuple_element<2, constant::Q>::type c = constant::get<2ul>(__q20);
                                                  ^~~~~~~~~~~~~~~~~~
-.tmp.cpp:40:33: note: candidate function not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
+.tmp.cpp:43:33: note: candidate function not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
   template<int N> constexpr int get(Q &&) { return N * N; }
                                 ^
-.tmp.cpp:85:46: error: variables defined in a constexpr function must be initialized
+.tmp.cpp:88:46: error: variables defined in a constexpr function must be initialized
     std::tuple_element<0, constant::Q>::type a = constant::get<0ul>(__q20);
                                              ^
-.tmp.cpp:96:52: error: no matching function for call to 'get'
+.tmp.cpp:99:52: error: no matching function for call to 'get'
       std::tuple_element<0, constant::Q>::type a = constant::get<0ul>(__q27);
                                                    ^~~~~~~~~~~~~~~~~~
-.tmp.cpp:40:33: note: candidate function not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
+.tmp.cpp:43:33: note: candidate function not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
   template<int N> constexpr int get(Q &&) { return N * N; }
                                 ^
-.tmp.cpp:97:52: error: no matching function for call to 'get'
+.tmp.cpp:100:52: error: no matching function for call to 'get'
       std::tuple_element<1, constant::Q>::type b = constant::get<1ul>(__q27);
                                                    ^~~~~~~~~~~~~~~~~~
-.tmp.cpp:40:33: note: candidate function not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
+.tmp.cpp:43:33: note: candidate function not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
   template<int N> constexpr int get(Q &&) { return N * N; }
                                 ^
-.tmp.cpp:98:52: error: no matching function for call to 'get'
+.tmp.cpp:101:52: error: no matching function for call to 'get'
       std::tuple_element<2, constant::Q>::type c = constant::get<2ul>(__q27);
                                                    ^~~~~~~~~~~~~~~~~~
-.tmp.cpp:40:33: note: candidate function not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
+.tmp.cpp:43:33: note: candidate function not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
   template<int N> constexpr int get(Q &&) { return N * N; }
                                 ^
-.tmp.cpp:96:48: error: variables defined in a constexpr function must be initialized
+.tmp.cpp:99:48: error: variables defined in a constexpr function must be initialized
       std::tuple_element<0, constant::Q>::type a = constant::get<0ul>(__q27);
                                                ^
 11 errors generated.

--- a/tests/StructuredBindingsHandler3Test.expect
+++ b/tests/StructuredBindingsHandler3Test.expect
@@ -5,8 +5,9 @@ namespace std { template<typename T> struct tuple_size; }
 namespace std { template<size_t, typename> struct tuple_element;
 /* First instantiated from: StructuredBindingsHandler3Test.cpp:17 */
 #ifdef INSIGHTS_USE_TEMPLATE
-class tuple_element<0, constant::Q>
+struct tuple_element<0, constant::Q>
 {
+  using type = int;
   
 };
 
@@ -14,8 +15,9 @@ class tuple_element<0, constant::Q>
 
 /* First instantiated from: StructuredBindingsHandler3Test.cpp:17 */
 #ifdef INSIGHTS_USE_TEMPLATE
-class tuple_element<1, constant::Q>
+struct tuple_element<1, constant::Q>
 {
+  using type = int;
   
 };
 
@@ -23,8 +25,9 @@ class tuple_element<1, constant::Q>
 
 /* First instantiated from: StructuredBindingsHandler3Test.cpp:17 */
 #ifdef INSIGHTS_USE_TEMPLATE
-class tuple_element<2, constant::Q>
+struct tuple_element<2, constant::Q>
 {
+  using type = int;
   
 };
 

--- a/tests/StructuredBindingsHandler4Test.expect
+++ b/tests/StructuredBindingsHandler4Test.expect
@@ -1,14 +1,14 @@
 int main()
 {
     char p[2];
-    char const __p4[2] = { p[0], p[1] };
+    char const __p4[2] = {p[0], p[1]};
     const char x = __p4[0];
     const char y = __p4[1];
     
 
 
     volatile char p2[2];
-    volatile char const __p28[2] = { p2[0], p2[1] };
+    volatile char const __p28[2] = {p2[0], p2[1]};
     const volatile char x2 = __p28[0];
     const volatile char y2 = __p28[1];
     

--- a/tests/StructuredBindingsHandler5Test.expect
+++ b/tests/StructuredBindingsHandler5Test.expect
@@ -49,9 +49,9 @@ public:
     template<>
     inline constexpr double & get<0>() noexcept
     {
-      if constexpr( 0ul == 1 ) ;
+      if constexpr(0ul == 1) ;
       else /* constexpr */ {
-        if constexpr( 0ul == 0 ) {
+        if constexpr(0ul == 0) {
           return (this->mY);
         }
         
@@ -65,7 +65,7 @@ public:
     template<>
     inline constexpr double get<1>() noexcept
     {
-      if constexpr( 1ul == 1 ) {
+      if constexpr(1ul == 1) {
         return this->GetX();
       }
     }
@@ -87,9 +87,9 @@ public:
     template<>
     inline constexpr const double & get<0>() noexcept
     {
-      if constexpr( 0ul == 1 ) ;
+      if constexpr(0ul == 1) ;
       else /* constexpr */ {
-        if constexpr( 0ul == 0 ) {
+        if constexpr(0ul == 0) {
           return (this->mY);
         }
         
@@ -103,7 +103,7 @@ public:
     template<>
     inline constexpr double get<1>() noexcept
     {
-      if constexpr( 1ul == 1 ) {
+      if constexpr(1ul == 1) {
         return this->GetX();
       }
     }

--- a/tests/StructuredBindingsHandler6Test.expect
+++ b/tests/StructuredBindingsHandler6Test.expect
@@ -56,9 +56,9 @@ public:
     template<>
     inline constexpr double get<0>() noexcept
     {
-      if constexpr( 0ul == 1 ) ;
+      if constexpr(0ul == 1) ;
       else /* constexpr */ {
-        if constexpr( 0ul == 0 ) {
+        if constexpr(0ul == 0) {
           return this->mY;
         }
         
@@ -72,7 +72,7 @@ public:
     template<>
     inline constexpr double get<1>() noexcept
     {
-      if constexpr( 1ul == 1 ) {
+      if constexpr(1ul == 1) {
         return this->GetX();
       }
     }
@@ -95,7 +95,7 @@ int main()
     printf("x:%lf y:%lf\n", x, y);
 
     char ar[2]{7,8};
-    char __ar64[2] = { ar[0], ar[1] };
+    char __ar64[2] = {ar[0], ar[1]};
     char a1 = __ar64[0];
     char a2 = __ar64[1];
     

--- a/tests/StructuredBindingsHandlerTest.expect
+++ b/tests/StructuredBindingsHandlerTest.expect
@@ -1,7 +1,7 @@
 int main()
 {
     char p[2];
-    char __p4[2] = { p[0], p[1] };
+    char __p4[2] = {p[0], p[1]};
     char x = __p4[0];
     char y = __p4[1];
     

--- a/tests/TemplateArgumentsTest.expect
+++ b/tests/TemplateArgumentsTest.expect
@@ -15,7 +15,7 @@ static inline decltype(auto) Normalize(const T& arg)
 template<>
 inline static char const (&)[8] Normalize<char [8]>(char const (&arg)[8])
 {
-  if constexpr( std::is_same_v<char [8], std::basic_string<char>> ) ;
+  if constexpr(std::is_same_v<char [8], std::basic_string<char>>) ;
   else /* constexpr */ {
     return arg;
   }
@@ -28,7 +28,7 @@ inline static char const (&)[8] Normalize<char [8]>(char const (&arg)[8])
 template<>
 inline static const int & Normalize<int>(const int & arg)
 {
-  if constexpr( std::is_same_v<int, std::basic_string<char>> ) ;
+  if constexpr(std::is_same_v<int, std::basic_string<char>>) ;
   else /* constexpr */ {
     return arg;
   }
@@ -41,7 +41,7 @@ inline static const int & Normalize<int>(const int & arg)
 template<>
 inline static const char * Normalize<std::basic_string<char> >(const std::basic_string<char> & arg)
 {
-  if constexpr( std::is_same_v<std::basic_string<char>, std::basic_string<char>> ) {
+  if constexpr(std::is_same_v<std::basic_string<char>, std::basic_string<char>>) {
     return arg.c_str();
   }
 }

--- a/tests/TemplateAsTemplateArgumentTest.expect
+++ b/tests/TemplateAsTemplateArgumentTest.expect
@@ -3,6 +3,10 @@ template<typename T> class my_array {};
 #ifdef INSIGHTS_USE_TEMPLATE
 class my_array<int>
 {
+  inline constexpr my_array() noexcept = default;
+  inline ~my_array() = default;
+  inline constexpr my_array(const my_array<int> &) = default;
+  inline constexpr my_array(my_array<int> &&) = default;
   
 };
 
@@ -20,6 +24,11 @@ class Map
 #ifdef INSIGHTS_USE_TEMPLATE
 class Map<int, int, my_array>
 {
+  my_array<int> key;
+  my_array<int> value;
+  inline constexpr Map() noexcept = default;
+  inline constexpr Map(const Map<int, int, my_array> &) = default;
+  inline constexpr Map(Map<int, int, my_array> &&) = default;
   
 };
 

--- a/tests/TemplateClassWithoutDefinitionTest.cpp
+++ b/tests/TemplateClassWithoutDefinitionTest.cpp
@@ -1,0 +1,12 @@
+template <typename T>
+class Foo{};
+
+typedef Foo<int> IntFoo; // this type is never instantiated which results in a 
+                         // CXXRecordDecl without a definition
+typedef Foo<double> DoubleFoo;
+
+
+int main()
+{
+  DoubleFoo df;
+}

--- a/tests/TemplateClassWithoutDefinitionTest.expect
+++ b/tests/TemplateClassWithoutDefinitionTest.expect
@@ -1,0 +1,24 @@
+template <typename T>
+class Foo{};
+/* First instantiated from: TemplateClassWithoutDefinitionTest.cpp:11 */
+#ifdef INSIGHTS_USE_TEMPLATE
+class Foo<double>
+{
+  inline constexpr Foo() noexcept = default;
+  inline constexpr Foo(const Foo<double> &) = default;
+  inline constexpr Foo(Foo<double> &&) = default;
+  
+};
+
+#endif
+
+
+typedef Foo<int> IntFoo; // this type is never instantiated which results in a 
+                         // CXXRecordDecl without a definition
+typedef Foo<double> DoubleFoo;
+
+
+int main()
+{
+  DoubleFoo df;
+}

--- a/tests/TemplateExpansion2Test.cpp
+++ b/tests/TemplateExpansion2Test.cpp
@@ -1,0 +1,64 @@
+#include <type_traits>
+#include <cstddef>
+
+namespace details {
+  template<class T>
+  struct remove_reference      { typedef T type; };
+  template<class T>
+  struct remove_reference<T&>  { typedef T type; };
+  template<class T>
+  struct remove_reference<T&&> { typedef T type; };
+
+  template<class T, size_t N = 0>
+  struct extent
+  {
+    static constexpr size_t value = N;
+
+    static_assert(N != 0, "Arrays only");
+  };
+
+  template<class T, size_t I>
+  struct extent<T[I], 0>
+  {
+    static constexpr size_t value = I;
+
+    static_assert(I != 0, "Arrays only");
+  };
+
+}  // namespace details
+
+#define ARRAY_SIZE(var_x)                             \
+  details::extent<typename details::remove_reference< \
+    decltype(var_x)>::type>::value
+
+class B
+{
+};
+
+class E{};
+
+template<typename T>
+class S : public B
+{
+};
+
+template<typename T>
+class Y : public S<T>, public E
+{
+};
+
+
+void test()
+{
+  int buffer[16]{};
+
+  const auto& xx = ARRAY_SIZE(buffer);
+
+  S<int> s; 
+
+  Y<double> y;
+}
+
+
+int main(){}
+

--- a/tests/TemplateExpansion2Test.expect
+++ b/tests/TemplateExpansion2Test.expect
@@ -1,0 +1,128 @@
+#include <type_traits>
+#include <cstddef>
+
+namespace details {
+  template<class T>
+  struct remove_reference      { typedef T type; };
+  #ifdef INSIGHTS_USE_TEMPLATE
+  struct remove_reference<int [16]>
+  {
+    using type = int [16];
+    
+  };
+  
+  #endif
+  
+  template<class T>
+  struct remove_reference<T&>  { typedef T type; };
+  template<class T>
+  struct remove_reference<T&&> { typedef T type; };
+
+  template<class T, size_t N = 0>
+  struct extent
+  {
+    static constexpr size_t value = N;
+
+    static_assert(N != 0, "Arrays only");
+  };
+  #ifdef INSIGHTS_USE_TEMPLATE
+  struct extent<int [16], 0>
+  {
+    inline static constexpr const size_t value = 16ul;
+    /* PASSED: static_assert(16ul != 0, "Arrays only"); */
+    
+  };
+  
+  #endif
+  
+
+  template<class T, size_t I>
+  struct extent<T[I], 0>
+  {
+    static constexpr size_t value = I;
+
+    static_assert(I != 0, "Arrays only");
+  };
+
+}  // namespace details
+
+#define ARRAY_SIZE(var_x)                             \
+  details::extent<typename details::remove_reference< \
+    decltype(var_x)>::type>::value
+
+class B
+{
+/* public: inline constexpr B() noexcept; */
+/* public: inline ~B(); */
+/* public: inline constexpr B(const B &); */
+/* public: inline constexpr B(B &&); */
+};
+
+class E{/* public: inline constexpr E() noexcept; */
+/* public: inline ~E(); */
+/* public: inline constexpr E(const E &); */
+/* public: inline constexpr E(E &&); */
+};
+
+template<typename T>
+class S : public B
+{
+};
+/* First instantiated from: TemplateExpansion2Test.cpp:57 */
+#ifdef INSIGHTS_USE_TEMPLATE
+class S<int> : public B
+{
+  inline constexpr S() noexcept = default;
+  inline constexpr S(const S<int> &) = default;
+  inline constexpr S(S<int> &&) = default;
+  
+};
+
+#endif
+
+/* First instantiated from: TemplateExpansion2Test.cpp:46 */
+#ifdef INSIGHTS_USE_TEMPLATE
+class S<double> : public B
+{
+  inline constexpr S() noexcept = default;
+  inline ~S() = default;
+  inline constexpr S(const S<double> &) = default;
+  inline constexpr S(S<double> &&) = default;
+  
+};
+
+#endif
+
+
+template<typename T>
+class Y : public S<T>, public E
+{
+};
+/* First instantiated from: TemplateExpansion2Test.cpp:59 */
+#ifdef INSIGHTS_USE_TEMPLATE
+class Y<double> : public S<double>, public E
+{
+  inline constexpr Y() noexcept = default;
+  inline constexpr Y(const Y<double> &) = default;
+  inline constexpr Y(Y<double> &&) = default;
+  
+};
+
+#endif
+
+
+
+void test()
+{
+  int buffer[16]{};
+
+  const unsigned long & xx = ARRAY_SIZE(buffer);
+
+  S<int> s; 
+
+  Y<double> y;
+}
+
+
+int main(){}
+

--- a/tests/TemplateExpansionTest.expect
+++ b/tests/TemplateExpansionTest.expect
@@ -2,8 +2,9 @@ template <template <typename> class... Templates>
 struct template_tuple {};
 /* First instantiated from: TemplateExpansionTest.cpp:9 */
 #ifdef INSIGHTS_USE_TEMPLATE
-class template_tuple<identity>
+struct template_tuple<identity>
 {
+  inline ~template_tuple() noexcept = default;
   
 };
 
@@ -34,6 +35,10 @@ void foo2() {
   #ifdef INSIGHTS_USE_TEMPLATE
   class B<Test, Test>
   {
+    inline constexpr B() noexcept = default;
+    inline ~B() = default;
+    inline constexpr B(const B<Test, Test> &) = default;
+    inline constexpr B(B<Test, Test> &&) = default;
     
   };
   
@@ -46,6 +51,9 @@ void foo2() {
   #ifdef INSIGHTS_USE_TEMPLATE
   class testType<int>
   {
+    inline constexpr testType() noexcept = default;
+    inline constexpr testType(const testType<int> &) = default;
+    inline constexpr testType(testType<int> &&) = default;
     
   };
   
@@ -77,6 +85,9 @@ void foo2() {
   #ifdef INSIGHTS_USE_TEMPLATE
   class testIntegral<2>
   {
+    inline constexpr testIntegral() noexcept = default;
+    inline constexpr testIntegral(const testIntegral<2> &) = default;
+    inline constexpr testIntegral(testIntegral<2> &&) = default;
     
   };
   
@@ -93,6 +104,10 @@ void foo2() {
   #ifdef INSIGHTS_USE_TEMPLATE
   class C<Test, Test>
   {
+    B<Test, Test> testTemplateExpansion;
+    inline constexpr C() noexcept = default;
+    inline constexpr C(const C<Test, Test> &) = default;
+    inline constexpr C(C<Test, Test> &&) = default;
     
   };
   
@@ -104,6 +119,9 @@ void foo2() {
   #ifdef INSIGHTS_USE_TEMPLATE
   class testExpr<4, 1>
   {
+    inline constexpr testExpr() noexcept = default;
+    inline constexpr testExpr(const testExpr<4, 1> &) = default;
+    inline constexpr testExpr(testExpr<4, 1> &&) = default;
     
   };
   
@@ -115,6 +133,9 @@ void foo2() {
   #ifdef INSIGHTS_USE_TEMPLATE
   class testPack<0, 1, 2, 4>
   {
+    inline constexpr testPack() noexcept = default;
+    inline constexpr testPack(const testPack<0, 1, 2, 4> &) = default;
+    inline constexpr testPack(testPack<0, 1, 2, 4> &&) = default;
     
   };
   

--- a/tests/TemplateHandler4Test.expect
+++ b/tests/TemplateHandler4Test.expect
@@ -11,7 +11,7 @@ bool Is(const T& x)
 template<>
 bool Is<int>(const int & x)
 {
-  int b = { x };
+  int b = {x};
   return b == x;
 }
 #endif

--- a/tests/TemplateHandlerTest.expect
+++ b/tests/TemplateHandlerTest.expect
@@ -72,6 +72,20 @@ private:
 class Template<int>
 {
   
+  public: 
+  inline Template(const int & x)
+  : mX{x}
+  {
+  }
+  
+  inline int Get() const;
+  
+  
+  private: 
+  const int mX;
+  inline constexpr Template(const Template<int> &) = default;
+  inline constexpr Template(Template<int> &&) = default;
+  
 };
 
 #endif
@@ -80,6 +94,20 @@ class Template<int>
 #ifdef INSIGHTS_USE_TEMPLATE
 class Template<double>
 {
+  
+  public: 
+  inline Template(const double & x)
+  : mX{x}
+  {
+  }
+  
+  inline double Get() const;
+  
+  
+  private: 
+  const double mX;
+  inline constexpr Template(const Template<double> &) = default;
+  inline constexpr Template(Template<double> &&) = default;
   
 };
 
@@ -111,9 +139,9 @@ void tprintf(const char* format, T value, Targs... Fargs) // recursive variadic 
 template<>
 void tprintf<const char *, char, int>(const char * format, const char * value, char Fargs, int Fargs)
 {
-  for(; static_cast<int>(*format) != static_cast<int>('\0'); format++)
+  for(; static_cast<int>(*format) != static_cast<int>('\0'); format++) 
   {
-    if( static_cast<int>(*format) == static_cast<int>('%') ) {
+    if(static_cast<int>(*format) == static_cast<int>('%')) {
       std::operator<<(std::cout, value);
       tprintf(format + 1, Fargs, Fargs);
       return;
@@ -129,9 +157,9 @@ void tprintf<const char *, char, int>(const char * format, const char * value, c
 template<>
 void tprintf<char, int>(const char * format, char value, int Fargs)
 {
-  for(; static_cast<int>(*format) != static_cast<int>('\0'); format++)
+  for(; static_cast<int>(*format) != static_cast<int>('\0'); format++) 
   {
-    if( static_cast<int>(*format) == static_cast<int>('%') ) {
+    if(static_cast<int>(*format) == static_cast<int>('%')) {
       std::operator<<(std::cout, value);
       tprintf(format + 1, Fargs);
       return;
@@ -147,9 +175,9 @@ void tprintf<char, int>(const char * format, char value, int Fargs)
 template<>
 void tprintf<int, >(const char * format, int value)
 {
-  for(; static_cast<int>(*format) != static_cast<int>('\0'); format++)
+  for(; static_cast<int>(*format) != static_cast<int>('\0'); format++) 
   {
-    if( static_cast<int>(*format) == static_cast<int>('%') ) {
+    if(static_cast<int>(*format) == static_cast<int>('%')) {
       std::cout.operator<<(value);
       tprintf(format + 1);
       return;

--- a/tests/TemplateWithNullptrTest.expect
+++ b/tests/TemplateWithNullptrTest.expect
@@ -15,6 +15,9 @@ class B {
 #ifdef INSIGHTS_USE_TEMPLATE
 class B<A, void (A::*)()>
 {
+  inline constexpr B() noexcept = default;
+  inline constexpr B(const B<A, void (A::*)()> &) = default;
+  inline constexpr B(B<A, void (A::*)()> &&) = default;
   
 };
 

--- a/tests/TemporaryHandler2Test.expect
+++ b/tests/TemporaryHandler2Test.expect
@@ -43,7 +43,7 @@ void f7(X& x)
 
 X f8(bool x, int y)
 {
-    if( x || y == 2 ) {
+    if(x || y == 2) {
        return X(y);
      }
      

--- a/tests/TypeIdInTemplateTest.cpp
+++ b/tests/TypeIdInTemplateTest.cpp
@@ -1,0 +1,21 @@
+#include <string>
+
+template <typename T>
+class Foo{
+public:    
+    std::string Get() {
+        std::string typeId{typeid(T).name()};
+        return typeId;
+    }
+
+};
+
+
+
+int main()
+{
+  Foo<int> i;
+
+  i.Get();
+}
+

--- a/tests/TypeIdInTemplateTest.expect
+++ b/tests/TypeIdInTemplateTest.expect
@@ -1,0 +1,41 @@
+#include <string>
+
+template <typename T>
+class Foo{
+public:    
+    std::string Get() {
+        std::string typeId{typeid(T).name()};
+        return typeId;
+    }
+
+};
+/* First instantiated from: TypeIdInTemplateTest.cpp:17 */
+#ifdef INSIGHTS_USE_TEMPLATE
+class Foo<int>
+{
+  
+  public: 
+  inline std::basic_string<char> Get()
+  {
+    std::basic_string<char> typeId = std::basic_string<char>{typeid(const std::type_info).name()} /* NRVO variable */;
+    return std::basic_string<char>(typeId);
+  }
+  
+  inline constexpr Foo() noexcept = default;
+  inline constexpr Foo(const Foo<int> &) = default;
+  inline constexpr Foo(Foo<int> &&) = default;
+  
+};
+
+#endif
+
+
+
+
+int main()
+{
+  Foo<int> i;
+
+  i.Get();
+}
+

--- a/tests/UserDefinedLiteral2Test.expect
+++ b/tests/UserDefinedLiteral2Test.expect
@@ -9,7 +9,7 @@ constexpr seconds_t operator ""_s(unsigned long long s)
 
 int main()
 {
-    if( true ) {
+    if(true) {
        std::chrono::duration<long long, std::ratio<1, 1> > s = operator""_s(1ull);
      }
      

--- a/tests/VisitorTest.expect
+++ b/tests/VisitorTest.expect
@@ -1,8 +1,12 @@
 template<class... Ts> struct visitor: Ts... { using Ts::operator()...; };
 /* First instantiated from: VisitorTest.cpp:7 */
 #ifdef INSIGHTS_USE_TEMPLATE
-class visitor<__lambda_8_7, __lambda_9_7>
+struct visitor<__lambda_8_7, __lambda_9_7> : public __lambda_8_7, public __lambda_9_7
 {
+  using visitor<__lambda_8_7, __lambda_9_7>::operator();
+  using visitor<__lambda_8_7, __lambda_9_7>::operator();
+  inline constexpr visitor<__lambda_8_7, __lambda_9_7> & operator=(visitor<__lambda_8_7, __lambda_9_7> &&) = default;
+  inline ~visitor() noexcept = default;
   
 };
 
@@ -31,7 +35,7 @@ int main()
        
      };
      
-     visitor<__lambda_8_7, __lambda_9_7> my_visitor = visitor{ __lambda_8_7(__lambda_8_7{}), __lambda_9_7(__lambda_9_7{}) };
+     visitor<__lambda_8_7, __lambda_9_7> my_visitor = visitor{__lambda_8_7(__lambda_8_7{}), __lambda_9_7(__lambda_9_7{})};
      
 
 


### PR DESCRIPTION
Up to now class templates ended up with just the class tag and name.
This change expands the whole class, including methods and variables.
There are some cases where a method has no body in the expanded version.
In that case this method is unused in the instatiated version.

This changes also brings support for more statements/expressions. Like
the placement delete or inline variable initialization.

A further simplification is the attempt to introduce a function which is
responsible to adding parens or curlys.