### PR TITLE
Fixed crash for simple code: using namespace std. 

### DIFF
--- a/CodeGenerator.cpp
+++ b/CodeGenerator.cpp
@@ -1507,7 +1507,11 @@ void CodeGenerator::InsertArg(const StaticAssertDecl* stmt)
 
 void CodeGenerator::InsertArg(const UsingDirectiveDecl* stmt)
 {
-    std::string ns{GetName(*stmt->getQualifier()->getAsNamespace())};
+    std::string ns{};
+
+    if(const auto* qualifier = stmt->getQualifier()) {
+        ns = GetName(*qualifier->getAsNamespace());
+    }
 
     if(!ns.empty()) {
         ns.append("::");

--- a/tests/UsingNamespaceStdTest.cpp
+++ b/tests/UsingNamespaceStdTest.cpp
@@ -1,0 +1,7 @@
+#include <cstdio>
+
+int main()
+{
+  using namespace std;
+}
+

--- a/tests/UsingNamespaceStdTest.expect
+++ b/tests/UsingNamespaceStdTest.expect
@@ -1,0 +1,8 @@
+#include <cstdio>
+
+int main()
+{
+  using namespace std;
+}
+
+

--- a/tests/testSTDIN.sh
+++ b/tests/testSTDIN.sh
@@ -13,3 +13,11 @@ echo "" | $1 -stdin x.cpp -- -std=c++1z > /dev/null
 
 
 $1 -version
+
+# close stdin
+exec 0<&-
+
+# results in: Bad file descriptor
+$1 -stdin x.cpp -- -std=c++1z
+
+exit 0


### PR DESCRIPTION
The logic behind this expected that after using always a name follows
which lead to the crash. This fix checks whether there is a name or not.
If not, it continues parsing.