### PR TITLE
Travis clang7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,19 +50,13 @@ matrix:
     env: COMPILER='clang++-8' COMPILER_CC='clang-8' LLVM_CONFIG=${LLVM_CONFIG_CURRENT}  COVERAGE='No' STATIC='No' DEBUG='No'
 
   - os: linux
-    compiler: clang
     sudo: required
+    services:
+    - docker
     before_install:
-    - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-    - sudo apt-add-repository "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-7 main"
-    - sudo apt-get update -q
-    - sudo apt-get install clang-7 llvm-7-dev libclang-7-dev
-    addons:
-      apt:
-        sources: *all_llvm_7_sources
-        packages: 
-        - libstdc++-7-dev
-    env: COMPILER='clang++-7' COMPILER_CC='clang-7' LLVM_CONFIG=/usr/bin/llvm-config-7  COVERAGE='No' STATIC='No' DEBUG='No'
+    - cd docker_travis && docker build -t cppinsights-travis .
+    ssh_known_hosts: cppinsights.io
+    env: COMPILER='clang++-7' COMPILER_CC='clang-7' LLVM_CONFIG=/usr/bin/llvm-config-7  COVERAGE='No' DEPLOY='Yes' STATIC='Yes' DEBUG='No' UPLOAD='Yes'
     
   # Linux g++ Build
   - os: linux
@@ -114,7 +108,7 @@ matrix:
         - doxygen
         - graphviz
       ssh_known_hosts: cppinsights.io
-    env: COMPILER='clang++-6.0' COMPILER_CC='clang-6.0' LLVM_CONFIG='/usr/bin/llvm-config-6.0' COVERAGE='No' DEPLOY='Yes' STATIC='Yes' DEBUG='No' UPLOAD='Yes'
+    env: COMPILER='clang++-6.0' COMPILER_CC='clang-6.0' LLVM_CONFIG='/usr/bin/llvm-config-6.0' COVERAGE='No' DEPLOY='No' STATIC='Yes' DEBUG='No' UPLOAD='No'
 
 install:
 - |   
@@ -145,18 +139,25 @@ before_script:
   - cd "${TRAVIS_BUILD_DIR}"
   - mkdir build
   - cd build
-  - cmake -DINSIGHTS_LLVM_CONFIG=${LLVM_CONFIG} -DINSIGHTS_COVERAGE=${COVERAGE} -DINSIGHTS_STATIC=${STATIC} -DDEBUG=${DEBUG}  ..
+  - |
+    if [[ "${DEPLOY}" == "Yes" ]]; then
+      docker run -v ${TRAVIS_BUILD_DIR}:/home/builder --rm cppinsights-travis /bin/bash -c "cd /home/builder/build && cmake -G Ninja -DINSIGHTS_STATIC=Yes .."
+    else
+      cmake -DINSIGHTS_LLVM_CONFIG=${LLVM_CONFIG} -DINSIGHTS_COVERAGE=${COVERAGE} -DINSIGHTS_STATIC=${STATIC} -DDEBUG=${DEBUG}  ..
+    fi
 
 script:
-- make -j 2
+- |
+  if [[ "${DEPLOY}" == "Yes" ]]; then
+    docker run -v ${TRAVIS_BUILD_DIR}:/home/builder --rm cppinsights-travis /bin/bash -c "cmake --build /home/builder/build"
+    docker run -v ${TRAVIS_BUILD_DIR}:/home/builder --rm cppinsights-travis /bin/bash -c "cmake --build /home/builder/build --target doc"
+  else
+    make -j 2
+  fi
 - |
   if [[ "${TRAVIS_OS_NAME}" == "osx" ]] && [[ "${SKIP_TESTS}" == "No" ]]; then
     make tests
   fi  
-- |
-  if [[ "${DEPLOY}" == "Yes" ]]; then
-    make doc
-  fi
 - |
   if [[ "${TRAVIS_OS_NAME}" == "osx" ]] && [[ "${TRAVIS_BRANCH}" = "master" ]]; then
       export GZ_FILE_NAME=${TRAVIS_BUILD_DIR}/insights-macos.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ matrix:
     osx_image: xcode9.3
     compiler: clang
       
-  - env: COMPILER='clang++' COMPILER_CC='clang' LLVM_CONFIG='llvm-config' LLVM_VERSION='7.0.0' COVERAGE='No' STATIC='No' DEBUG='No' UPLOAD='No'
+  - env: COMPILER='clang++' COMPILER_CC='clang' LLVM_CONFIG='llvm-config' LLVM_VERSION='7.0.0' COVERAGE='No' STATIC='No' DEBUG='No' UPLOAD='No' SKIP_TESTS='No'
     os: osx
     osx_image: xcode9.3
     compiler: clang
@@ -150,7 +150,7 @@ before_script:
 script:
 - make -j 2
 - |
-  if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
+  if [[ "${TRAVIS_OS_NAME}" == "osx" ]] && [[ "${SKIP_TESTS}" == "No" ]]; then
     make tests
   fi  
 - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,25 @@ llvm_current_packages: &all_llvm_current_packages
 - llvm-8-dev
 - libclang-8-dev
 
+llvm_7_sources: &all_llvm_7_sources
+- ubuntu-toolchain-r-test
+
+llvm_7_packages: &all_llvm_7_packages
+- clang-7
+- llvm-7-dev
+- libclang-7-dev
+
 
 matrix:
   include:
 
     # 1/ OSX Builds
   - env: COMPILER='clang++' COMPILER_CC='clang' LLVM_CONFIG='llvm-config' LLVM_VERSION='6.0.0' COVERAGE='No' STATIC='No' DEBUG='No' UPLOAD='Yes'
+    os: osx
+    osx_image: xcode9.3
+    compiler: clang
+      
+  - env: COMPILER='clang++' COMPILER_CC='clang' LLVM_CONFIG='llvm-config' LLVM_VERSION='7.0.0' COVERAGE='No' STATIC='No' DEBUG='No' UPLOAD='No'
     os: osx
     osx_image: xcode9.3
     compiler: clang
@@ -36,6 +49,21 @@ matrix:
         - libstdc++-7-dev
     env: COMPILER='clang++-8' COMPILER_CC='clang-8' LLVM_CONFIG=${LLVM_CONFIG_CURRENT}  COVERAGE='No' STATIC='No' DEBUG='No'
 
+  - os: linux
+    compiler: clang
+    sudo: required
+    before_install:
+    - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+    - sudo apt-add-repository "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-7 main"
+    - sudo apt-get update -q
+    - sudo apt-get install clang-7 llvm-7-dev libclang-7-dev
+    addons:
+      apt:
+        sources: *all_llvm_7_sources
+        packages: 
+        - libstdc++-7-dev
+    env: COMPILER='clang++-7' COMPILER_CC='clang-7' LLVM_CONFIG=/usr/bin/llvm-config-7  COVERAGE='No' STATIC='No' DEBUG='No'
+    
   # Linux g++ Build
   - os: linux
     compiler: gcc

--- a/Insights.cpp
+++ b/Insights.cpp
@@ -57,7 +57,8 @@ class CppInsightASTConsumer final : public ASTConsumer
 {
 public:
     explicit CppInsightASTConsumer(Rewriter& rewriter)
-    : mMatcher{}
+    : ASTConsumer()
+    , mMatcher{}
     , mCompilerGeneratedHandler{rewriter, mMatcher}
     , mStaticAssertHandler{rewriter, mMatcher}
     , mTemplateHandler{rewriter, mMatcher}

--- a/docker_travis/Dockerfile
+++ b/docker_travis/Dockerfile
@@ -1,0 +1,30 @@
+FROM ubuntu:18.04
+
+LABEL maintainer "Andreas Fertig"
+
+# Install compiler, python
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates gnupg wget ninja-build
+
+RUN echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-7 main" >> /etc/apt/sources.list
+RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends llvm-7-dev libclang-7-dev g++-8 cmake zlib1g-dev doxygen graphviz && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN useradd builder \
+    && mkdir /home/builder \
+    && chown -R builder:builder /home/builder
+
+RUN ln -s /usr/bin/llvm-config-7 /usr/bin/llvm-config
+
+RUN ln -fs /usr/bin/g++-8 /usr/bin/g++
+RUN ln -fs /usr/bin/g++-8 /usr/bin/c++
+RUN ln -fs /usr/bin/gcc-8 /usr/bin/gcc
+RUN ln -fs /usr/bin/gcc-8 /usr/bin/cc
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends gdb && \
+    rm -rf /var/lib/apt/lists/*
+

--- a/tests/Class2Test.expect
+++ b/tests/Class2Test.expect
@@ -81,7 +81,7 @@ int main()
   s.count.operator++(0);
   Test t = Test();
   char * raw = reinterpret_cast<char *>(&s + 1);
-  Test * p = reinterpret_cast<Test *>(&raw[static_cast<long>(static_cast<int>(s.count.operator int()))]);
+  Test * p = reinterpret_cast<Test *>(&raw[static_cast<int>(s.count.operator int())]);
   (*p).operator=((t));
   (*p).operator=(s2.count);
   s.count.operator+=(Test(static_cast<int>(sizeof(p))));

--- a/tests/Issue50.expect
+++ b/tests/Issue50.expect
@@ -5,7 +5,7 @@ void foo(T && t)
 /* First instantiated from: Issue50.cpp:10 */
 #ifdef INSIGHTS_USE_TEMPLATE
 template<>
-void foo<Test &>(Test && t)
+void foo<Test &>(Test & t)
 {
 }
 #endif

--- a/tests/Issue50_2.cpp
+++ b/tests/Issue50_2.cpp
@@ -1,4 +1,4 @@
-//#define INSIGHTS_USE_TEMPLATE
+#define INSIGHTS_USE_TEMPLATE
 #include <utility>
 
 struct Test

--- a/tests/Issue50_2.expect
+++ b/tests/Issue50_2.expect
@@ -1,4 +1,4 @@
-//#define INSIGHTS_USE_TEMPLATE
+#define INSIGHTS_USE_TEMPLATE
 #include <utility>
 
 struct Test
@@ -16,7 +16,7 @@ void foo(T&& t)
 /* First instantiated from: Issue50_2.cpp:16 */
 #ifdef INSIGHTS_USE_TEMPLATE
 template<>
-void foo<Test &>(Test && t)
+void foo<Test &>(Test & t)
 {
 }
 #endif
@@ -25,7 +25,7 @@ void foo<Test &>(Test && t)
 /* First instantiated from: Issue50_2.cpp:19 */
 #ifdef INSIGHTS_USE_TEMPLATE
 template<>
-void foo<int &>(int && t)
+void foo<int &>(int & t)
 {
 }
 #endif

--- a/tests/Issue50_3.expect
+++ b/tests/Issue50_3.expect
@@ -1,12 +1,14 @@
+#define INSIGHTS_USE_TEMPLATE
+
 template<class F>
 void foo(F&& f)
 {
 }
 
-/* First instantiated from: Issue50_3.cpp:16 */
+/* First instantiated from: Issue50_3.cpp:18 */
 #ifdef INSIGHTS_USE_TEMPLATE
 template<>
-void foo<int &&(&)(int &&)>(int &&(&&)(int &&) f)
+void foo<int &&(&)(int &&)>(int &&(&f)(int &&))
 {
 }
 #endif

--- a/tests/StructuredBindingsHandler3Test.ccerr
+++ b/tests/StructuredBindingsHandler3Test.ccerr
@@ -1,61 +1,61 @@
-.tmp.cpp:78:50: error: no matching function for call to 'get'
-  std::tuple_element<0, constant::Q>::type&& a = constant::get<0ul>(constant::__q17);
+.tmp.cpp:84:48: error: no matching function for call to 'get'
+  std::tuple_element<0, constant::Q>::type a = constant::get<0ul>(constant::__q17);
+                                               ^~~~~~~~~~~~~~~~~~
+.tmp.cpp:46:33: note: candidate function template not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
+  template<int N> constexpr int get(Q &&) { return N * N; }
+                                ^
+.tmp.cpp:85:48: error: no matching function for call to 'get'
+  std::tuple_element<1, constant::Q>::type b = constant::get<1ul>(constant::__q17);
+                                               ^~~~~~~~~~~~~~~~~~
+.tmp.cpp:46:33: note: candidate function template not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
+  template<int N> constexpr int get(Q &&) { return N * N; }
+                                ^
+.tmp.cpp:86:48: error: no matching function for call to 'get'
+  std::tuple_element<2, constant::Q>::type c = constant::get<2ul>(constant::__q17);
+                                               ^~~~~~~~~~~~~~~~~~
+.tmp.cpp:46:33: note: candidate function template not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
+  template<int N> constexpr int get(Q &&) { return N * N; }
+                                ^
+.tmp.cpp:92:50: error: no matching function for call to 'get'
+    std::tuple_element<0, constant::Q>::type a = constant::get<0ul>(__q20);
                                                  ^~~~~~~~~~~~~~~~~~
-.tmp.cpp:40:33: note: candidate function not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
+.tmp.cpp:46:33: note: candidate function template not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
   template<int N> constexpr int get(Q &&) { return N * N; }
                                 ^
-.tmp.cpp:79:50: error: no matching function for call to 'get'
-  std::tuple_element<1, constant::Q>::type&& b = constant::get<1ul>(constant::__q17);
+.tmp.cpp:93:50: error: no matching function for call to 'get'
+    std::tuple_element<1, constant::Q>::type b = constant::get<1ul>(__q20);
                                                  ^~~~~~~~~~~~~~~~~~
-.tmp.cpp:40:33: note: candidate function not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
+.tmp.cpp:46:33: note: candidate function template not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
   template<int N> constexpr int get(Q &&) { return N * N; }
                                 ^
-.tmp.cpp:80:50: error: no matching function for call to 'get'
-  std::tuple_element<2, constant::Q>::type&& c = constant::get<2ul>(constant::__q17);
+.tmp.cpp:94:50: error: no matching function for call to 'get'
+    std::tuple_element<2, constant::Q>::type c = constant::get<2ul>(__q20);
                                                  ^~~~~~~~~~~~~~~~~~
-.tmp.cpp:40:33: note: candidate function not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
+.tmp.cpp:46:33: note: candidate function template not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
   template<int N> constexpr int get(Q &&) { return N * N; }
                                 ^
-.tmp.cpp:85:52: error: no matching function for call to 'get'
-    std::tuple_element<0, constant::Q>::type&& a = constant::get<0ul>(__q20);
+.tmp.cpp:92:46: error: variables defined in a constexpr function must be initialized
+    std::tuple_element<0, constant::Q>::type a = constant::get<0ul>(__q20);
+                                             ^
+.tmp.cpp:104:52: error: no matching function for call to 'get'
+      std::tuple_element<0, constant::Q>::type a = constant::get<0ul>(__q27);
                                                    ^~~~~~~~~~~~~~~~~~
-.tmp.cpp:40:33: note: candidate function not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
+.tmp.cpp:46:33: note: candidate function template not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
   template<int N> constexpr int get(Q &&) { return N * N; }
                                 ^
-.tmp.cpp:86:52: error: no matching function for call to 'get'
-    std::tuple_element<1, constant::Q>::type&& b = constant::get<1ul>(__q20);
+.tmp.cpp:105:52: error: no matching function for call to 'get'
+      std::tuple_element<1, constant::Q>::type b = constant::get<1ul>(__q27);
                                                    ^~~~~~~~~~~~~~~~~~
-.tmp.cpp:40:33: note: candidate function not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
+.tmp.cpp:46:33: note: candidate function template not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
   template<int N> constexpr int get(Q &&) { return N * N; }
                                 ^
-.tmp.cpp:87:52: error: no matching function for call to 'get'
-    std::tuple_element<2, constant::Q>::type&& c = constant::get<2ul>(__q20);
+.tmp.cpp:106:52: error: no matching function for call to 'get'
+      std::tuple_element<2, constant::Q>::type c = constant::get<2ul>(__q27);
                                                    ^~~~~~~~~~~~~~~~~~
-.tmp.cpp:40:33: note: candidate function not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
+.tmp.cpp:46:33: note: candidate function template not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
   template<int N> constexpr int get(Q &&) { return N * N; }
                                 ^
-.tmp.cpp:85:48: error: variables defined in a constexpr function must be initialized
-    std::tuple_element<0, constant::Q>::type&& a = constant::get<0ul>(__q20);
+.tmp.cpp:104:48: error: variables defined in a constexpr function must be initialized
+      std::tuple_element<0, constant::Q>::type a = constant::get<0ul>(__q27);
                                                ^
-.tmp.cpp:96:54: error: no matching function for call to 'get'
-      std::tuple_element<0, constant::Q>::type&& a = constant::get<0ul>(__q27);
-                                                     ^~~~~~~~~~~~~~~~~~
-.tmp.cpp:40:33: note: candidate function not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
-  template<int N> constexpr int get(Q &&) { return N * N; }
-                                ^
-.tmp.cpp:97:54: error: no matching function for call to 'get'
-      std::tuple_element<1, constant::Q>::type&& b = constant::get<1ul>(__q27);
-                                                     ^~~~~~~~~~~~~~~~~~
-.tmp.cpp:40:33: note: candidate function not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
-  template<int N> constexpr int get(Q &&) { return N * N; }
-                                ^
-.tmp.cpp:98:54: error: no matching function for call to 'get'
-      std::tuple_element<2, constant::Q>::type&& c = constant::get<2ul>(__q27);
-                                                     ^~~~~~~~~~~~~~~~~~
-.tmp.cpp:40:33: note: candidate function not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
-  template<int N> constexpr int get(Q &&) { return N * N; }
-                                ^
-.tmp.cpp:96:50: error: variables defined in a constexpr function must be initialized
-      std::tuple_element<0, constant::Q>::type&& a = constant::get<0ul>(__q27);
-                                                 ^
 11 errors generated.


### PR DESCRIPTION
Use clang 7.0 in Tavis CI and as deployment target such that it is the version used by the web-frontend.