### PR TITLE
Fixed #131: Global DecompositionDecl transformation was wrong.

### DIFF
--- a/CodeGenerator.cpp
+++ b/CodeGenerator.cpp
@@ -2705,6 +2705,13 @@ void CodeGenerator::WrapInCurlys(T&& lambda, const AddSpaceAtTheEnd addSpaceAtTh
 void StructuredBindingsCodeGenerator::InsertArg(const DeclRefExpr* stmt)
 {
     const auto name = GetName(*stmt);
+
+    // Special case for structured bindings, probably only with std::tuple. The get which is used to retrieve the value
+    // seems to carry no std:: in front. Insert it to make the code compile.
+    if(not name.empty() && BeginsWith(name, "get")) {
+        mOutputFormatHelper.Append("std::");
+    }
+
     mOutputFormatHelper.Append(name);
 
     if(name.empty() || EndsWith(name, "::")) {

--- a/InsightsStrCat.h
+++ b/InsightsStrCat.h
@@ -27,6 +27,16 @@ static inline bool EndsWith(const std::string& src, const std::string& ending)
 }
 //-----------------------------------------------------------------------------
 
+static inline bool BeginsWith(const std::string& src, const std::string& begining)
+{
+    if(begining.size() > src.size()) {
+        return false;
+    }
+
+    return std::equal(begining.begin(), begining.end(), src.begin());
+}
+//-----------------------------------------------------------------------------
+
 static inline std::string ToString(const llvm::APSInt& val)
 {
     return val.toString(10);

--- a/tests/GlobalVarFromFunctionInitTest.cpp
+++ b/tests/GlobalVarFromFunctionInitTest.cpp
@@ -1,0 +1,3 @@
+int Func() { return 2; }
+
+int v = /* */ Func(); //

--- a/tests/GlobalVarFromFunctionInitTest.expect
+++ b/tests/GlobalVarFromFunctionInitTest.expect
@@ -1,0 +1,8 @@
+int Func()
+{
+  return 2;
+}
+
+
+int v = Func();
+ //

--- a/tests/Issue131.cpp
+++ b/tests/Issue131.cpp
@@ -1,0 +1,5 @@
+#include <tuple>
+
+std::tuple<int, float> foo();
+ 
+auto [a, b] = foo();

--- a/tests/Issue131.expect
+++ b/tests/Issue131.expect
@@ -1,0 +1,9 @@
+#include <tuple>
+
+std::tuple<int, float> foo();
+
+ 
+std::tuple<int, float> __foo5 = foo();
+std::tuple_element<0, std::tuple<int, float> >::type& a = std::get<0ul>(__foo5);
+std::tuple_element<1, std::tuple<int, float> >::type& b = std::get<1ul>(__foo5);
+

--- a/tests/StructuredBindingsHandler6Test.expect
+++ b/tests/StructuredBindingsHandler6Test.expect
@@ -132,12 +132,12 @@ int main()
   const char& a19 = __aa75[1];
   std::tuple<int, char, double> muple = std::make_tuple(1, 'a', 2.2999999999999998);
   std::tuple<int, char, double> & __muple80 = muple;
-  std::tuple_element<0, std::tuple<int, char, double> >::type& i = get<0ul>(__muple80);
-  std::tuple_element<1, std::tuple<int, char, double> >::type& c = get<1ul>(__muple80);
-  std::tuple_element<2, std::tuple<int, char, double> >::type& d = get<2ul>(__muple80);
+  std::tuple_element<0, std::tuple<int, char, double> >::type& i = std::get<0ul>(__muple80);
+  std::tuple_element<1, std::tuple<int, char, double> >::type& c = std::get<1ul>(__muple80);
+  std::tuple_element<2, std::tuple<int, char, double> >::type& d = std::get<2ul>(__muple80);
   std::tuple<int, char, double> __muple82 = std::tuple<int, char, double>(muple);
-  std::tuple_element<0, std::tuple<int, char, double> >::type& ii = get<0ul>(__muple82);
-  std::tuple_element<1, std::tuple<int, char, double> >::type& cc = get<1ul>(__muple82);
-  std::tuple_element<2, std::tuple<int, char, double> >::type& dd = get<2ul>(__muple82);
+  std::tuple_element<0, std::tuple<int, char, double> >::type& ii = std::get<0ul>(__muple82);
+  std::tuple_element<1, std::tuple<int, char, double> >::type& cc = std::get<1ul>(__muple82);
+  std::tuple_element<2, std::tuple<int, char, double> >::type& dd = std::get<2ul>(__muple82);
 }
 

--- a/tests/StructuredBindingsHandler9Test.cpp
+++ b/tests/StructuredBindingsHandler9Test.cpp
@@ -1,0 +1,18 @@
+#include <tuple>
+
+std::tuple<int, float> foo;
+ 
+auto [a, b] = foo;
+auto& [ra, rb] = foo;
+
+
+char c[3]{};
+
+auto [x, y, z] = c;
+
+auto& [cx, cy, cz] = c;
+
+
+std::tuple<int, float> Func();
+ 
+const auto& [fa, fb] = Func();

--- a/tests/StructuredBindingsHandler9Test.expect
+++ b/tests/StructuredBindingsHandler9Test.expect
@@ -1,0 +1,38 @@
+#include <tuple>
+
+std::tuple<int, float> foo = std::tuple<int, float>();
+
+ 
+std::tuple<int, float> __foo5 = std::tuple<int, float>(foo);
+std::tuple_element<0, std::tuple<int, float> >::type& a = std::get<0ul>(__foo5);
+std::tuple_element<1, std::tuple<int, float> >::type& b = std::get<1ul>(__foo5);
+
+std::tuple<int, float> & __foo6 = foo;
+std::tuple_element<0, std::tuple<int, float> >::type& ra = std::get<0ul>(__foo6);
+std::tuple_element<1, std::tuple<int, float> >::type& rb = std::get<1ul>(__foo6);
+
+
+
+char c[3] = {'\0', '\0', '\0'};
+
+
+char __c11[3] = {c[0], c[1], c[2]};
+char x = __c11[0];
+char y = __c11[1];
+char z = __c11[2];
+
+
+char (&__c13)[3] = c;
+char& cx = __c13[0];
+char& cy = __c13[1];
+char& cz = __c13[2];
+
+
+
+std::tuple<int, float> Func();
+
+ 
+const std::tuple<int, float> & __Func18 = Func();
+std::tuple_element<0, const std::tuple<int, float> >::type& fa = std::get<0ul>(__Func18);
+std::tuple_element<1, const std::tuple<int, float> >::type& fb = std::get<1ul>(__Func18);
+

--- a/tests/TupeInRangeBasedForTest.cerr
+++ b/tests/TupeInRangeBasedForTest.cerr
@@ -1,7 +1,0 @@
-.tmp.cpp:33:36: error: use of undeclared identifier 'get'
-      std::basic_string<char>& s = get<0ul>(__operator15);
-                                   ^
-.tmp.cpp:34:83: error: use of undeclared identifier 'get'
-      std::tuple_element<1, std::tuple<std::basic_string<char>, int> >::type& n = get<1ul>(__operator15);
-                                                                                  ^
-2 errors generated.

--- a/tests/TupeInRangeBasedForTest.expect
+++ b/tests/TupeInRangeBasedForTest.expect
@@ -30,8 +30,8 @@ int main()
     for( ; std::operator!=(__begin1, __end1); __begin1.operator++() )
     {
       std::tuple<std::basic_string<char>, int> __operator15 = std::tuple<std::basic_string<char>, int>(__begin1.operator*());
-      std::basic_string<char>& s = get<0ul>(__operator15);
-      std::tuple_element<1, std::tuple<std::basic_string<char>, int> >::type& n = get<1ul>(__operator15);
+      std::basic_string<char>& s = std::get<0ul>(__operator15);
+      std::tuple_element<1, std::tuple<std::basic_string<char>, int> >::type& n = std::get<1ul>(__operator15);
       printf("c=%s, n=%d\n", s.c_str(), n);
     }
   }


### PR DESCRIPTION
A global DecompositionDecl which involves a callExpr introduces the
decomposed variables. With this, the global VarDecl matcher matched
multiple times which resulted in an messed up transformation. Added a
limit to the matcher to skip the decomposed variable declarations.