### PR TITLE
Fixed #60: Handle non-type template parameters correctly.

### DIFF
--- a/CodeGenerator.cpp
+++ b/CodeGenerator.cpp
@@ -1906,7 +1906,8 @@ void CodeGenerator::InsertTemplateArg(const TemplateArgument& arg)
     switch(arg.getKind()) {
         case TemplateArgument::Type: mOutputFormatHelper.Append(GetName(arg.getAsType())); break;
         case TemplateArgument::Declaration:
-            mOutputFormatHelper.Append(GetNameAsFunctionPointer(arg.getAsDecl()->getType()));
+            // TODO: handle pointers
+            mOutputFormatHelper.Append("&", arg.getAsDecl()->getQualifiedNameAsString());
             break;
         case TemplateArgument::NullPtr: mOutputFormatHelper.Append(GetName(arg.getNullPtrType())); break;
         case TemplateArgument::Integral: mOutputFormatHelper.Append(arg.getAsIntegral()); break;

--- a/tests/Issue60.cpp
+++ b/tests/Issue60.cpp
@@ -1,0 +1,34 @@
+#define INSIGHTS_USE_TEMPLATE
+
+#include <map>
+
+struct Person {
+    int age;
+    int yob() const {
+        return 2018 - age;
+    }
+};
+
+template<typename Key, typename POD>
+Key extractKey(Key POD::* pMember);
+template<typename Key, typename POD>
+POD extractPOD(Key POD::* pMember);
+
+template<auto pMember>
+using Key_t = decltype(extractKey(pMember));
+
+template<auto pMember>
+using POD_t = decltype(extractPOD(pMember));
+
+template<auto pmember>
+struct Index {
+  using Key = Key_t<pmember>;
+  using POD = POD_t<pmember>;  
+
+  std::map<Key, int> data;
+  static Key extractKey(POD const& pod) {
+    return pod.*pmember;
+  }
+};
+
+Index<&Person::age> myAgeIndex;

--- a/tests/Issue60.expect
+++ b/tests/Issue60.expect
@@ -1,0 +1,56 @@
+#define INSIGHTS_USE_TEMPLATE
+
+#include <map>
+
+struct Person {
+    int age;
+    inline int yob() const
+    {
+      return 2018 - this->age;
+    }
+    
+};
+
+template<typename Key, typename POD>
+Key extractKey(Key POD::* pMember);
+template<typename Key, typename POD>
+POD extractPOD(Key POD::* pMember);
+
+template<auto pMember>
+using Key_t = decltype(extractKey(pMember));
+
+template<auto pMember>
+using POD_t = decltype(extractPOD(pMember));
+
+template<auto pmember>
+struct Index {
+  using Key = Key_t<pmember>;
+  using POD = POD_t<pmember>;  
+
+  std::map<Key, int> data;
+  static Key extractKey(POD const& pod) {
+    return pod.*pmember;
+  }
+};
+/* First instantiated from: Issue60.cpp:34 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+struct Index<&Person::age>
+{
+  using Key = Key_t<&Person::age>;
+  using POD = POD_t<&Person::age>;
+  std::map<int, int, std::less<int>, std::allocator<std::pair<const int, int> > > data;
+  static inline Index<&Person::age>::Key extractKey(const Index<&Person::age>::POD & pod);
+  
+  inline Index(const Index<&Person::age> &) = default;
+  inline Index(Index<&Person::age> &&) = default;
+  inline Index<&Person::age> & operator=(Index<&Person::age> &&) = default;
+  inline Index() noexcept = default;
+  inline ~Index() noexcept = default;
+  
+};
+
+#endif
+
+
+Index<&Person::age> myAgeIndex;

--- a/tests/NonTypeTemplateArgTest.cpp
+++ b/tests/NonTypeTemplateArgTest.cpp
@@ -1,0 +1,18 @@
+#define INSIGHTS_USE_TEMPLATE
+#include <cstdio>
+
+static const char c[] = "Hello World";
+
+template<auto C>
+struct SC
+{
+    static void Print() { printf("%s\n", C); }
+};
+
+int main()
+{
+    SC<c> sc;
+
+    sc.Print();
+}
+

--- a/tests/NonTypeTemplateArgTest.expect
+++ b/tests/NonTypeTemplateArgTest.expect
@@ -1,0 +1,36 @@
+#define INSIGHTS_USE_TEMPLATE
+#include <cstdio>
+
+static const char c[] = "Hello World";
+
+template<auto C>
+struct SC
+{
+    static void Print() { printf("%s\n", C); }
+};
+/* First instantiated from: NonTypeTemplateArgTest.cpp:14 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+struct SC<&c>
+{
+  static inline void Print()
+  {
+    printf("%s\n", c);
+  }
+  
+  inline constexpr SC() noexcept = default;
+  inline constexpr SC(const SC<&c> &) = default;
+  inline constexpr SC(SC<&c> &&) = default;
+  
+};
+
+#endif
+
+
+int main()
+{
+  SC<c> sc = SC<&c>();
+  sc.Print();
+}
+
+

--- a/tests/TemplateExpansionTest.expect
+++ b/tests/TemplateExpansionTest.expect
@@ -70,7 +70,7 @@ void foo2()
   /* First instantiated from: TemplateExpansionTest.cpp:45 */
   #ifdef INSIGHTS_USE_TEMPLATE
   template<>
-  class testDecl<int (*)()>
+  class testDecl<&foo>
   {
     
   };


### PR DESCRIPTION
In case of non-type template parameters the full type was deduced
instead of the variable itself.