### PR TITLE
Fixed #116: A typedef concealed the const qualifier.

### DIFF
--- a/InsightsHelpers.cpp
+++ b/InsightsHelpers.cpp
@@ -240,7 +240,7 @@ static std::string GetNameInternal(const QualType& t, const Unqualified unqualif
                         return refType->getPointeeTypeAsWritten().getLocalQualifiers().getAsString();
                     }
 
-                    return t.getLocalQualifiers().getAsString();
+                    return t.getCanonicalType().getLocalQualifiers().getAsString();
                 }()};
 
                 if(const auto* tt = dyn_cast_or_null<ClassTemplateSpecializationDecl>(decl)) {

--- a/tests/Issue116.cpp
+++ b/tests/Issue116.cpp
@@ -1,0 +1,12 @@
+#include <string>
+#include <unordered_map>
+
+using namespace std;
+
+int main()
+{
+    unordered_map<string, string> m;
+    for (auto & [key, value] : m) {
+      
+    }
+}

--- a/tests/Issue116.expect
+++ b/tests/Issue116.expect
@@ -1,0 +1,22 @@
+#include <string>
+#include <unordered_map>
+
+using namespace std;
+
+int main()
+{
+  unordered_map<std::string, std::string> m = std::unordered_map<std::basic_string<char>, std::basic_string<char>, std::hash<std::basic_string<char> >, std::equal_to<std::basic_string<char> >, std::allocator<std::pair<const std::basic_string<char>, std::basic_string<char> > > >();
+  {
+    std::unordered_map<std::basic_string<char>, std::basic_string<char>, std::hash<std::basic_string<char> >, std::equal_to<std::basic_string<char> >, std::allocator<std::pair<const std::basic_string<char>, std::basic_string<char> > > > & __range1 = m;
+    std::__hash_map_iterator<std::__hash_iterator<std::__hash_node<std::__hash_value_type<std::basic_string<char>, std::basic_string<char> >, void *> *> > __begin1 = __range1.begin();
+    std::__hash_map_iterator<std::__hash_iterator<std::__hash_node<std::__hash_value_type<std::basic_string<char>, std::basic_string<char> >, void *> *> > __end1 = __range1.end();
+    
+    for( ; operator!=(__begin1, __end1); __begin1.operator++() )
+    {
+      std::pair<const std::basic_string<char>, std::basic_string<char> > & __operator9 = __begin1.operator*();
+      const std::basic_string<char>& key = std::get<0ul>(__operator9);
+      std::basic_string<char>& value = std::get<1ul>(__operator9);
+    }
+  }
+}
+


### PR DESCRIPTION
Use the canonical type to get all CVR's.