### PR TITLE
Fixed #102: Not all TypeAlias's are expressions.

### DIFF
--- a/CodeGenerator.cpp
+++ b/CodeGenerator.cpp
@@ -1458,10 +1458,13 @@ void CodeGenerator::InsertArg(const TypeAliasDecl* stmt)
 
         mOutputFormatHelper.Append(stream.str(), "<");
 
-        for(const auto& arg : templateSpecializationType->template_arguments()) {
-            arg.getAsExpr()->dump();
-            InsertArg(arg.getAsExpr());
-        }
+        ForEachArg(templateSpecializationType->template_arguments(), [&](const auto& arg) {
+            if(arg.getKind() == TemplateArgument::Expression) {
+                InsertArg(arg.getAsExpr());
+            } else {
+                InsertTemplateArg(arg);
+            }
+        });
 
         mOutputFormatHelper.Append(">");
     } else {

--- a/tests/Issue102.cpp
+++ b/tests/Issue102.cpp
@@ -1,0 +1,85 @@
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <string>
+#include <type_traits>
+#include <typeindex>
+#include <typeinfo>
+
+
+
+// ====================  Copy paste this ==============================================================================
+#include <tuple>
+#include <utility>
+
+template <typename T>
+struct FunctionArgs : FunctionArgs<decltype(&T::operator())> {};
+
+template <typename R, typename... Args>
+struct FunctionArgsBase {
+    using args = std::tuple<Args...>;
+	using arity = std::integral_constant<unsigned, sizeof...(Args)>;
+	using result = R;
+};
+
+template <typename R, typename... Args>
+struct FunctionArgs<R(*)(Args...)> : FunctionArgsBase<R, Args...> {};
+template <typename R, typename C, typename... Args>
+struct FunctionArgs<R(C::*)(Args...)> : FunctionArgsBase<R, Args...> {};
+template <typename R, typename C, typename... Args>
+struct FunctionArgs<R(C::*)(Args...) const> : FunctionArgsBase<R, Args...> {};
+
+// forward declarations
+template<class T, class Case, class ...Cases>
+decltype(auto) match(T&& value, const Case& _case, const Cases&... cases);
+template<class T, class Case>
+decltype(auto) match(T&& value, const Case& _case);
+
+namespace details {
+	template<class T, class Case, class ...OtherCases>
+	decltype(auto) match_call(const Case& _case, T&& value, std::true_type, const OtherCases&... other) {
+		return _case(std::forward<T>(value));
+	}
+
+	template<class T, class Case, class ...OtherCases>
+	decltype(auto) match_call(const Case& _case, T&& value, std::false_type, const OtherCases&... other) {
+		return match(std::forward<T>(value), other...);
+	}
+}
+
+template<class T, class Case, class ...Cases>
+decltype(auto) match(T&& value, const Case& _case, const Cases&... cases) {
+    using namespace std;
+    using args = typename FunctionArgs<Case>::args;
+	using arg = tuple_element_t<0, args>;
+	using match = is_same<decay_t<arg>, decay_t<T>>;
+	return details::match_call(_case, std::forward<T>(value), match{}, cases...);
+}
+
+
+// the last one is default
+template<class T, class Case>
+decltype(auto) match(T&& value, const Case& _case) {
+	return _case(std::forward<T>(value));
+}
+
+// ==================================================================================================
+
+
+
+template<class T>
+decltype(auto) test(T&& value) {
+    return match(value
+		,[](std::string value)	{ std::cout << "This is string "; return value + " Hi!"; }
+		,[](int i)				{ std::cout << "This is int ";	 return i * 100; }
+		,[](auto a)				{ std::cout << "This is default ";return 0; }
+	);
+}
+
+int main() {
+    std::cout << test(200) << std::endl;
+    std::cout << test("RR") << std::endl;          // because const char*
+    std::cout << test(std::string{"ARR"}) << std::endl; 
+	return 0;
+}
+

--- a/tests/Issue102.expect
+++ b/tests/Issue102.expect
@@ -1,0 +1,474 @@
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <string>
+#include <type_traits>
+#include <typeindex>
+#include <typeinfo>
+
+
+
+// ====================  Copy paste this ==============================================================================
+#include <tuple>
+#include <utility>
+
+template <typename T>
+struct FunctionArgs : FunctionArgs<decltype(&T::operator())> {};
+
+/* First instantiated from: Issue102.cpp:53 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+struct FunctionArgs<__lambda_73_4> : public FunctionArgs<std::basic_string<char> (__lambda_73_4::*)(std::basic_string<char>) const>
+{
+  
+};
+
+#endif
+
+
+/* First instantiated from: Issue102.cpp:16 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+struct FunctionArgs<std::basic_string<char> (__lambda_73_4::*)(std::basic_string<char>) const> : public FunctionArgsBase<std::basic_string<char>, std::basic_string<char> >
+{
+  
+};
+
+#endif
+
+
+/* First instantiated from: Issue102.cpp:53 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+struct FunctionArgs<__lambda_74_4> : public FunctionArgs<int (__lambda_74_4::*)(int) const>
+{
+  
+};
+
+#endif
+
+
+/* First instantiated from: Issue102.cpp:16 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+struct FunctionArgs<int (__lambda_74_4::*)(int) const> : public FunctionArgsBase<int, int>
+{
+  
+};
+
+#endif
+
+
+/* First instantiated from: Issue102.cpp:53 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+struct FunctionArgs<__lambda_73_4> : public FunctionArgs<std::basic_string<char> (__lambda_73_4::*)(std::basic_string<char>) const>
+{
+  
+};
+
+#endif
+
+
+/* First instantiated from: Issue102.cpp:16 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+struct FunctionArgs<std::basic_string<char> (__lambda_73_4::*)(std::basic_string<char>) const> : public FunctionArgsBase<std::basic_string<char>, std::basic_string<char> >
+{
+  
+};
+
+#endif
+
+
+/* First instantiated from: Issue102.cpp:53 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+struct FunctionArgs<__lambda_74_4> : public FunctionArgs<int (__lambda_74_4::*)(int) const>
+{
+  
+};
+
+#endif
+
+
+/* First instantiated from: Issue102.cpp:16 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+struct FunctionArgs<int (__lambda_74_4::*)(int) const> : public FunctionArgsBase<int, int>
+{
+  
+};
+
+#endif
+
+
+/* First instantiated from: Issue102.cpp:53 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+struct FunctionArgs<__lambda_73_4> : public FunctionArgs<std::basic_string<char> (__lambda_73_4::*)(std::basic_string<char>) const>
+{
+  
+};
+
+#endif
+
+
+/* First instantiated from: Issue102.cpp:16 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+struct FunctionArgs<std::basic_string<char> (__lambda_73_4::*)(std::basic_string<char>) const> : public FunctionArgsBase<std::basic_string<char>, std::basic_string<char> >
+{
+  
+};
+
+#endif
+
+
+template <typename R, typename... Args>
+struct FunctionArgsBase {
+    using args = std::tuple<Args...>;
+	using arity = std::integral_constant<unsigned, sizeof...(Args)>;
+	using result = R;
+};
+
+/* First instantiated from: Issue102.cpp:30 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+struct FunctionArgsBase<std::basic_string<char>, std::basic_string<char> >
+{
+  using args = tuple<std::basic_string<char>>;
+  using arity = integral_constant<unsigned int, static_cast<unsigned int>(1)>;
+  using result = std::basic_string<char>;
+  
+};
+
+#endif
+
+
+/* First instantiated from: Issue102.cpp:30 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+struct FunctionArgsBase<int, int>
+{
+  using args = tuple<int>;
+  using arity = integral_constant<unsigned int, static_cast<unsigned int>(1)>;
+  using result = int;
+  
+};
+
+#endif
+
+
+template <typename R, typename... Args>
+struct FunctionArgs<R(*)(Args...)> : FunctionArgsBase<R, Args...> {};
+template <typename R, typename C, typename... Args>
+struct FunctionArgs<R(C::*)(Args...)> : FunctionArgsBase<R, Args...> {};
+template <typename R, typename C, typename... Args>
+struct FunctionArgs<R(C::*)(Args...) const> : FunctionArgsBase<R, Args...> {};
+
+// forward declarations
+template<class T, class Case, class ...Cases>
+decltype(auto) match(T&& value, const Case& _case, const Cases&... cases);
+template<class T, class Case>
+decltype(auto) match(T&& value, const Case& _case);
+
+namespace details {
+	template<class T, class Case, class ...OtherCases>
+	decltype(auto) match_call(const Case& _case, T&& value, std::true_type, const OtherCases&... other) {
+		return _case(std::forward<T>(value));
+	}
+	
+	/* First instantiated from: Issue102.cpp:56 */
+	#ifdef INSIGHTS_USE_TEMPLATE
+	template<>
+	int match_call<int &, __lambda_74_4, __lambda_75_4>(const __lambda_74_4 & _case, int & value, std::integral_constant<bool, 1>, const __lambda_75_4 & __other3)
+	{
+	  return _case.operator()(std::forward<int &>(value));
+	}
+	#endif
+	
+	
+	/* First instantiated from: Issue102.cpp:56 */
+	#ifdef INSIGHTS_USE_TEMPLATE
+	template<>
+	std::basic_string<char> match_call<std::basic_string<char> &, __lambda_73_4, __lambda_74_4, __lambda_75_4>(const __lambda_73_4 & _case, std::basic_string<char> & value, std::integral_constant<bool, 1>, const __lambda_74_4 & __other3, const __lambda_75_4 & __other4)
+	{
+	  return _case.operator()(std::basic_string<char>(std::forward<std::basic_string<char> &>(value)));
+	}
+	#endif
+	
+
+	template<class T, class Case, class ...OtherCases>
+	decltype(auto) match_call(const Case& _case, T&& value, std::false_type, const OtherCases&... other) {
+		return match(std::forward<T>(value), other...);
+	}
+	
+	/* First instantiated from: Issue102.cpp:56 */
+	#ifdef INSIGHTS_USE_TEMPLATE
+	template<>
+	int match_call<int &, __lambda_73_4, __lambda_74_4, __lambda_75_4>(const __lambda_73_4 & _case, int & value, std::integral_constant<bool, 0>, const __lambda_74_4 & __other3, const __lambda_75_4 & __other4)
+	{
+	  return match(std::forward<int &>(value), __other3, __other4);
+	}
+	#endif
+	
+	
+	/* First instantiated from: Issue102.cpp:56 */
+	#ifdef INSIGHTS_USE_TEMPLATE
+	template<>
+	int match_call<char const (&)[3], __lambda_73_4, __lambda_74_4, __lambda_75_4>(const __lambda_73_4 & _case, char const (&value)[3], std::integral_constant<bool, 0>, const __lambda_74_4 & __other3, const __lambda_75_4 & __other4)
+	{
+	  return match(std::forward<char const (&)[3]>(value), __other3, __other4);
+	}
+	#endif
+	
+	
+	/* First instantiated from: Issue102.cpp:56 */
+	#ifdef INSIGHTS_USE_TEMPLATE
+	template<>
+	int match_call<char const (&)[3], __lambda_74_4, __lambda_75_4>(const __lambda_74_4 & _case, char const (&value)[3], std::integral_constant<bool, 0>, const __lambda_75_4 & __other3)
+	{
+	  return match(std::forward<char const (&)[3]>(value), __other3);
+	}
+	#endif
+	
+}
+
+template<class T, class Case, class ...Cases>
+decltype(auto) match(T&& value, const Case& _case, const Cases&... cases) {
+    using namespace std;
+    using args = typename FunctionArgs<Case>::args;
+	using arg = tuple_element_t<0, args>;
+	using match = is_same<decay_t<arg>, decay_t<T>>;
+	return details::match_call(_case, std::forward<T>(value), match{}, cases...);
+}
+
+/* First instantiated from: Issue102.cpp:72 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+int match<int &, __lambda_73_4, __lambda_74_4, __lambda_75_4>(int & value, const __lambda_73_4 & _case, const __lambda_74_4 & __cases2, const __lambda_75_4 & __cases3)
+{
+  using namespace std;
+  using args = tuple<std::basic_string<char>>;
+  using arg = tuple_element_t<0, std::tuple<std::basic_string<char> >>;
+  using match = is_same<std::basic_string<char>, decay_t<int &>>;
+  return details::match_call(_case, std::forward<int &>(value), std::integral_constant<bool, 0>(static_cast<std::integral_constant<bool, 0>&>(std::is_same<std::basic_string<char>, int>{{}})), __cases2, __cases3);
+}
+#endif
+
+
+/* First instantiated from: Issue102.cpp:46 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+int match<int &, __lambda_74_4, __lambda_75_4>(int & value, const __lambda_74_4 & _case, const __lambda_75_4 & __cases2)
+{
+  using namespace std;
+  using args = tuple<int>;
+  using arg = tuple_element_t<0, std::tuple<int>>;
+  using match = is_same<decay_t<arg>, decay_t<int &>>;
+  return details::match_call(_case, std::forward<int &>(value), std::integral_constant<bool, 1>(static_cast<std::integral_constant<bool, 1>&>(std::is_same<int, int>{{}})), __cases2);
+}
+#endif
+
+
+/* First instantiated from: Issue102.cpp:72 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+int match<char const (&)[3], __lambda_73_4, __lambda_74_4, __lambda_75_4>(char const (&value)[3], const __lambda_73_4 & _case, const __lambda_74_4 & __cases2, const __lambda_75_4 & __cases3)
+{
+  using namespace std;
+  using args = tuple<std::basic_string<char>>;
+  using arg = tuple_element_t<0, std::tuple<std::basic_string<char> >>;
+  using match = is_same<std::basic_string<char>, decay_t<char const (&)[3]>>;
+  return details::match_call(_case, std::forward<char const (&)[3]>(value), std::integral_constant<bool, 0>(static_cast<std::integral_constant<bool, 0>&>(std::is_same<std::basic_string<char>, const char *>{{}})), __cases2, __cases3);
+}
+#endif
+
+
+/* First instantiated from: Issue102.cpp:46 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+int match<char const (&)[3], __lambda_74_4, __lambda_75_4>(char const (&value)[3], const __lambda_74_4 & _case, const __lambda_75_4 & __cases2)
+{
+  using namespace std;
+  using args = tuple<int>;
+  using arg = tuple_element_t<0, std::tuple<int>>;
+  using match = is_same<decay_t<arg>, decay_t<char const (&)[3]>>;
+  return details::match_call(_case, std::forward<char const (&)[3]>(value), std::integral_constant<bool, 0>(static_cast<std::integral_constant<bool, 0>&>(std::is_same<int, const char *>{{}})), __cases2);
+}
+#endif
+
+
+/* First instantiated from: Issue102.cpp:72 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+std::basic_string<char> match<std::basic_string<char> &, __lambda_73_4, __lambda_74_4, __lambda_75_4>(std::basic_string<char> & value, const __lambda_73_4 & _case, const __lambda_74_4 & __cases2, const __lambda_75_4 & __cases3)
+{
+  using namespace std;
+  using args = tuple<std::basic_string<char>>;
+  using arg = tuple_element_t<0, std::tuple<std::basic_string<char> >>;
+  using match = is_same<std::basic_string<char>, std::basic_string<char>>;
+  return details::match_call(_case, std::forward<std::basic_string<char> &>(value), std::integral_constant<bool, 1>(static_cast<std::integral_constant<bool, 1>&>(std::is_same<std::basic_string<char>, std::basic_string<char> >{{}})), __cases2, __cases3);
+}
+#endif
+
+
+
+// the last one is default
+template<class T, class Case>
+decltype(auto) match(T&& value, const Case& _case) {
+	return _case(std::forward<T>(value));
+}
+
+/* First instantiated from: Issue102.cpp:46 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+int match<char const (&)[3], __lambda_75_4>(char const (&value)[3], const __lambda_75_4 & _case)
+{
+  return _case.operator()(std::forward<char const (&)[3]>(value));
+}
+#endif
+
+
+// ==================================================================================================
+
+
+
+template<class T>
+decltype(auto) test(T&& value) {
+    return match(value
+		,[](std::string value)	{ std::cout << "This is string "; return value + " Hi!"; }
+		,[](int i)				{ std::cout << "This is int ";	 return i * 100; }
+		,[](auto a)				{ std::cout << "This is default ";return 0; }
+	);
+}
+
+/* First instantiated from: Issue102.cpp:80 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+int test<int>(int && value)
+{
+      
+  class __lambda_73_4
+  {
+    public: inline std::basic_string<char> operator()(std::basic_string<char> value) const
+    {
+      std::operator<<(std::cout, "This is string ");
+      return operator+(value, " Hi!");
+    }
+    
+  };
+  
+  
+  class __lambda_74_4
+  {
+    public: inline /*constexpr */ int operator()(int i) const
+    {
+      std::operator<<(std::cout, "This is int ");
+      return i * 100;
+    }
+    
+  };
+  
+  
+  class __lambda_75_4
+  {
+    
+  };
+  
+  return match(value, __lambda_73_4{}, __lambda_74_4{}, __lambda_75_4{});
+}
+#endif
+
+
+/* First instantiated from: Issue102.cpp:81 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+int test<char const (&)[3]>(char const (&value)[3])
+{
+      
+  class __lambda_73_4
+  {
+    public: inline std::basic_string<char> operator()(std::basic_string<char> value) const
+    {
+      std::operator<<(std::cout, "This is string ");
+      return operator+(value, " Hi!");
+    }
+    
+  };
+  
+  
+  class __lambda_74_4
+  {
+    public: inline /*constexpr */ int operator()(int i) const
+    {
+      std::operator<<(std::cout, "This is int ");
+      return i * 100;
+    }
+    
+  };
+  
+  
+  class __lambda_75_4
+  {
+    public: inline /*constexpr */ int operator()(const char * a) const
+    {
+      std::operator<<(std::cout, "This is default ");
+      return 0;
+    }
+    
+  };
+  
+  return match(value, __lambda_73_4{}, __lambda_74_4{}, __lambda_75_4{});
+}
+#endif
+
+
+/* First instantiated from: Issue102.cpp:82 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+std::basic_string<char> test<std::basic_string<char> >(std::basic_string<char> && value)
+{
+      
+  class __lambda_73_4
+  {
+    public: inline std::basic_string<char> operator()(std::basic_string<char> value) const
+    {
+      std::operator<<(std::cout, "This is string ");
+      return operator+(value, " Hi!");
+    }
+    
+  };
+  
+  
+  class __lambda_74_4
+  {
+    public: inline /*constexpr */ int operator()(int i) const
+    {
+      std::operator<<(std::cout, "This is int ");
+      return i * 100;
+    }
+    
+  };
+  
+  
+  class __lambda_75_4
+  {
+    
+  };
+  
+  return match(value, __lambda_73_4{}, __lambda_74_4{}, __lambda_75_4{});
+}
+#endif
+
+
+int main()
+{
+  std::cout.operator<<(test(200)).operator<<(std::endl);
+  std::cout.operator<<(test("RR")).operator<<(std::endl);
+  std::operator<<(std::cout, test(std::basic_string<char>{"ARR"})).operator<<(std::endl);
+  return 0;
+}
+
+

--- a/tests/LambdaAsTemplateArgTest.cpp
+++ b/tests/LambdaAsTemplateArgTest.cpp
@@ -1,0 +1,15 @@
+template <typename T>
+struct FunctionArgs  {};
+
+template <typename R, typename C, typename... Args>
+struct FunctionArgs<R(C::*)(Args...) const>  {};
+
+
+int main()
+{
+    int y = 2;
+    int z = 3;
+    auto l = [&](int x) { return x + y; };
+
+    FunctionArgs<decltype(&decltype(l)::operator())> a;
+}

--- a/tests/LambdaAsTemplateArgTest.expect
+++ b/tests/LambdaAsTemplateArgTest.expect
@@ -1,0 +1,46 @@
+template <typename T>
+struct FunctionArgs  {};
+
+/* First instantiated from: LambdaAsTemplateArgTest.cpp:14 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+struct FunctionArgs<int (__lambda_12_14::*)(int) const>
+{
+  inline constexpr FunctionArgs() noexcept = default;
+  inline constexpr FunctionArgs(const FunctionArgs<int (__lambda_12_14::*)(int) const> &) = default;
+  inline constexpr FunctionArgs(FunctionArgs<int (__lambda_12_14::*)(int) const> &&) = default;
+  
+};
+
+#endif
+
+
+template <typename R, typename C, typename... Args>
+struct FunctionArgs<R(C::*)(Args...) const>  {};
+
+
+int main()
+{
+  int y = 2;
+  int z = 3;
+    
+  class __lambda_12_14
+  {
+    public: inline /*constexpr */ int operator()(int x) const
+    {
+      return x + y;
+    }
+    
+    private:
+    int& y;
+    
+    public: __lambda_12_14(int& _y)
+    : y{_y}
+    {}
+    
+  };
+  
+  __lambda_12_14 l = __lambda_12_14{y};
+  FunctionArgs<decltype(&decltype(l)::operator())> a = FunctionArgs<int (__lambda_12_14::*)(int) const>();
+}
+


### PR DESCRIPTION
Filter only expression to handle them special for TypeAlias and pass the
rest to the normal parser.