### PR TITLE
Fix #50: Remove second and invalid ampersand for an l-value ref.

### DIFF
--- a/InsightsHelpers.cpp
+++ b/InsightsHelpers.cpp
@@ -30,7 +30,16 @@ static const struct CppInsightsPrintingPolicy : PrintingPolicy
 
 static const std::string GetAsCPPStyleString(const QualType& t)
 {
-    return t.getAsString(InsightsPrintingPolicy);
+    std::string ret{t.getAsString(InsightsPrintingPolicy)};
+    // FIXME: workaround a possible clang bug. getAsString() returns && for an l-value ref. The code below checks
+    // whether t is a l-value ref and in that case does a string search and replace for && to &.
+    if(t->isLValueReferenceType()) {
+        if(const std::string::size_type i = ret.find("&&", 0); std::string::npos != i) {
+            ret = ret.replace(i, 2, "&");
+        }
+    }
+
+    return ret;
 }
 //-----------------------------------------------------------------------------
 

--- a/tests/AutoHandler2Test.cpp
+++ b/tests/AutoHandler2Test.cpp
@@ -1,3 +1,4 @@
+#define INSIGHTS_USE_TEMPLATE
 #include <map>
 #include <set>
 

--- a/tests/AutoHandler2Test.expect
+++ b/tests/AutoHandler2Test.expect
@@ -1,3 +1,4 @@
+#define INSIGHTS_USE_TEMPLATE
 #include <map>
 #include <set>
 
@@ -6,7 +7,7 @@ template <typename T> void foo(T & t)
     auto it = t.find(42);
 }
 
-/* First instantiated from: AutoHandler2Test.cpp:14 */
+/* First instantiated from: AutoHandler2Test.cpp:15 */
 #ifdef INSIGHTS_USE_TEMPLATE
 template<>
 void foo<std::map<int, int, std::less<int>, std::allocator<std::pair<const int, int> > > >(std::map<int, int, std::less<int>, std::allocator<std::pair<const int, int> > > & t)
@@ -16,7 +17,7 @@ void foo<std::map<int, int, std::less<int>, std::allocator<std::pair<const int, 
 #endif
 
 
-/* First instantiated from: AutoHandler2Test.cpp:15 */
+/* First instantiated from: AutoHandler2Test.cpp:16 */
 #ifdef INSIGHTS_USE_TEMPLATE
 template<>
 void foo<std::set<int, std::less<int>, std::allocator<int> > >(std::set<int, std::less<int>, std::allocator<int> > & t)

--- a/tests/CXXDefaultInitExprTest.cpp
+++ b/tests/CXXDefaultInitExprTest.cpp
@@ -1,3 +1,5 @@
+#define INSIGHTS_USE_TEMPLATE
+
 template<typename T, bool array>
 class Alloc
 {

--- a/tests/CXXDefaultInitExprTest.expect
+++ b/tests/CXXDefaultInitExprTest.expect
@@ -1,3 +1,5 @@
+#define INSIGHTS_USE_TEMPLATE
+
 template<typename T, bool array>
 class Alloc
 {
@@ -10,8 +12,9 @@ public:
     {
     }
 };
-/* First instantiated from: CXXDefaultInitExprTest.cpp:16 */
+/* First instantiated from: CXXDefaultInitExprTest.cpp:18 */
 #ifdef INSIGHTS_USE_TEMPLATE
+template<>
 class Alloc<int, 0>
 {
   const int z;
@@ -33,8 +36,9 @@ class Alloc<int, 0>
 
 #endif
 
-/* First instantiated from: CXXDefaultInitExprTest.cpp:17 */
+/* First instantiated from: CXXDefaultInitExprTest.cpp:19 */
 #ifdef INSIGHTS_USE_TEMPLATE
+template<>
 class Alloc<char, 1>
 {
   const int z;

--- a/tests/CXXDestructorTest.cpp
+++ b/tests/CXXDestructorTest.cpp
@@ -1,3 +1,5 @@
+#define INSIGHTS_USE_TEMPLATE
+
 template<typename T, bool array>
 class Alloc
 {

--- a/tests/CXXDestructorTest.expect
+++ b/tests/CXXDestructorTest.expect
@@ -1,3 +1,5 @@
+#define INSIGHTS_USE_TEMPLATE
+
 template<typename T, bool array>
 class Alloc
 {
@@ -23,8 +25,9 @@ public:
         }
     }
 };
-/* First instantiated from: CXXDestructorTest.cpp:29 */
+/* First instantiated from: CXXDestructorTest.cpp:31 */
 #ifdef INSIGHTS_USE_TEMPLATE
+template<>
 class Alloc<int, 0>
 {
   int * data;
@@ -59,8 +62,9 @@ class Alloc<int, 0>
 
 #endif
 
-/* First instantiated from: CXXDestructorTest.cpp:30 */
+/* First instantiated from: CXXDestructorTest.cpp:32 */
 #ifdef INSIGHTS_USE_TEMPLATE
+template<>
 class Alloc<char, 1>
 {
   char * data;

--- a/tests/CXXMethodTemplateExplicitSpecializationTest.expect
+++ b/tests/CXXMethodTemplateExplicitSpecializationTest.expect
@@ -6,6 +6,7 @@ public:
 };
 /* First instantiated from: CXXMethodTemplateExplicitSpecializationTest.cpp:10 */
 #ifdef INSIGHTS_USE_TEMPLATE
+template<>
 class Foo<int>
 {
   
@@ -22,6 +23,7 @@ class Foo<int>
 
 /* First instantiated from: CXXMethodTemplateExplicitSpecializationTest.cpp:15 */
 #ifdef INSIGHTS_USE_TEMPLATE
+template<>
 class Foo<char>
 {
   

--- a/tests/CharLiteralTest.expect
+++ b/tests/CharLiteralTest.expect
@@ -21,6 +21,7 @@ struct Foo
 };
 /* First instantiated from: CharLiteralTest.cpp:61 */
 #ifdef INSIGHTS_USE_TEMPLATE
+template<>
 struct Foo<int>
 {
   int raw;
@@ -47,6 +48,7 @@ struct Foo<int>
 
 /* First instantiated from: CharLiteralTest.cpp:60 */
 #ifdef INSIGHTS_USE_TEMPLATE
+template<>
 struct Foo<char>
 {
   char raw;

--- a/tests/ClassOperatorHandler7Test.cpp
+++ b/tests/ClassOperatorHandler7Test.cpp
@@ -1,3 +1,5 @@
+#define INSIGHTS_USE_TEMPLATE
+
 //CXXDependentScopeMemberExpr
 // http://lists.llvm.org/pipermail/cfe-dev/2017-January/052433.html
 

--- a/tests/ClassOperatorHandler7Test.expect
+++ b/tests/ClassOperatorHandler7Test.expect
@@ -1,3 +1,5 @@
+#define INSIGHTS_USE_TEMPLATE
+
 //CXXDependentScopeMemberExpr
 // http://lists.llvm.org/pipermail/cfe-dev/2017-January/052433.html
 
@@ -6,8 +8,9 @@ struct A
 {
    void foo(int);
 };
-/* First instantiated from: ClassOperatorHandler7Test.cpp:20 */
+/* First instantiated from: ClassOperatorHandler7Test.cpp:22 */
 #ifdef INSIGHTS_USE_TEMPLATE
+template<>
 struct A<int>
 {
   void foo(int);
@@ -20,8 +23,9 @@ struct A<int>
 
 #endif
 
-/* First instantiated from: ClassOperatorHandler7Test.cpp:20 */
+/* First instantiated from: ClassOperatorHandler7Test.cpp:22 */
 #ifdef INSIGHTS_USE_TEMPLATE
+template<>
 struct A<int *>
 {
   struct B
@@ -59,7 +63,7 @@ void foo()
   a.foo(3);
 }
 
-/* First instantiated from: ClassOperatorHandler7Test.cpp:24 */
+/* First instantiated from: ClassOperatorHandler7Test.cpp:26 */
 #ifdef INSIGHTS_USE_TEMPLATE
 template<>
 void foo<int>()
@@ -70,7 +74,7 @@ void foo<int>()
 #endif
 
 
-/* First instantiated from: ClassOperatorHandler7Test.cpp:25 */
+/* First instantiated from: ClassOperatorHandler7Test.cpp:27 */
 #ifdef INSIGHTS_USE_TEMPLATE
 template<>
 void foo<int *>()
@@ -94,7 +98,7 @@ bool foo2() {
     return vec.empty(); // 'vec' is identified as part of 'CXXDependentScopeMemberExpr' but call expression 'empty' is not and it's completely missing from the AST
 }
 
-/* First instantiated from: ClassOperatorHandler7Test.cpp:50 */
+/* First instantiated from: ClassOperatorHandler7Test.cpp:52 */
 #ifdef INSIGHTS_USE_TEMPLATE
 template<>
 bool foo2<int>()

--- a/tests/ClassOperatorHandler9Test.cpp
+++ b/tests/ClassOperatorHandler9Test.cpp
@@ -1,3 +1,5 @@
+#define INSIGHTS_USE_TEMPLATE
+
 #include <vector>
 
 template<typename T>

--- a/tests/ClassOperatorHandler9Test.expect
+++ b/tests/ClassOperatorHandler9Test.expect
@@ -1,3 +1,5 @@
+#define INSIGHTS_USE_TEMPLATE
+
 #include <vector>
 
 template<typename T>
@@ -26,8 +28,9 @@ public:
 
     T& operator[](const std::size_t i) { return v[i]; }
 };
-/* First instantiated from: ClassOperatorHandler9Test.cpp:32 */
+/* First instantiated from: ClassOperatorHandler9Test.cpp:34 */
 #ifdef INSIGHTS_USE_TEMPLATE
+template<>
 class MyVector<int>
 {
   std::vector<int, std::allocator<int> > v;
@@ -92,7 +95,7 @@ MyVector<T> operator*(const MyVector<T>& a, const MyVector<T>& b)
     return result;
 }
 
-/* First instantiated from: ClassOperatorHandler9Test.cpp:68 */
+/* First instantiated from: ClassOperatorHandler9Test.cpp:70 */
 #ifdef INSIGHTS_USE_TEMPLATE
 template<>
 MyVector<int> operator*<int>(const MyVector<int> & a, const MyVector<int> & b)

--- a/tests/ClassTemplateTest.cpp
+++ b/tests/ClassTemplateTest.cpp
@@ -1,3 +1,5 @@
+#define INSIGHTS_USE_TEMPLATE
+
 template <typename T>
 class Foo{
 public:

--- a/tests/ClassTemplateTest.expect
+++ b/tests/ClassTemplateTest.expect
@@ -1,3 +1,5 @@
+#define INSIGHTS_USE_TEMPLATE
+
 template <typename T>
 class Foo{
 public:
@@ -6,8 +8,9 @@ public:
 protected:
     bool Mo() { return false; }
 };
-/* First instantiated from: ClassTemplateTest.cpp:10 */
+/* First instantiated from: ClassTemplateTest.cpp:12 */
 #ifdef INSIGHTS_USE_TEMPLATE
+template<>
 class Foo<int>
 {
   

--- a/tests/ClassTemplateWithoutDefinitionTest.expect
+++ b/tests/ClassTemplateWithoutDefinitionTest.expect
@@ -2,6 +2,7 @@ template <typename T>
 class Foo{};
 /* First instantiated from: ClassTemplateWithoutDefinitionTest.cpp:11 */
 #ifdef INSIGHTS_USE_TEMPLATE
+template<>
 class Foo<double>
 {
   inline constexpr Foo() noexcept = default;

--- a/tests/ClassWithDeletedSpecialFunctionTest.cpp
+++ b/tests/ClassWithDeletedSpecialFunctionTest.cpp
@@ -1,3 +1,5 @@
+#define INSIGHTS_USE_TEMPLATE
+
 template<typename T>
 class Foo {
 public:

--- a/tests/ClassWithDeletedSpecialFunctionTest.expect
+++ b/tests/ClassWithDeletedSpecialFunctionTest.expect
@@ -1,11 +1,14 @@
+#define INSIGHTS_USE_TEMPLATE
+
 template<typename T>
 class Foo {
 public:
     Foo() = delete;
     Foo(int){}
 };
-/* First instantiated from: ClassWithDeletedSpecialFunctionTest.cpp:10 */
+/* First instantiated from: ClassWithDeletedSpecialFunctionTest.cpp:12 */
 #ifdef INSIGHTS_USE_TEMPLATE
+template<>
 class Foo<int>
 {
   

--- a/tests/ClassWithoutDefinitionTest.expect
+++ b/tests/ClassWithoutDefinitionTest.expect
@@ -6,6 +6,7 @@ class Foo
 };
 /* First instantiated from: ClassWithoutDefinitionTest.cpp:10 */
 #ifdef INSIGHTS_USE_TEMPLATE
+template<>
 class Foo<int>
 {
   class Bar;

--- a/tests/DelegatingCtorTest.cpp
+++ b/tests/DelegatingCtorTest.cpp
@@ -1,3 +1,5 @@
+#define INSIGHTS_USE_TEMPLATE
+
 template<typename T>
 struct Foo {
   Foo(char x, int y) : _x{x}, _y(y) {}

--- a/tests/DelegatingCtorTest.expect
+++ b/tests/DelegatingCtorTest.expect
@@ -1,3 +1,5 @@
+#define INSIGHTS_USE_TEMPLATE
+
 template<typename T>
 struct Foo {
   Foo(char x, int y) : _x{x}, _y(y) {}
@@ -6,8 +8,9 @@ struct Foo {
   char _x;
   int _y;
 };
-/* First instantiated from: DelegatingCtorTest.cpp:19 */
+/* First instantiated from: DelegatingCtorTest.cpp:21 */
 #ifdef INSIGHTS_USE_TEMPLATE
+template<>
 struct Foo<int>
 {
   inline Foo(char x, int y)
@@ -31,8 +34,9 @@ struct Foo<int>
 
 #endif
 
-/* First instantiated from: DelegatingCtorTest.cpp:12 */
+/* First instantiated from: DelegatingCtorTest.cpp:14 */
 #ifdef INSIGHTS_USE_TEMPLATE
+template<>
 struct Foo<char>
 {
   inline Foo(char x, int y)
@@ -60,8 +64,9 @@ struct Bar : Foo<T>
 {
     Bar(int x) : Foo<T>(x, 2) {}
 };
-/* First instantiated from: DelegatingCtorTest.cpp:22 */
+/* First instantiated from: DelegatingCtorTest.cpp:24 */
 #ifdef INSIGHTS_USE_TEMPLATE
+template<>
 struct Bar<char> : public Foo<char>
 {
   inline Bar(int x)

--- a/tests/FunctionalCast2Test.cpp
+++ b/tests/FunctionalCast2Test.cpp
@@ -1,3 +1,5 @@
+#define INSIGHTS_USE_TEMPLATE
+
 #include <cstdio>
 #include <type_traits>
 #include <utility>

--- a/tests/FunctionalCast2Test.expect
+++ b/tests/FunctionalCast2Test.expect
@@ -1,3 +1,5 @@
+#define INSIGHTS_USE_TEMPLATE
+
 #include <cstdio>
 #include <type_traits>
 #include <utility>
@@ -9,7 +11,7 @@ namespace details::array_single_compare {
     return ((to == ar[I]) && ...);
   }
   
-  /* First instantiated from: FunctionalCast2Test.cpp:16 */
+  /* First instantiated from: FunctionalCast2Test.cpp:18 */
   #ifdef INSIGHTS_USE_TEMPLATE
   template<>
   inline constexpr bool Compare<unsigned char, 6, int, 0, 1, 2, 3, 4, 5>(const unsigned char (&ar)[6], const int & to, std::integer_sequence<unsigned long, 0, 1, 2, 3, 4, 5>)
@@ -26,7 +28,7 @@ constexpr bool Compare(const T (&ar)[N], const TTo& to)
   return details::array_single_compare::Compare(ar, to, std::make_index_sequence<N>{});
 }
 
-/* First instantiated from: FunctionalCast2Test.cpp:45 */
+/* First instantiated from: FunctionalCast2Test.cpp:47 */
 #ifdef INSIGHTS_USE_TEMPLATE
 template<>
 inline constexpr bool Compare<unsigned char, 6, int>(const unsigned char (&ar)[6], const int & to)
@@ -43,7 +45,7 @@ namespace details::array_compare {
     return ((to[I] == ar[I]) && ...);
   }
   
-  /* First instantiated from: FunctionalCast2Test.cpp:30 */
+  /* First instantiated from: FunctionalCast2Test.cpp:32 */
   #ifdef INSIGHTS_USE_TEMPLATE
   template<>
   inline constexpr bool Compare<unsigned char, 6, 0, 1, 2, 3, 4, 5>(const unsigned char (&ar)[6], const unsigned char (&to)[6], std::integer_sequence<unsigned long, 0, 1, 2, 3, 4, 5>)
@@ -60,7 +62,7 @@ constexpr bool Compare(const T (&ar)[N], const T (&to)[N])
   return details::array_compare::Compare(ar, to, std::make_index_sequence<N>{});
 }
 
-/* First instantiated from: FunctionalCast2Test.cpp:49 */
+/* First instantiated from: FunctionalCast2Test.cpp:51 */
 #ifdef INSIGHTS_USE_TEMPLATE
 template<>
 inline constexpr bool Compare<unsigned char, 6>(const unsigned char (&ar)[6], const unsigned char (&to)[6])

--- a/tests/InitializerListTest.cpp
+++ b/tests/InitializerListTest.cpp
@@ -1,3 +1,5 @@
+#define INSIGHTS_USE_TEMPLATE
+
 #include <utility>
 
 class X {

--- a/tests/InitializerListTest.expect
+++ b/tests/InitializerListTest.expect
@@ -1,3 +1,5 @@
+#define INSIGHTS_USE_TEMPLATE
+
 #include <utility>
 
 class X {
@@ -70,7 +72,7 @@ void bar(std::initializer_list<int> x)
 template<typename T>
 void something(std::initializer_list<T>) {}
 
-/* First instantiated from: InitializerListTest.cpp:56 */
+/* First instantiated from: InitializerListTest.cpp:58 */
 #ifdef INSIGHTS_USE_TEMPLATE
 template<>
 void something<int>(std::initializer_list<int>)
@@ -79,7 +81,7 @@ void something<int>(std::initializer_list<int>)
 #endif
 
 
-/* First instantiated from: InitializerListTest.cpp:58 */
+/* First instantiated from: InitializerListTest.cpp:60 */
 #ifdef INSIGHTS_USE_TEMPLATE
 template<>
 void something<float>(std::initializer_list<float>)

--- a/tests/Issue1.cpp
+++ b/tests/Issue1.cpp
@@ -1,3 +1,5 @@
+#define INSIGHTS_USE_TEMPLATE
+
 template<typename T> T foo() {return T(42); } 
 template<typename T> T fooGood() {return T{42}; } 
 

--- a/tests/Issue1.expect
+++ b/tests/Issue1.expect
@@ -1,6 +1,8 @@
+#define INSIGHTS_USE_TEMPLATE
+
 template<typename T> T foo() {return T(42); }
 
-/* First instantiated from: Issue1.cpp:4 */
+/* First instantiated from: Issue1.cpp:6 */
 #ifdef INSIGHTS_USE_TEMPLATE
 template<>
 int foo<int>()
@@ -11,7 +13,7 @@ int foo<int>()
  
 template<typename T> T fooGood() {return T{42}; }
 
-/* First instantiated from: Issue1.cpp:5 */
+/* First instantiated from: Issue1.cpp:7 */
 #ifdef INSIGHTS_USE_TEMPLATE
 template<>
 int fooGood<int>()

--- a/tests/Issue15.cpp
+++ b/tests/Issue15.cpp
@@ -1,3 +1,5 @@
+#define INSIGHTS_USE_TEMPLATE
+
 #include <chrono>
 #include <string>
 

--- a/tests/Issue15.expect
+++ b/tests/Issue15.expect
@@ -1,3 +1,5 @@
+#define INSIGHTS_USE_TEMPLATE
+
 #include <chrono>
 #include <string>
 
@@ -19,7 +21,7 @@ constexpr int operator""_cs()
     return 0;
 }
 
-/* First instantiated from: Issue15.cpp:36 */
+/* First instantiated from: Issue15.cpp:38 */
 #ifdef INSIGHTS_USE_TEMPLATE
 template<>
 inline constexpr int operator""_cs<52, 53, 54, 55>()
@@ -35,7 +37,7 @@ constexpr int operator""_x()
     return 0;
 }
 
-/* First instantiated from: Issue15.cpp:31 */
+/* First instantiated from: Issue15.cpp:33 */
 #ifdef INSIGHTS_USE_TEMPLATE
 template<>
 inline constexpr int operator""_x<char, 49, 50, 51, 52, 53>()

--- a/tests/Issue50.cpp
+++ b/tests/Issue50.cpp
@@ -1,0 +1,12 @@
+template <class T>
+void foo(T && t)
+{ }
+
+struct Test {};
+
+int main()
+{
+    Test test;
+    foo(test);
+    return 0;
+}

--- a/tests/Issue50_2.cpp
+++ b/tests/Issue50_2.cpp
@@ -1,0 +1,20 @@
+#define INSIGHTS_USE_TEMPLATE
+#include <utility>
+
+struct Test {};
+
+template <class T>
+void foo(T && t)
+{ }
+
+int main()
+{
+    Test test;
+    foo(test);
+
+  	int i=0;
+  	foo(i);
+  
+    long l;
+    foo(std::move(l));
+}

--- a/tests/Issue50_2.expect
+++ b/tests/Issue50_2.expect
@@ -1,0 +1,49 @@
+#define INSIGHTS_USE_TEMPLATE
+#include <utility>
+
+struct Test {/* public: inline constexpr Test() noexcept; */
+/* public: inline constexpr Test(const Test &); */
+/* public: inline constexpr Test(Test &&); */
+};
+
+template <class T>
+void foo(T && t)
+{ }
+
+/* First instantiated from: Issue50_2.cpp:13 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+void foo<Test &>(Test & t)
+{
+}
+#endif
+
+
+/* First instantiated from: Issue50_2.cpp:16 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+void foo<int &>(int & t)
+{
+}
+#endif
+
+
+/* First instantiated from: Issue50_2.cpp:19 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+void foo<long>(long && t)
+{
+}
+#endif
+
+
+int main()
+{
+  Test test = Test();
+  foo(test);
+  int i = 0;
+  foo(i);
+  long l;
+  foo(std::move(l));
+}
+

--- a/tests/LambdaHandlerVLATest.cerr
+++ b/tests/LambdaHandlerVLATest.cerr
@@ -1,7 +1,7 @@
-.tmp.cpp:97:16: error: invalid use of 'this' outside of a non-static member function
+.tmp.cpp:98:16: error: invalid use of 'this' outside of a non-static member function
     float (&e)[this->nt];
                ^
-.tmp.cpp:99:39: error: invalid use of 'this' outside of a non-static member function
+.tmp.cpp:100:39: error: invalid use of 'this' outside of a non-static member function
     public: __lambda_40_8(float (&_e)[this->nt])
                                       ^
 2 errors generated.

--- a/tests/LambdaHandlerVLATest.expect
+++ b/tests/LambdaHandlerVLATest.expect
@@ -28,6 +28,7 @@ struct SA
 };
 /* First instantiated from: LambdaHandlerVLATest.cpp:59 */
 #ifdef INSIGHTS_USE_TEMPLATE
+template<>
 struct SA<2>
 {
   inline SA(const int & PA)

--- a/tests/RangeForStmtHandler3Test.expect
+++ b/tests/RangeForStmtHandler3Test.expect
@@ -74,6 +74,7 @@ struct str_view {
 };
 /* First instantiated from: RangeForStmtHandler3Test.cpp:49 */
 #ifdef INSIGHTS_USE_TEMPLATE
+template<>
 struct str_view<char>
 {
   const char * ptr;

--- a/tests/RangeForStmtHandler4Test.cpp
+++ b/tests/RangeForStmtHandler4Test.cpp
@@ -1,3 +1,5 @@
+#define INSIGHTS_USE_TEMPLATE
+
 // https://mbevin.wordpress.com/2012/11/14/range-based-for/
 template<class T>
 class MyArrayWrapper {

--- a/tests/RangeForStmtHandler4Test.expect
+++ b/tests/RangeForStmtHandler4Test.expect
@@ -1,3 +1,5 @@
+#define INSIGHTS_USE_TEMPLATE
+
 // https://mbevin.wordpress.com/2012/11/14/range-based-for/
 template<class T>
 class MyArrayWrapper {
@@ -8,8 +10,9 @@ public:
    int* begin() { return size>0 ? &data[0] : nullptr; }
    int* end()   { return size>0 ? &data[size-1] : nullptr; }
 };
-/* First instantiated from: RangeForStmtHandler4Test.cpp:14 */
+/* First instantiated from: RangeForStmtHandler4Test.cpp:16 */
 #ifdef INSIGHTS_USE_TEMPLATE
+template<>
 class MyArrayWrapper<int>
 {
   int * data;

--- a/tests/StaticAndTemplatesTest.cpp
+++ b/tests/StaticAndTemplatesTest.cpp
@@ -1,0 +1,28 @@
+#define INSIGHTS_USE_TEMPLATE
+
+template<typename T>
+constexpr T min(const T& a, const T& b)
+{
+    return (a < b) ? a : b;
+} 
+
+template<typename T>
+static T max(const T& a, const T& b)
+{
+    return (a > b) ? a : b;
+} 
+
+int main()
+{
+    int a=1, b=2;
+
+    int mi = min(a, b);
+
+    double ad=2.4, bd=3.4;
+
+    auto md = min( ad, bd);
+
+    int ma1 = max(1, 2);
+    double ma2 = max(2.0, 4.0);
+}
+

--- a/tests/StaticAndTemplatesTest.expect
+++ b/tests/StaticAndTemplatesTest.expect
@@ -1,0 +1,67 @@
+#define INSIGHTS_USE_TEMPLATE
+
+template<typename T>
+constexpr T min(const T& a, const T& b)
+{
+    return (a < b) ? a : b;
+}
+
+/* First instantiated from: StaticAndTemplatesTest.cpp:19 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+inline constexpr int min<int>(const int & a, const int & b)
+{
+  return (a < b) ? a : b;
+}
+#endif
+
+
+/* First instantiated from: StaticAndTemplatesTest.cpp:23 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+inline constexpr double min<double>(const double & a, const double & b)
+{
+  return (a < b) ? a : b;
+}
+#endif
+ 
+
+template<typename T>
+static T max(const T& a, const T& b)
+{
+    return (a > b) ? a : b;
+}
+
+/* First instantiated from: StaticAndTemplatesTest.cpp:25 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+int max<int>(const int & a, const int & b)
+{
+  return (a > b) ? a : b;
+}
+#endif
+
+
+/* First instantiated from: StaticAndTemplatesTest.cpp:26 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+double max<double>(const double & a, const double & b)
+{
+  return (a > b) ? a : b;
+}
+#endif
+ 
+
+int main()
+{
+  int a = 1;
+  int b = 2;
+  int mi = min(a, b);
+  double ad = 2.3999999999999999;
+  double bd = 3.3999999999999999;
+  double md = min(ad, bd);
+  int ma1 = max(1, 2);
+  double ma2 = max(2.0, 4.0);
+}
+
+

--- a/tests/StdFunctionTest.cpp
+++ b/tests/StdFunctionTest.cpp
@@ -1,3 +1,5 @@
+#define INSIGHTS_USE_TEMPLATE
+
 #include <functional>
 #include <cstdio>
 

--- a/tests/StdFunctionTest.expect
+++ b/tests/StdFunctionTest.expect
@@ -1,3 +1,5 @@
+#define INSIGHTS_USE_TEMPLATE
+
 #include <functional>
 #include <cstdio>
 
@@ -11,7 +13,7 @@ void Test(T& t)
 {
 }
 
-/* First instantiated from: StdFunctionTest.cpp:15 */
+/* First instantiated from: StdFunctionTest.cpp:17 */
 #ifdef INSIGHTS_USE_TEMPLATE
 template<>
 void Test<std::function<void ()> >(std::function<void ()> & t)

--- a/tests/StructuredBindingsHandler3Test.cerr
+++ b/tests/StructuredBindingsHandler3Test.cerr
@@ -1,61 +1,61 @@
-.tmp.cpp:81:48: error: no matching function for call to 'get'
+.tmp.cpp:84:48: error: no matching function for call to 'get'
   std::tuple_element<0, constant::Q>::type a = constant::get<0ul>(constant::__q17);
                                                ^~~~~~~~~~~~~~~~~~
-.tmp.cpp:43:33: note: candidate function not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
+.tmp.cpp:46:33: note: candidate function not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
   template<int N> constexpr int get(Q &&) { return N * N; }
                                 ^
-.tmp.cpp:82:48: error: no matching function for call to 'get'
+.tmp.cpp:85:48: error: no matching function for call to 'get'
   std::tuple_element<1, constant::Q>::type b = constant::get<1ul>(constant::__q17);
                                                ^~~~~~~~~~~~~~~~~~
-.tmp.cpp:43:33: note: candidate function not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
+.tmp.cpp:46:33: note: candidate function not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
   template<int N> constexpr int get(Q &&) { return N * N; }
                                 ^
-.tmp.cpp:83:48: error: no matching function for call to 'get'
+.tmp.cpp:86:48: error: no matching function for call to 'get'
   std::tuple_element<2, constant::Q>::type c = constant::get<2ul>(constant::__q17);
                                                ^~~~~~~~~~~~~~~~~~
-.tmp.cpp:43:33: note: candidate function not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
+.tmp.cpp:46:33: note: candidate function not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
   template<int N> constexpr int get(Q &&) { return N * N; }
                                 ^
-.tmp.cpp:89:50: error: no matching function for call to 'get'
+.tmp.cpp:92:50: error: no matching function for call to 'get'
     std::tuple_element<0, constant::Q>::type a = constant::get<0ul>(__q20);
                                                  ^~~~~~~~~~~~~~~~~~
-.tmp.cpp:43:33: note: candidate function not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
+.tmp.cpp:46:33: note: candidate function not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
   template<int N> constexpr int get(Q &&) { return N * N; }
                                 ^
-.tmp.cpp:90:50: error: no matching function for call to 'get'
+.tmp.cpp:93:50: error: no matching function for call to 'get'
     std::tuple_element<1, constant::Q>::type b = constant::get<1ul>(__q20);
                                                  ^~~~~~~~~~~~~~~~~~
-.tmp.cpp:43:33: note: candidate function not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
+.tmp.cpp:46:33: note: candidate function not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
   template<int N> constexpr int get(Q &&) { return N * N; }
                                 ^
-.tmp.cpp:91:50: error: no matching function for call to 'get'
+.tmp.cpp:94:50: error: no matching function for call to 'get'
     std::tuple_element<2, constant::Q>::type c = constant::get<2ul>(__q20);
                                                  ^~~~~~~~~~~~~~~~~~
-.tmp.cpp:43:33: note: candidate function not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
+.tmp.cpp:46:33: note: candidate function not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
   template<int N> constexpr int get(Q &&) { return N * N; }
                                 ^
-.tmp.cpp:89:46: error: variables defined in a constexpr function must be initialized
+.tmp.cpp:92:46: error: variables defined in a constexpr function must be initialized
     std::tuple_element<0, constant::Q>::type a = constant::get<0ul>(__q20);
                                              ^
-.tmp.cpp:101:52: error: no matching function for call to 'get'
+.tmp.cpp:104:52: error: no matching function for call to 'get'
       std::tuple_element<0, constant::Q>::type a = constant::get<0ul>(__q27);
                                                    ^~~~~~~~~~~~~~~~~~
-.tmp.cpp:43:33: note: candidate function not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
+.tmp.cpp:46:33: note: candidate function not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
   template<int N> constexpr int get(Q &&) { return N * N; }
                                 ^
-.tmp.cpp:102:52: error: no matching function for call to 'get'
+.tmp.cpp:105:52: error: no matching function for call to 'get'
       std::tuple_element<1, constant::Q>::type b = constant::get<1ul>(__q27);
                                                    ^~~~~~~~~~~~~~~~~~
-.tmp.cpp:43:33: note: candidate function not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
+.tmp.cpp:46:33: note: candidate function not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
   template<int N> constexpr int get(Q &&) { return N * N; }
                                 ^
-.tmp.cpp:103:52: error: no matching function for call to 'get'
+.tmp.cpp:106:52: error: no matching function for call to 'get'
       std::tuple_element<2, constant::Q>::type c = constant::get<2ul>(__q27);
                                                    ^~~~~~~~~~~~~~~~~~
-.tmp.cpp:43:33: note: candidate function not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
+.tmp.cpp:46:33: note: candidate function not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
   template<int N> constexpr int get(Q &&) { return N * N; }
                                 ^
-.tmp.cpp:101:48: error: variables defined in a constexpr function must be initialized
+.tmp.cpp:104:48: error: variables defined in a constexpr function must be initialized
       std::tuple_element<0, constant::Q>::type a = constant::get<0ul>(__q27);
                                                ^
 11 errors generated.

--- a/tests/StructuredBindingsHandler3Test.expect
+++ b/tests/StructuredBindingsHandler3Test.expect
@@ -5,6 +5,7 @@ namespace std { template<typename T> struct tuple_size; }
 namespace std { template<size_t, typename> struct tuple_element;
 /* First instantiated from: StructuredBindingsHandler3Test.cpp:17 */
 #ifdef INSIGHTS_USE_TEMPLATE
+template<>
 struct tuple_element<0, constant::Q>
 {
   using type = int;
@@ -15,6 +16,7 @@ struct tuple_element<0, constant::Q>
 
 /* First instantiated from: StructuredBindingsHandler3Test.cpp:17 */
 #ifdef INSIGHTS_USE_TEMPLATE
+template<>
 struct tuple_element<1, constant::Q>
 {
   using type = int;
@@ -25,6 +27,7 @@ struct tuple_element<1, constant::Q>
 
 /* First instantiated from: StructuredBindingsHandler3Test.cpp:17 */
 #ifdef INSIGHTS_USE_TEMPLATE
+template<>
 struct tuple_element<2, constant::Q>
 {
   using type = int;

--- a/tests/TemplateArgumentsTest.expect
+++ b/tests/TemplateArgumentsTest.expect
@@ -13,7 +13,7 @@ static inline decltype(auto) Normalize(const T& arg)
 /* First instantiated from: TemplateArgumentsTest.cpp:16 */
 #ifdef INSIGHTS_USE_TEMPLATE
 template<>
-static inline char const (&)[8] Normalize<char [8]>(char const (&arg)[8])
+inline char const (&)[8] Normalize<char [8]>(char const (&arg)[8])
 {
   if constexpr(std::is_same_v<char [8], std::basic_string<char>>) ;
   else /* constexpr */ {
@@ -27,7 +27,7 @@ static inline char const (&)[8] Normalize<char [8]>(char const (&arg)[8])
 /* First instantiated from: TemplateArgumentsTest.cpp:16 */
 #ifdef INSIGHTS_USE_TEMPLATE
 template<>
-static inline const int & Normalize<int>(const int & arg)
+inline const int & Normalize<int>(const int & arg)
 {
   if constexpr(std::is_same_v<int, std::basic_string<char>>) ;
   else /* constexpr */ {
@@ -41,7 +41,7 @@ static inline const int & Normalize<int>(const int & arg)
 /* First instantiated from: TemplateArgumentsTest.cpp:16 */
 #ifdef INSIGHTS_USE_TEMPLATE
 template<>
-static inline const char * Normalize<std::basic_string<char> >(const std::basic_string<char> & arg)
+inline const char * Normalize<std::basic_string<char> >(const std::basic_string<char> & arg)
 {
   if constexpr(std::is_same_v<std::basic_string<char>, std::basic_string<char>>) {
     return arg.c_str();

--- a/tests/TemplateAsTemplateArgumentTest.expect
+++ b/tests/TemplateAsTemplateArgumentTest.expect
@@ -1,6 +1,7 @@
 template<typename T> class my_array {};
 /* First instantiated from: TemplateAsTemplateArgumentTest.cpp:7 */
 #ifdef INSIGHTS_USE_TEMPLATE
+template<>
 class my_array<int>
 {
   inline constexpr my_array() noexcept = default;
@@ -22,6 +23,7 @@ class Map
 };
 /* First instantiated from: TemplateAsTemplateArgumentTest.cpp:13 */
 #ifdef INSIGHTS_USE_TEMPLATE
+template<>
 class Map<int, int, my_array>
 {
   my_array<int> key;

--- a/tests/TemplateExpansion2Test.expect
+++ b/tests/TemplateExpansion2Test.expect
@@ -5,6 +5,7 @@ namespace details {
   template<class T>
   struct remove_reference      { typedef T type; };
   #ifdef INSIGHTS_USE_TEMPLATE
+  template<>
   struct remove_reference<int [16]>
   {
     using type = int [16];
@@ -26,6 +27,7 @@ namespace details {
     static_assert(N != 0, "Arrays only");
   };
   #ifdef INSIGHTS_USE_TEMPLATE
+  template<>
   struct extent<int [16], 0>
   {
     inline static constexpr const size_t value = 16ul;
@@ -70,6 +72,7 @@ class S : public B
 };
 /* First instantiated from: TemplateExpansion2Test.cpp:57 */
 #ifdef INSIGHTS_USE_TEMPLATE
+template<>
 class S<int> : public B
 {
   inline constexpr S() noexcept = default;
@@ -82,6 +85,7 @@ class S<int> : public B
 
 /* First instantiated from: TemplateExpansion2Test.cpp:46 */
 #ifdef INSIGHTS_USE_TEMPLATE
+template<>
 class S<double> : public B
 {
   inline constexpr S() noexcept = default;
@@ -100,6 +104,7 @@ class Y : public S<T>, public E
 };
 /* First instantiated from: TemplateExpansion2Test.cpp:59 */
 #ifdef INSIGHTS_USE_TEMPLATE
+template<>
 class Y<double> : public S<double>, public E
 {
   inline constexpr Y() noexcept = default;

--- a/tests/TemplateExpansionTest.expect
+++ b/tests/TemplateExpansionTest.expect
@@ -2,6 +2,7 @@ template <template <typename> class... Templates>
 struct template_tuple {};
 /* First instantiated from: TemplateExpansionTest.cpp:9 */
 #ifdef INSIGHTS_USE_TEMPLATE
+template<>
 struct template_tuple<identity>
 {
   inline ~template_tuple() noexcept = default;
@@ -35,6 +36,7 @@ void foo2()
   template<template<typename> class ...> class B { };
   /* First instantiated from: TemplateExpansionTest.cpp:27 */
   #ifdef INSIGHTS_USE_TEMPLATE
+  template<>
   class B<Test, Test>
   {
     inline constexpr B() noexcept = default;
@@ -52,6 +54,7 @@ void foo2()
   template<typename> class testType { };
   /* First instantiated from: TemplateExpansionTest.cpp:43 */
   #ifdef INSIGHTS_USE_TEMPLATE
+  template<>
   class testType<int>
   {
     inline constexpr testType() noexcept = default;
@@ -66,6 +69,7 @@ void foo2()
   template<int fp(void)> class testDecl { };
   /* First instantiated from: TemplateExpansionTest.cpp:45 */
   #ifdef INSIGHTS_USE_TEMPLATE
+  template<>
   class testDecl<int (*)()>
   {
     
@@ -75,6 +79,7 @@ void foo2()
   
   /* First instantiated from: TemplateExpansionTest.cpp:46 */
   #ifdef INSIGHTS_USE_TEMPLATE
+  template<>
   class testDecl<int (*)()>
   {
     
@@ -86,6 +91,7 @@ void foo2()
   template<int> class testIntegral { };
   /* First instantiated from: TemplateExpansionTest.cpp:48 */
   #ifdef INSIGHTS_USE_TEMPLATE
+  template<>
   class testIntegral<2>
   {
     inline constexpr testIntegral() noexcept = default;
@@ -105,6 +111,7 @@ void foo2()
   };
   /* First instantiated from: TemplateExpansionTest.cpp:41 */
   #ifdef INSIGHTS_USE_TEMPLATE
+  template<>
   class C<Test, Test>
   {
     B<Test, Test> testTemplateExpansion;
@@ -120,6 +127,7 @@ void foo2()
   template<int, int = 0> class testExpr{};
   /* First instantiated from: TemplateExpansionTest.cpp:50 */
   #ifdef INSIGHTS_USE_TEMPLATE
+  template<>
   class testExpr<4, 1>
   {
     inline constexpr testExpr() noexcept = default;
@@ -134,6 +142,7 @@ void foo2()
   template<int, int ...> class testPack { };
   /* First instantiated from: TemplateExpansionTest.cpp:52 */
   #ifdef INSIGHTS_USE_TEMPLATE
+  template<>
   class testPack<0, 1, 2, 4>
   {
     inline constexpr testPack() noexcept = default;

--- a/tests/TemplateHandler3Test.cpp
+++ b/tests/TemplateHandler3Test.cpp
@@ -1,3 +1,5 @@
+#define INSIGHTS_USE_TEMPLATE
+    
 template<int N, typename T>
 constexpr T min(const T& b)
 {

--- a/tests/TemplateHandler3Test.expect
+++ b/tests/TemplateHandler3Test.expect
@@ -1,10 +1,12 @@
+#define INSIGHTS_USE_TEMPLATE
+    
 template<int N, typename T>
 constexpr T min(const T& b)
 {
     return N < b;
 }
 
-/* First instantiated from: TemplateHandler3Test.cpp:9 */
+/* First instantiated from: TemplateHandler3Test.cpp:11 */
 #ifdef INSIGHTS_USE_TEMPLATE
 template<>
 inline constexpr int min<2, int>(const int & b)

--- a/tests/TemplateHandler4Test.cpp
+++ b/tests/TemplateHandler4Test.cpp
@@ -1,3 +1,5 @@
+#define INSIGHTS_USE_TEMPLATE
+    
 template<typename T>
 bool Is(const T& x)
 {

--- a/tests/TemplateHandler4Test.expect
+++ b/tests/TemplateHandler4Test.expect
@@ -1,3 +1,5 @@
+#define INSIGHTS_USE_TEMPLATE
+    
 template<typename T>
 bool Is(const T& x)
 {
@@ -6,7 +8,7 @@ bool Is(const T& x)
     return b == x;
 }
 
-/* First instantiated from: TemplateHandler4Test.cpp:11 */
+/* First instantiated from: TemplateHandler4Test.cpp:13 */
 #ifdef INSIGHTS_USE_TEMPLATE
 template<>
 bool Is<int>(const int & x)

--- a/tests/TemplateHandlerTest.expect
+++ b/tests/TemplateHandlerTest.expect
@@ -36,7 +36,7 @@ static T max(const T& a, const T& b)
 /* First instantiated from: TemplateHandlerTest.cpp:67 */
 #ifdef INSIGHTS_USE_TEMPLATE
 template<>
-static int max<int>(const int & a, const int & b)
+int max<int>(const int & a, const int & b)
 {
   return (a > b) ? a : b;
 }
@@ -46,7 +46,7 @@ static int max<int>(const int & a, const int & b)
 /* First instantiated from: TemplateHandlerTest.cpp:68 */
 #ifdef INSIGHTS_USE_TEMPLATE
 template<>
-static double max<double>(const double & a, const double & b)
+double max<double>(const double & a, const double & b)
 {
   return (a > b) ? a : b;
 }
@@ -69,6 +69,7 @@ private:
 };
 /* First instantiated from: TemplateHandlerTest.cpp:61 */
 #ifdef INSIGHTS_USE_TEMPLATE
+template<>
 class Template<int>
 {
   
@@ -92,6 +93,7 @@ class Template<int>
 
 /* First instantiated from: TemplateHandlerTest.cpp:63 */
 #ifdef INSIGHTS_USE_TEMPLATE
+template<>
 class Template<double>
 {
   

--- a/tests/TemplateWithNullptrTest.expect
+++ b/tests/TemplateWithNullptrTest.expect
@@ -14,6 +14,7 @@ class B {
 };
 /* First instantiated from: TemplateWithNullptrTest.cpp:15 */
 #ifdef INSIGHTS_USE_TEMPLATE
+template<>
 class B<A, void (A::*)()>
 {
   inline constexpr B() noexcept = default;

--- a/tests/TypeIdInTemplateTest.cpp
+++ b/tests/TypeIdInTemplateTest.cpp
@@ -1,3 +1,5 @@
+#define INSIGHTS_USE_TEMPLATE
+
 #include <string>
 
 template <typename T>

--- a/tests/TypeIdInTemplateTest.expect
+++ b/tests/TypeIdInTemplateTest.expect
@@ -1,3 +1,5 @@
+#define INSIGHTS_USE_TEMPLATE
+
 #include <string>
 
 template <typename T>
@@ -9,8 +11,9 @@ public:
     }
 
 };
-/* First instantiated from: TypeIdInTemplateTest.cpp:17 */
+/* First instantiated from: TypeIdInTemplateTest.cpp:19 */
 #ifdef INSIGHTS_USE_TEMPLATE
+template<>
 class Foo<int>
 {
   

--- a/tests/UsingDeclTest.expect
+++ b/tests/UsingDeclTest.expect
@@ -44,6 +44,7 @@ struct D : B {
 };
 /* First instantiated from: UsingDeclTest.cpp:56 */
 #ifdef INSIGHTS_USE_TEMPLATE
+template<>
 struct D<int> : public B
 {
   using D<int>::m;

--- a/tests/VisitorTest.expect
+++ b/tests/VisitorTest.expect
@@ -1,6 +1,7 @@
 template<class... Ts> struct visitor: Ts... { using Ts::operator()...; };
 /* First instantiated from: VisitorTest.cpp:7 */
 #ifdef INSIGHTS_USE_TEMPLATE
+template<>
 struct visitor<__lambda_8_7, __lambda_9_7> : public __lambda_8_7, public __lambda_9_7
 {
   using visitor<__lambda_8_7, __lambda_9_7>::operator();


### PR DESCRIPTION
It looks like clang does handle l-value references in the AST dump
wrong. It adds a second ampersand which makes it an r-value reference.
As #50 points out this second ampersand leads to invalid code. The
workaround implemented here does a simple (but expensive) string search
in case of an l-value ref and simply replaces the && with just &.

To fix #50 it is important to start ensuring that template code is valid
and does not change. Hence all compiling code does define
INSIGHTS_USE_TEMPLATE to enable compilation of the transformed template
code.