### PR TITLE
Added support for FunctionTemplateDecl.

### DIFF
--- a/CodeGenerator.cpp
+++ b/CodeGenerator.cpp
@@ -1675,6 +1675,20 @@ void CodeGenerator::InsertArg(const CXXNoexceptExpr* stmt)
 }
 //-----------------------------------------------------------------------------
 
+void CodeGenerator::InsertArg(const FunctionTemplateDecl* stmt)
+{
+    for(const auto spec : stmt->specializations()) {
+        InsertArg(spec->getAsFunction());
+    }
+}
+//-----------------------------------------------------------------------------
+
+void CodeGenerator::InsertArg(const TypeAliasTemplateDecl* stmt)
+{
+    InsertArg(stmt->getTemplatedDecl());
+}
+//-----------------------------------------------------------------------------
+
 void CodeGenerator::InsertArg(const CXXRecordDecl* stmt)
 {
     if(dyn_cast_or_null<ClassTemplateSpecializationDecl>(stmt)) {

--- a/CodeGeneratorTypes.h
+++ b/CodeGeneratorTypes.h
@@ -36,6 +36,8 @@ SUPPORTED_DECL(FriendDecl)
 SUPPORTED_DECL(EnumDecl)
 SUPPORTED_DECL(EnumConstantDecl)
 SUPPORTED_DECL(NamespaceAliasDecl)
+SUPPORTED_DECL(FunctionTemplateDecl)
+SUPPORTED_DECL(TypeAliasTemplateDecl)
 
 SUPPORTED_STMT(CXXDeleteExpr)
 SUPPORTED_STMT(CXXDefaultInitExpr)

--- a/TemplateHandler.cpp
+++ b/TemplateHandler.cpp
@@ -23,12 +23,13 @@ namespace clang::insights {
 TemplateHandler::TemplateHandler(Rewriter& rewrite, MatchFinder& matcher)
 : InsightsBase(rewrite)
 {
-    matcher.addMatcher(functionDecl(allOf(unless(isExpansionInSystemHeader()),
-                                          unless(isMacroOrInvalidLocation()),
-                                          hasParent(functionTemplateDecl()),
-                                          isTemplateInstantiationPlain()))
-                           .bind("func"),
-                       this);
+    matcher.addMatcher(
+        functionDecl(allOf(unless(isExpansionInSystemHeader()),
+                           unless(isMacroOrInvalidLocation()),
+                           hasParent(functionTemplateDecl(unless(hasParent(classTemplateSpecializationDecl())))),
+                           isTemplateInstantiationPlain()))
+            .bind("func"),
+        this);
 
     matcher.addMatcher(classTemplateSpecializationDecl(unless(isExpansionInSystemHeader()),
                                                        hasParent(classTemplateDecl().bind("decl")))

--- a/tests/FunctionTemplateDecl2Test.cpp
+++ b/tests/FunctionTemplateDecl2Test.cpp
@@ -1,0 +1,22 @@
+class Test
+{
+public:
+    Test() = default;
+
+    template<typename T2>
+    Test& operator=(const T2& other)
+    {
+
+        return *this;
+    }
+};
+
+int main()
+{
+    Test ti;
+    Test tc;
+
+    ti = 2;
+
+    tc = 'a';
+}

--- a/tests/FunctionTemplateDecl2Test.expect
+++ b/tests/FunctionTemplateDecl2Test.expect
@@ -1,0 +1,46 @@
+class Test
+{
+public:
+    Test() = default;
+
+    template<typename T2>
+    Test& operator=(const T2& other)
+    {
+
+        return *this;
+    }
+    
+    /* First instantiated from: FunctionTemplateDecl2Test.cpp:19 */
+    #ifdef INSIGHTS_USE_TEMPLATE
+    template<>
+    inline Test & operator=<int>(const int & other)
+    {
+      return *this;
+    }
+    #endif
+    
+    
+    /* First instantiated from: FunctionTemplateDecl2Test.cpp:21 */
+    #ifdef INSIGHTS_USE_TEMPLATE
+    template<>
+    inline Test & operator=<char>(const char & other)
+    {
+      return *this;
+    }
+    #endif
+    
+/* public: inline constexpr Test() noexcept; */
+/* public: inline constexpr Test(const Test &); */
+/* public: inline constexpr Test(Test &&); */
+/* public: inline constexpr Test & operator=(const Test &); */
+/* public: inline constexpr Test & operator=(Test &&); */
+};
+
+int main()
+{
+  Test ti = Test();
+  Test tc = Test();
+  ti.operator=(2);
+  tc.operator=('a');
+}
+

--- a/tests/FunctionTemplateDecl3Test.cpp
+++ b/tests/FunctionTemplateDecl3Test.cpp
@@ -1,0 +1,26 @@
+template<typename T>
+class Test
+{
+public:
+    Test() = default;
+
+    template<typename T2>
+    Test& operator=(const Test<T2>& other)
+    {
+
+        return *this;
+    }
+};
+
+int main()
+{
+    Test<int> ti;
+    Test<char> tc;
+    Test<float> tf;
+
+    ti = tc;
+    ti = tf;
+
+    tc = ti;
+}
+

--- a/tests/FunctionTemplateDecl3Test.expect
+++ b/tests/FunctionTemplateDecl3Test.expect
@@ -1,0 +1,89 @@
+template<typename T>
+class Test
+{
+public:
+    Test() = default;
+
+    template<typename T2>
+    Test& operator=(const Test<T2>& other)
+    {
+
+        return *this;
+    }
+};
+/* First instantiated from: FunctionTemplateDecl3Test.cpp:17 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+class Test<int>
+{
+  
+  public: 
+  inline constexpr Test() noexcept = default;
+  template<>
+  inline Test<int> & operator=<char>(const Test<char> & other)
+  {
+    return *this;
+  }
+  template<>
+  inline Test<int> & operator=<float>(const Test<float> & other)
+  {
+    return *this;
+  }
+  inline constexpr Test(const Test<int> &) = default;
+  inline constexpr Test(Test<int> &&) = default;
+  inline constexpr Test<int> & operator=(const Test<int> &) = default;
+  inline constexpr Test<int> & operator=(Test<int> &&) = default;
+  
+};
+
+#endif
+
+/* First instantiated from: FunctionTemplateDecl3Test.cpp:18 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+class Test<char>
+{
+  
+  public: 
+  inline constexpr Test() noexcept = default;
+  template<>
+  inline Test<char> & operator=<int>(const Test<int> & other)
+  {
+    return *this;
+  }
+  inline constexpr Test(const Test<char> &) = default;
+  inline constexpr Test(Test<char> &&) = default;
+  inline constexpr Test<char> & operator=(const Test<char> &) = default;
+  inline constexpr Test<char> & operator=(Test<char> &&) = default;
+  
+};
+
+#endif
+
+/* First instantiated from: FunctionTemplateDecl3Test.cpp:19 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+class Test<float>
+{
+  
+  public: 
+  inline constexpr Test() noexcept = default;
+  inline constexpr Test(const Test<float> &) = default;
+  inline constexpr Test(Test<float> &&) = default;
+  
+};
+
+#endif
+
+
+int main()
+{
+  Test<int> ti = Test<int>();
+  Test<char> tc = Test<char>();
+  Test<float> tf = Test<float>();
+  ti.operator=(tc);
+  ti.operator=(tf);
+  tc.operator=(ti);
+}
+
+

--- a/tests/FunctionTemplateDeclTest.cpp
+++ b/tests/FunctionTemplateDeclTest.cpp
@@ -1,0 +1,24 @@
+template<typename T>
+class Test
+{
+public:
+    Test() = default;
+
+    template<typename T2>
+    Test& operator=(const Test<T2>& other)
+    {
+
+        return *this;
+    }
+};
+
+int main()
+{
+    Test<int> ti;
+    Test<char> tc;
+
+    ti = tc;
+
+    tc = ti;
+}
+

--- a/tests/FunctionTemplateDeclTest.expect
+++ b/tests/FunctionTemplateDeclTest.expect
@@ -1,0 +1,67 @@
+template<typename T>
+class Test
+{
+public:
+    Test() = default;
+
+    template<typename T2>
+    Test& operator=(const Test<T2>& other)
+    {
+
+        return *this;
+    }
+};
+/* First instantiated from: FunctionTemplateDeclTest.cpp:17 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+class Test<int>
+{
+  
+  public: 
+  inline constexpr Test() noexcept = default;
+  template<>
+  inline Test<int> & operator=<char>(const Test<char> & other)
+  {
+    return *this;
+  }
+  inline constexpr Test(const Test<int> &) = default;
+  inline constexpr Test(Test<int> &&) = default;
+  inline constexpr Test<int> & operator=(const Test<int> &) = default;
+  inline constexpr Test<int> & operator=(Test<int> &&) = default;
+  
+};
+
+#endif
+
+/* First instantiated from: FunctionTemplateDeclTest.cpp:18 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+class Test<char>
+{
+  
+  public: 
+  inline constexpr Test() noexcept = default;
+  template<>
+  inline Test<char> & operator=<int>(const Test<int> & other)
+  {
+    return *this;
+  }
+  inline constexpr Test(const Test<char> &) = default;
+  inline constexpr Test(Test<char> &&) = default;
+  inline constexpr Test<char> & operator=(const Test<char> &) = default;
+  inline constexpr Test<char> & operator=(Test<char> &&) = default;
+  
+};
+
+#endif
+
+
+int main()
+{
+  Test<int> ti = Test<int>();
+  Test<char> tc = Test<char>();
+  ti.operator=(tc);
+  tc.operator=(ti);
+}
+
+

--- a/tests/TypeAliasTemplateTest.cpp
+++ b/tests/TypeAliasTemplateTest.cpp
@@ -1,0 +1,20 @@
+template<bool B>
+struct bool_constant
+{
+  static const bool value = B;
+};
+
+template<typename... A>
+struct F
+{
+  template<typename... B>
+    using SameSize = bool_constant<sizeof...(A) == sizeof...(B)>;
+
+  template<typename... B, typename = SameSize<B...>>
+  F(B...) { }
+};
+
+int main()
+{
+  F<int> f1(3);
+}

--- a/tests/TypeAliasTemplateTest.expect
+++ b/tests/TypeAliasTemplateTest.expect
@@ -1,0 +1,39 @@
+template<bool B>
+struct bool_constant
+{
+  static const bool value = B;
+};
+
+template<typename... A>
+struct F
+{
+  template<typename... B>
+    using SameSize = bool_constant<sizeof...(A) == sizeof...(B)>;
+
+  template<typename... B, typename = SameSize<B...>>
+  F(B...) { }
+};
+/* First instantiated from: TypeAliasTemplateTest.cpp:19 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+struct F<int>
+{
+  using SameSize = bool_constant<sizeof...(A) == sizeof...(B)>;
+  template<>
+  inline F<int, bool_constant<1> >(int)
+  {
+  }
+  
+  inline constexpr F(const F<int> &) = default;
+  inline constexpr F(F<int> &&) = default;
+  
+};
+
+#endif
+
+
+int main()
+{
+  F<int> f1 = F<int>(3);
+}
+


### PR DESCRIPTION
As most of the time the AST matchers catch a FunctionTemplateDecl this
has gone unseen for a while. If a FunctionTemplateDecl is within a
ClassTemplate the matcher should not trigger, instead it is processed
with the instantiated template.