### PR TITLE
Re-enable building with clang current.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,18 +20,18 @@ matrix:
     compiler: clang
       
     # Linux Clang Build
-#  - os: linux
-#    compiler: clang
-#    addons:
-#      apt:
-#        sources: *all_sources
-#        packages:
-#        - clang-7
-#        - libstdc++-6-dev
-#        - llvm-7-dev
-#        - libclang-7-dev
-#        - zlib1g-dev
-#    env: COMPILER='clang++-7' COMPILER_CC='clang-7' LLVM_CONFIG='/usr/bin/llvm-config-7'  COVERAGE='No' STATIC='No' DEBUG='No'
+  - os: linux
+    compiler: clang
+    addons:
+      apt:
+        sources: *all_sources
+        packages:
+        - clang-7
+        - libstdc++-7-dev
+        - llvm-7-dev
+        - libclang-7-dev
+        - zlib1g-dev
+    env: COMPILER='clang++-7' COMPILER_CC='clang-7' LLVM_CONFIG='/usr/bin/llvm-config-7'  COVERAGE='No' STATIC='No' DEBUG='No'
 
   # Linux g++ Build
   - os: linux

--- a/AutoStmtHandler.cpp
+++ b/AutoStmtHandler.cpp
@@ -17,6 +17,10 @@ using namespace clang;
 using namespace clang::ast_matchers;
 //-----------------------------------------------------------------------------
 
+// XXX: recent clang source has a declType matcher. Try to figure out a migration path.
+const internal::VariadicDynCastAllOfMatcher<Type, DecltypeType> myDecltypeType;
+//-----------------------------------------------------------------------------
+
 namespace clang::insights {
 
 AutoStmtHandler::AutoStmtHandler(Rewriter& rewrite, MatchFinder& matcher)
@@ -27,8 +31,8 @@ AutoStmtHandler::AutoStmtHandler(Rewriter& rewrite, MatchFinder& matcher)
         hasAncestor(varDecl(anyOf(hasType(autoType().bind("autoType")),
                                   hasType(qualType(hasDescendant(autoType().bind("autoType")))),
                                   /* decltype and decltype(auto) */
-                                  hasType(decltypeType().bind("dt")),
-                                  hasType(qualType(hasDescendant(decltypeType().bind("dt")))))));
+                                  hasType(myDecltypeType().bind("dt")),
+                                  hasType(qualType(hasDescendant(myDecltypeType().bind("dt")))))));
 
     matcher.addMatcher(varDecl(unless(anyOf(isExpansionInSystemHeader(),
                                             isMacroOrInvalidLocation(),
@@ -40,8 +44,8 @@ AutoStmtHandler::AutoStmtHandler(Rewriter& rewrite, MatchFinder& matcher)
                                      hasType(autoType().bind("autoType")),
                                      hasType(qualType(hasDescendant(autoType().bind("autoType")))),
                                      /* decltype and decltype(auto) */
-                                     hasType(decltypeType().bind("dt")),
-                                     hasType(qualType(hasDescendant(decltypeType().bind("dt"))))))
+                                     hasType(myDecltypeType().bind("dt")),
+                                     hasType(qualType(hasDescendant(myDecltypeType().bind("dt"))))))
                            .bind("autoDecl"),
                        this);
 }

--- a/InsightsMatchers.h
+++ b/InsightsMatchers.h
@@ -16,9 +16,6 @@
 
 namespace clang {
 namespace ast_matchers {
-const internal::VariadicDynCastAllOfMatcher<Type, DecltypeType>      decltypeType;
-const internal::VariadicDynCastAllOfMatcher<Decl, DecompositionDecl> decompositionDecl;  // DecompositionDecl
-//-----------------------------------------------------------------------------
 
 /* don't replace stuff in template definitions */
 static const auto isTemplate = anyOf(hasAncestor(classTemplateDecl()),


### PR DESCRIPTION
This handles cc30333c2cdf3beb6bb32165bf2e5550f9977227 which disabled the
clang current build.