### PR TITLE
Added test for complex float and int.

### DIFF
--- a/ClangCompat.h
+++ b/ClangCompat.h
@@ -13,6 +13,9 @@
 #include "version.h"
 //-----------------------------------------------------------------------------
 
+#define IS_CLANG_NEWER_THAN(major) CLANG_VERSION_MAJOR > (major)
+//-----------------------------------------------------------------------------
+
 namespace clang::insights {
 
 template<unsigned int MAJOR>

--- a/CodeGenerator.cpp
+++ b/CodeGenerator.cpp
@@ -1297,6 +1297,10 @@ static const char* getValueOfValueInit(const QualType& t)
             }
 
             break;
+
+#if IS_CLANG_NEWER_THAN(7)
+        case Type::STK_FixedPoint: Error("STK_FixedPoint is not implemented"); break;
+#endif
     }
 
     return "0";

--- a/tests/ImplicitValueInitExprTest.cpp
+++ b/tests/ImplicitValueInitExprTest.cpp
@@ -36,6 +36,12 @@ struct Ints
     unsigned int ui;
 };
 
+struct Complex
+{
+    float _Complex fc;
+    int _Complex ic;    
+};
+
 int main()
 {
     // XXX wired nullptr in clang-7 on macOS
@@ -50,4 +56,6 @@ int main()
     Pointer p{};
 
     Ints i{};
+
+    Complex cc[5] = { [2].fc = 1.0, [2].ic = 3, [0].ic = 22 };
 }

--- a/tests/ImplicitValueInitExprTest.expect
+++ b/tests/ImplicitValueInitExprTest.expect
@@ -36,6 +36,12 @@ struct Ints
     unsigned int ui;
 };
 
+struct Complex
+{
+    float _Complex fc;
+    int _Complex ic;    
+};
+
 int main()
 {
   Point array[10] = {{1.0, 0.0}, {0.0, 0.0}, {2.0, 1.0}};
@@ -44,5 +50,6 @@ int main()
   Bool b = {false};
   Pointer p = {nullptr};
   Ints i = {0, 0};
+  Complex cc[5] = {{0.0f, 22}, {0.0f, 0}, {static_cast<float>(1.0), 3}};
 }
 

--- a/tests/LambdaHandlerTest.cpp
+++ b/tests/LambdaHandlerTest.cpp
@@ -43,7 +43,7 @@ int main()
     auto lambda73 = [&foo](int& x, const auto& b, const auto c)  { printf( "%d\n", foo+x);  return foo+x+b+c; };
     lambda73(foo, b, 44);
 
-    auto lambda8 = [foo, b](int& x, int b)  { printf( "%d\n", foo+x);  return foo+x+b; };
+    auto lambda8 = [foo, b](int& x, int bb)  { printf( "%d\n", foo+x);  return foo+x+bb; };
 
-    auto lambda9 = [foo, b](int& x, int b) noexcept { printf( "%d\n", foo+x);  return foo+x+b; };
+    auto lambda9 = [foo, b](int& x, int bb) noexcept { printf( "%d\n", foo+x);  return foo+x+bb; };
 }

--- a/tests/LambdaHandlerTest.expect
+++ b/tests/LambdaHandlerTest.expect
@@ -200,10 +200,10 @@ int main()
     
   class __lambda_46_20
   {
-    public: inline /*constexpr */ int operator()(int & x, int b) const
+    public: inline /*constexpr */ int operator()(int & x, int bb) const
     {
       printf("%d\n", foo + x);
-      return foo + x + b;
+      return foo + x + bb;
     }
     
     private:
@@ -221,10 +221,10 @@ int main()
     
   class __lambda_48_20
   {
-    public: inline /*constexpr */ int operator()(int & x, int b) const noexcept
+    public: inline /*constexpr */ int operator()(int & x, int bb) const noexcept
     {
       printf("%d\n", foo + x);
-      return foo + x + b;
+      return foo + x + bb;
     }
     
     private:


### PR DESCRIPTION
Before this patch, there was no test to verify that the path
STK_FloatingComplex and STK_IntegralComplex did work as expected. This
patch adds the missing test cases.