### PR TITLE
Fixed crash for a catch-all clause.

### DIFF
--- a/CodeGenerator.cpp
+++ b/CodeGenerator.cpp
@@ -1335,8 +1335,12 @@ void CodeGenerator::InsertArg(const CXXCatchStmt* stmt)
 
     WrapInParensOrCurlys(BraceKind::Parens,
                          [&]() {
-                             mOutputFormatHelper.Append(GetTypeNameAsParameter(
-                                 stmt->getCaughtType(), stmt->getExceptionDecl()->getNameAsString()));
+                             if(!stmt->getCaughtType().isNull()) {
+                                 mOutputFormatHelper.Append(GetTypeNameAsParameter(
+                                     stmt->getCaughtType(), stmt->getExceptionDecl()->getNameAsString()));
+                             } else {
+                                 mOutputFormatHelper.Append("...");
+                             }
                          },
                          AddSpaceAtTheEnd::Yes);
 

--- a/tests/ExceptionTest.cpp
+++ b/tests/ExceptionTest.cpp
@@ -12,6 +12,9 @@ int main()
     catch (std::logic_error& e){
       return -1;
     }
+    catch(...) {
+      return -3;
+    }
 
     
     return 0;

--- a/tests/ExceptionTest.expect
+++ b/tests/ExceptionTest.expect
@@ -10,6 +10,8 @@ int main()
     return -1;
   } catch(std::logic_error & e) {
     return -1;
+  } catch(...) {
+    return -3;
   }
   ;
   return 0;


### PR DESCRIPTION
A catch-all: catch(...) did lead to a crash as it was assumed that
getCaughtType() always returns a valid type. This fix guards it with an
if-clause and re-added the '...' in case of an catch-all.