### PR TITLE
Handle specialized class method templates correctly.

### DIFF
--- a/CodeGenerator.h
+++ b/CodeGenerator.h
@@ -130,10 +130,9 @@ public:
     STRONG_BOOL(SkipConstexpr);
     STRONG_BOOL(SkipAccess);
 
-    static void InsertAccessModifierAndNameWithReturnType(OutputFormatHelper& outputFormatHelper,
-                                                          const FunctionDecl& decl,
-                                                          const SkipConstexpr skipConstexpr = SkipConstexpr::No,
-                                                          const SkipAccess    skipAccess    = SkipAccess::No);
+    void InsertAccessModifierAndNameWithReturnType(const FunctionDecl& decl,
+                                                   const SkipConstexpr skipConstexpr = SkipConstexpr::No,
+                                                   const SkipAccess    skipAccess    = SkipAccess::No);
 
     static const char* GetStorageClassAsString(const StorageClass& sc);
     static std::string GetStorageClassAsStringWithSpace(const StorageClass& sc);

--- a/CompilerGeneratedHandler.cpp
+++ b/CompilerGeneratedHandler.cpp
@@ -39,7 +39,8 @@ void CompilerGeneratedHandler::run(const MatchFinder::MatchResult& result)
         OutputFormatHelper outputFormatHelper{};
         outputFormatHelper.Append("/* ");
 
-        CodeGenerator::InsertAccessModifierAndNameWithReturnType(outputFormatHelper, *methodDecl);
+        CodeGenerator codeGenerator{outputFormatHelper};
+        codeGenerator.InsertAccessModifierAndNameWithReturnType(*methodDecl);
 
         outputFormatHelper.AppendNewLine("; */");
 

--- a/TemplateHandler.cpp
+++ b/TemplateHandler.cpp
@@ -78,13 +78,13 @@ void TemplateHandler::InsertInstantiatedTemplate(const FunctionDecl& funcDecl, c
         const auto& sm = GetSM(result);
         InsertInstantiationPoint(outputFormatHelper, sm, funcDecl.getPointOfInstantiation());
         outputFormatHelper.AppendNewLine("#ifdef INSIGHTS_USE_TEMPLATE");
+        CodeGenerator codeGenerator{outputFormatHelper};
 
-        CodeGenerator::InsertAccessModifierAndNameWithReturnType(
-            outputFormatHelper, funcDecl, CodeGenerator::SkipConstexpr::No, CodeGenerator::SkipAccess::Yes);
+        codeGenerator.InsertAccessModifierAndNameWithReturnType(
+            funcDecl, CodeGenerator::SkipConstexpr::No, CodeGenerator::SkipAccess::Yes);
 
         outputFormatHelper.AppendNewLine();
 
-        CodeGenerator codeGenerator{outputFormatHelper};
         codeGenerator.InsertArg(body);
 
         outputFormatHelper.AppendNewLine();

--- a/tests/CXXMethodTemplateExplicitSpecializationTest.cpp
+++ b/tests/CXXMethodTemplateExplicitSpecializationTest.cpp
@@ -1,0 +1,23 @@
+template<typename T>
+class Foo
+{
+public:
+    void Func();
+};
+
+
+template<>
+void Foo<int>::Func()
+{
+}
+
+template<>
+void Foo<char>::Func()
+{
+}
+
+int main()
+{
+    Foo<int> f;
+    Foo<char> fc;
+}

--- a/tests/CXXMethodTemplateExplicitSpecializationTest.expect
+++ b/tests/CXXMethodTemplateExplicitSpecializationTest.expect
@@ -1,0 +1,58 @@
+template<typename T>
+class Foo
+{
+public:
+    void Func();
+};
+/* First instantiated from: CXXMethodTemplateExplicitSpecializationTest.cpp:10 */
+#ifdef INSIGHTS_USE_TEMPLATE
+class Foo<int>
+{
+  
+  public: 
+  void Func();
+  
+  inline constexpr Foo() noexcept = default;
+  inline constexpr Foo(const Foo<int> &) = default;
+  inline constexpr Foo(Foo<int> &&) = default;
+  
+};
+
+#endif
+
+/* First instantiated from: CXXMethodTemplateExplicitSpecializationTest.cpp:15 */
+#ifdef INSIGHTS_USE_TEMPLATE
+class Foo<char>
+{
+  
+  public: 
+  void Func();
+  
+  inline constexpr Foo() noexcept = default;
+  inline constexpr Foo(const Foo<char> &) = default;
+  inline constexpr Foo(Foo<char> &&) = default;
+  
+};
+
+#endif
+
+
+
+template<>
+void Foo<int>::Func()
+{
+}
+
+
+template<>
+void Foo<char>::Func()
+{
+}
+
+
+int main()
+{
+  Foo<int> f = Foo<int>();
+  Foo<char> fc = Foo<char>();
+}
+


### PR DESCRIPTION
A class template which implements a specialized method outside of its
definition needs to have the empty template keyword and name the type for
which it is specialized.