### PR TITLE
Fixed issue #53: Defaulted special members outside a class.

### DIFF
--- a/FunctionDeclHandler.cpp
+++ b/FunctionDeclHandler.cpp
@@ -22,29 +22,31 @@ namespace clang::insights {
 FunctionDeclHandler::FunctionDeclHandler(Rewriter& rewrite, MatchFinder& matcher)
 : InsightsBase(rewrite)
 {
-    matcher.addMatcher(functionDecl(unless(anyOf(cxxMethodDecl(unless(isUserProvided())),
-                                                 cxxMethodDecl(hasParent(cxxRecordDecl(isLambda()))),
-                                                 isExpansionInSystemHeader(),
-                                                 isTemplate,
-                                                 hasAncestor(friendDecl()),    // friendDecl has functionDecl as child
-                                                 hasAncestor(functionDecl()),  // prevent forward declarations
-                                                 isMacroOrInvalidLocation())))
-                           .bind("funcDecl"),
-                       this);
+    matcher.addMatcher(
+        functionDecl(unless(anyOf(cxxMethodDecl(anyOf(
+                                      unless(isUserProvided()), isDefaulted(), hasParent(cxxRecordDecl(isLambda())))),
+                                  isExpansionInSystemHeader(),
+                                  isTemplate,
+                                  hasAncestor(friendDecl()),    // friendDecl has functionDecl as child
+                                  hasAncestor(functionDecl()),  // prevent forward declarations
+                                  isMacroOrInvalidLocation())))
+            .bind("funcDecl"),
+        this);
 
     static const auto hasTemplateDescendant = anyOf(hasDescendant(classTemplateDecl()),
                                                     hasDescendant(functionTemplateDecl()),
                                                     hasDescendant(classTemplateSpecializationDecl()));
 
-    matcher.addMatcher(friendDecl(unless(anyOf(cxxMethodDecl(unless(isUserProvided())),
-                                               cxxMethodDecl(hasParent(cxxRecordDecl(isLambda()))),
-                                               isExpansionInSystemHeader(),
-                                               isTemplate,
-                                               hasTemplateDescendant,
-                                               hasAncestor(functionDecl()),  // prevent forward declarations
-                                               isMacroOrInvalidLocation())))
-                           .bind("friendDecl"),
-                       this);
+    matcher.addMatcher(
+        friendDecl(unless(anyOf(cxxMethodDecl(anyOf(
+                                    unless(isUserProvided()), isDefaulted(), hasParent(cxxRecordDecl(isLambda())))),
+                                isExpansionInSystemHeader(),
+                                isTemplate,
+                                hasTemplateDescendant,
+                                hasAncestor(functionDecl()),  // prevent forward declarations
+                                isMacroOrInvalidLocation())))
+            .bind("friendDecl"),
+        this);
 }
 //-----------------------------------------------------------------------------
 

--- a/tests/Issue53.cpp
+++ b/tests/Issue53.cpp
@@ -1,0 +1,10 @@
+struct Base
+{
+    Base();
+    Base(const Base &);
+    ~Base();
+};
+
+Base::Base() = default;
+Base::Base(const Base &) = default;
+Base::~Base() = default;

--- a/tests/Issue53.expect
+++ b/tests/Issue53.expect
@@ -1,0 +1,15 @@
+struct Base
+{
+    Base();
+    
+    ;
+    Base(const Base &);
+    
+    ;
+    ~Base() noexcept;
+    ;
+};
+
+Base::Base() = default;
+Base::Base(const Base &) = default;
+Base::~Base() = default;


### PR DESCRIPTION
Defaulted members outside a class lead to invalid code. The fix ensures,
that such definitions are left alone for now, as there is no code to
generate anyway.