### PR TITLE
Fixed missing semi in case of a single statement for/while-loop.

### DIFF
--- a/CodeGenerator.cpp
+++ b/CodeGenerator.cpp
@@ -272,7 +272,20 @@ void CodeGenerator::InsertArg(const WhileStmt* stmt)
     mOutputFormatHelper.Append("while");
     WrapInParensOrCurlys(BraceKind::Parens, [&]() { InsertArg(stmt->getCond()); }, AddSpaceAtTheEnd::Yes);
 
-    InsertArg(stmt->getBody());
+    const auto* body = stmt->getBody();
+    const bool  hasCompoundStmt{isa<CompoundStmt>(body)};
+
+    InsertArg(body);
+
+    if(hasCompoundStmt) {
+        mOutputFormatHelper.AppendNewLine();
+    } else {
+        const bool isBodyBraced = isa<CompoundStmt>(body);
+        if(!isBodyBraced) {
+            mOutputFormatHelper.AppendNewLine(';');
+        }
+    }
+
     mOutputFormatHelper.AppendNewLine();
 }
 //-----------------------------------------------------------------------------
@@ -970,17 +983,23 @@ void CodeGenerator::InsertArg(const ForStmt* stmt)
                          },
                          AddSpaceAtTheEnd::Yes);
 
-    const bool hasCompoundStmt{isa<CompoundStmt>(stmt->getBody())};
+    const auto* body = stmt->getBody();
+    const bool  hasCompoundStmt{isa<CompoundStmt>(body)};
 
     if(hasCompoundStmt) {
         mOutputFormatHelper.AppendNewLine();
     }
 
-    InsertArg(stmt->getBody());
+    InsertArg(body);
 
     // Note: an empty for-loop carries a simi-colon at the end
     if(hasCompoundStmt) {
         mOutputFormatHelper.AppendNewLine();
+    } else {
+        const bool isBodyBraced = isa<CompoundStmt>(body);
+        if(!isBodyBraced) {
+            mOutputFormatHelper.AppendNewLine(';');
+        }
     }
 
     mOutputFormatHelper.AppendNewLine();

--- a/tests/ClassOperatorHandler5Test.expect
+++ b/tests/ClassOperatorHandler5Test.expect
@@ -11,6 +11,7 @@ std::basic_string<char> trim(const std::basic_string<char> & input)
   while(i < static_cast<int>(static_cast<int>(input.length())) && static_cast<int>(input.operator[](i)) <= static_cast<int>(' ')) {
     i++;
   }
+  
   if(i >= static_cast<int>(static_cast<int>(input.length()))) {
     return std::basic_string<char>("");
   }
@@ -23,6 +24,7 @@ std::basic_string<char> trim(const std::basic_string<char> & input)
   while(i >= 0 && static_cast<int>(final.operator[](i)) <= static_cast<int>(' ')) {
     i--;
   }
+  
   return final.substr(0, static_cast<unsigned long>(i + 1));
 }
 

--- a/tests/LambdaHandler9Test.expect
+++ b/tests/LambdaHandler9Test.expect
@@ -35,6 +35,7 @@ int main()
       while(static_cast<unsigned long>(i) < sizeof(buffer)) {
         buffer[i++] = 1;
       }
+      
     }
     
   };

--- a/tests/LoopStatementsTest.expect
+++ b/tests/LoopStatementsTest.expect
@@ -1,12 +1,14 @@
 int main()
 {
   for(int i = 0; i < 2; ++i) ;
+  ;
   
   for(int i = 0; i < 2; ++i) 
   {
   }
   
   for(int i = {0}; i < 2; i++) ;
+  ;
   
 }
 

--- a/tests/SingleLineLoopsTest.cpp
+++ b/tests/SingleLineLoopsTest.cpp
@@ -1,0 +1,11 @@
+void Foo() {}
+
+int main()
+{
+  for(int i = 0; i < 2; ++i) Foo();
+  
+  int i=0;
+  while( ++i < 5 ) Foo();
+
+  do Foo(); while( ++i < 5 );
+}

--- a/tests/SingleLineLoopsTest.expect
+++ b/tests/SingleLineLoopsTest.expect
@@ -1,0 +1,16 @@
+void Foo()
+{
+}
+
+
+int main()
+{
+  for(int i = 0; i < 2; ++i) Foo();
+  
+  int i = 0;
+  while(++i < 5) Foo();
+  
+  do Foo(); while(++i < 5);
+  
+}
+


### PR DESCRIPTION
The semicolon at the end of a single unbraced  statement (as body) in a
for- or while-loop was missing which leads to non-compiling code.