### PR TITLE
Fixed #64: Implicit lambda captures are captured by copy.

### DIFF
--- a/tests/Issue64.cpp
+++ b/tests/Issue64.cpp
@@ -1,0 +1,14 @@
+#include <string>
+
+void func(const std::string& arg) {
+ 
+  auto s =[arg] {
+    return arg.size();
+  }();
+}
+
+int main() {
+  std::string b;
+  
+  func(b);
+}

--- a/tests/Issue64.expect
+++ b/tests/Issue64.expect
@@ -1,0 +1,31 @@
+#include <string>
+
+void func(const std::basic_string<char> & arg)
+{
+      
+  class __lambda_5_11
+  {
+    public: inline /*constexpr */ unsigned long operator()() const
+    {
+      return arg.size();
+    }
+    
+    private:
+    const std::basic_string<char> arg;
+    
+    public: __lambda_5_11(const std::basic_string<char> & _arg)
+    : arg{_arg}
+    {}
+    
+  } __lambda_5_11{arg};
+  
+  unsigned long s = __lambda_5_11.operator()();
+}
+
+
+int main()
+{
+  std::string b = std::basic_string<char>();
+  func(b);
+}
+

--- a/tests/LambdaImplicitCaptureTest.cpp
+++ b/tests/LambdaImplicitCaptureTest.cpp
@@ -1,0 +1,11 @@
+#include <cstdio>
+
+int main() 
+{
+    int x = 22;
+
+    auto z = [x]() mutable { ++x; return x; } ();
+
+    // we expext x: 22, z: 23
+    printf("x: %d z: %d\n", x, z);
+}

--- a/tests/LambdaImplicitCaptureTest.expect
+++ b/tests/LambdaImplicitCaptureTest.expect
@@ -1,0 +1,27 @@
+#include <cstdio>
+
+int main()
+{
+  int x = 22;
+      
+  class __lambda_7_14
+  {
+    public: inline /*constexpr */ int operator()()
+    {
+      ++x;
+      return x;
+    }
+    
+    private:
+    int x;
+    
+    public: __lambda_7_14(int _x)
+    : x{_x}
+    {}
+    
+  } __lambda_7_14{x};
+  
+  int z = __lambda_7_14.operator()();
+  printf("x: %d z: %d\n", x, z);
+}
+


### PR DESCRIPTION
As http://eel.is/c++draft/expr.prim.lambda#capture-10 states, implicit
lambda captures are capture by copy. Insights used the variable type
before which produced an reference for a reference type. This fix strips
the reference in case of an implicit capture and make the resulting
lambda complying  to the standard.