### PR TITLE
Fixed crash in case of a PredefinedExpr which is unresolved.

### DIFF
--- a/CodeGenerator.cpp
+++ b/CodeGenerator.cpp
@@ -1249,7 +1249,18 @@ void CodeGenerator::InsertArg(const CharacterLiteral* stmt)
 
 void CodeGenerator::InsertArg(const PredefinedExpr* stmt)
 {
-    InsertArg(stmt->getFunctionName());
+    // Check if getFunctionName returns a valid StringLiteral. It does return a nullptr, if this PredefinedExpr is in a
+    // UnresolvedLookupExpr. In that case, print the identifier, e.g. __func__.
+    if(const auto* functionName = stmt->getFunctionName()) {
+        InsertArg(functionName);
+    } else {
+#if IS_CLANG_NEWER_THAN(7)
+        const auto name = PredefinedExpr::getIdentKindName(stmt->getIdentKind());
+#else
+        const auto name = PredefinedExpr::getIdentTypeName(stmt->getIdentType());
+#endif
+        mOutputFormatHelper.Append(name.str());
+    }
 }
 //-----------------------------------------------------------------------------
 

--- a/tests/UnresolvedPredefinedExprTest.cpp
+++ b/tests/UnresolvedPredefinedExprTest.cpp
@@ -1,0 +1,16 @@
+template<typename T>
+class Test
+{
+public:
+    Test()
+    {
+        const char* f = __func__; // UnresolvedLookupExpr
+    }
+};
+
+int main()
+{
+    const char* f = __func__;
+
+    Test<int> t;
+}

--- a/tests/UnresolvedPredefinedExprTest.expect
+++ b/tests/UnresolvedPredefinedExprTest.expect
@@ -1,0 +1,35 @@
+template<typename T>
+class Test
+{
+public:
+    Test()
+    {
+        const char* f = __func__; // UnresolvedLookupExpr
+    }
+};
+/* First instantiated from: UnresolvedPredefinedExprTest.cpp:15 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+class Test<int>
+{
+  
+  public: 
+  inline Test()
+  {
+    const char * f = "Test";
+  }
+  
+  inline constexpr Test(const Test<int> &) = default;
+  inline constexpr Test(Test<int> &&) = default;
+  
+};
+
+#endif
+
+
+int main()
+{
+  const char * f = "main";
+  Test<int> t = Test<int>();
+}
+


### PR DESCRIPTION
A PredefinedExpr within the definition of a template is unresolved, e.g.
for __func__ the name of the function is unknown in the template itself.
It first appears in an instantiation of a template. Before the fix the
assumption was, that a PredefinedExpr always returns a StringLiteral
with the function name. In the case when the PredefinedExpr was
unresolved that StringLiteral is nullptr. This fix adds a check and
inserts the predefined name in case the name is currently unresolved.