### PR TITLE
Fixed issue #46: Lambda's in global scope.

### DIFF
--- a/AutoStmtHandler.cpp
+++ b/AutoStmtHandler.cpp
@@ -6,6 +6,7 @@
  ****************************************************************************/
 
 #include "AutoStmtHandler.h"
+#include "CodeGenerator.h"
 #include "InsightsHelpers.h"
 #include "InsightsMatchers.h"
 #include "InsightsStaticStrings.h"
@@ -21,9 +22,18 @@ namespace clang::insights {
 AutoStmtHandler::AutoStmtHandler(Rewriter& rewrite, MatchFinder& matcher)
 : InsightsBase(rewrite)
 {
+
+    static const auto isAutoAncestor =
+        hasAncestor(varDecl(anyOf(hasType(autoType().bind("autoType")),
+                                  hasType(qualType(hasDescendant(autoType().bind("autoType")))),
+                                  /* decltype and decltype(auto) */
+                                  hasType(decltypeType().bind("dt")),
+                                  hasType(qualType(hasDescendant(decltypeType().bind("dt")))))));
+
     matcher.addMatcher(varDecl(unless(anyOf(isExpansionInSystemHeader(),
                                             isMacroOrInvalidLocation(),
                                             decompositionDecl(),
+                                            isAutoAncestor,
                                             /* don't replace auto in templates */
                                             isTemplate,
                                             hasAncestor(functionDecl()))),
@@ -41,36 +51,18 @@ AutoStmtHandler::AutoStmtHandler(Rewriter& rewrite, MatchFinder& matcher)
 void AutoStmtHandler::run(const MatchFinder::MatchResult& result)
 {
     if(const auto* autoDecl = result.Nodes.getNodeAs<VarDecl>("autoDecl")) {
-        const QualType type = [&]() {
-            if(const auto* declType = result.Nodes.getNodeAs<DecltypeType>("dt")) {
-                return declType->getUnderlyingType();
-            }
-
-            return autoDecl->getType();
-        }();
-
-        const std::string fqn{[&]() {
-            if(autoDecl->getType()->isFunctionPointerType()) {
-                const auto lineNo = result.SourceManager->getSpellingLineNumber(autoDecl->getSourceRange().getBegin());
-
-                const std::string funcPtrName{StrCat("FuncPtr_", std::to_string(lineNo))};
-                std::string       usingStr{StrCat("using ", funcPtrName, " = ", GetName(type), ";\n ", funcPtrName)};
-
-                return StrCat((autoDecl->isConstexpr() ? kwConstExprSpace : ""), usingStr);
-
-            } else {
-                return StrCat((autoDecl->isConstexpr() ? kwConstExprSpace : ""), GetName(type));
-            }
-        }()};
+        OutputFormatHelper outputFormatHelper{};
+        CodeGenerator      codeGenerator{outputFormatHelper};
+        codeGenerator.InsertArg(autoDecl);
 
         // constexpr int* x = 5;
         // ^              ^   ^
         // 1              2   3
         // the SourceRange starts at (1) end ends at (3). The Location in the other hand starts at (1) and ends
         // at (2)
-        const SourceRange sr{autoDecl->getSourceRange().getBegin(), autoDecl->getLocation().getLocWithOffset(-1)};
+        const auto sr = GetSourceRangeAfterToken(autoDecl->getSourceRange(), tok::semi, result);
 
-        mRewrite.ReplaceText(sr, fqn);
+        mRewrite.ReplaceText(sr, outputFormatHelper.GetString());
     }
 }
 //-----------------------------------------------------------------------------

--- a/CompilerGeneratedHandler.cpp
+++ b/CompilerGeneratedHandler.cpp
@@ -27,7 +27,7 @@ CompilerGeneratedHandler::CompilerGeneratedHandler(Rewriter& rewrite, MatchFinde
                                                             isTemplate,
                                                             hasAncestor(functionDecl()),
                                                             isMacroOrInvalidLocation())),
-                                               hasParent(cxxRecordDecl().bind("record")));
+                                               hasParent(cxxRecordDecl(unless(isLambda())).bind("record")));
 
     matcher.addMatcher(cxxMethodDecl(compilerProvided).bind("method"), this);
 }

--- a/FunctionDeclHandler.cpp
+++ b/FunctionDeclHandler.cpp
@@ -23,6 +23,7 @@ FunctionDeclHandler::FunctionDeclHandler(Rewriter& rewrite, MatchFinder& matcher
 : InsightsBase(rewrite)
 {
     matcher.addMatcher(functionDecl(unless(anyOf(cxxMethodDecl(unless(isUserProvided())),
+                                                 cxxMethodDecl(hasParent(cxxRecordDecl(isLambda()))),
                                                  isExpansionInSystemHeader(),
                                                  isTemplate,
                                                  hasAncestor(friendDecl()),    // friendDecl has functionDecl as child
@@ -36,6 +37,7 @@ FunctionDeclHandler::FunctionDeclHandler(Rewriter& rewrite, MatchFinder& matcher
                                                     hasDescendant(classTemplateSpecializationDecl()));
 
     matcher.addMatcher(friendDecl(unless(anyOf(cxxMethodDecl(unless(isUserProvided())),
+                                               cxxMethodDecl(hasParent(cxxRecordDecl(isLambda()))),
                                                isExpansionInSystemHeader(),
                                                isTemplate,
                                                hasTemplateDescendant,

--- a/tests/AutoHandler7Test.expect
+++ b/tests/AutoHandler7Test.expect
@@ -5,9 +5,11 @@ const char * Foo()
 }
 
 
-int x = 22;
+static int x = 22;
 
-const char * c = Foo();
+
+static const char * c = Foo();
+
 
 
 int main()

--- a/tests/Issue46.cpp
+++ b/tests/Issue46.cpp
@@ -1,0 +1,10 @@
+auto x = []() {
+    return 5;
+};
+
+auto x2 = [a=5](int b) {
+    return b*a;
+};
+
+int main()
+{}

--- a/tests/Issue46.expect
+++ b/tests/Issue46.expect
@@ -1,0 +1,37 @@
+
+class __lambda_1_10
+{
+  public: inline /*constexpr */ int operator()() const
+  {
+    return 5;
+  }
+  
+};
+
+__lambda_1_10 x = __lambda_1_10{};
+
+
+
+class __lambda_5_11
+{
+  public: inline /*constexpr */ int operator()(int b) const
+  {
+    return b * a;
+  }
+  
+  private:
+  int a;
+  
+  public: __lambda_5_11(int _a)
+  : a{_a}
+  {}
+  
+};
+
+__lambda_5_11 x2 = __lambda_5_11{5};
+
+
+int main()
+{
+}
+


### PR DESCRIPTION
Once again the matchers caused trouble. The global autoDecl matcher did
also catch the lambda which resulted in a mess. This fix forwards
autoDecls into CodeGenerator as well and locks it against double match.