### PR TITLE
Fixed issue #51: Crash of insights with invalid code.

### DIFF
--- a/CodeGenerator.cpp
+++ b/CodeGenerator.cpp
@@ -462,9 +462,11 @@ static const DeclRefExpr* FindDeclRef(const Stmt* stmt)
         }
     }
 
-    for(const auto* child : stmt->children()) {
-        if(const auto* childRef = FindDeclRef(child)) {
-            return childRef;
+    if(stmt) {
+        for(const auto* child : stmt->children()) {
+            if(const auto* childRef = FindDeclRef(child)) {
+                return childRef;
+            }
         }
     }
 

--- a/tests/Issue51.cpp
+++ b/tests/Issue51.cpp
@@ -1,0 +1,8 @@
+#include <map>
+
+int main()
+// no open curly bracket here
+    using Map = std::map<int, bool>;
+    Map m;
+    auto [it, ok] = m.insert({1, true});
+}


### PR DESCRIPTION
A missing brace in main leads insights to a crash. While the program is
invalid, the reason for the crash was a nullptr in FindDeclRef which
potentially can occur with valid code as well. The fix handles the case
that stmt is a nullptr.