### PR TITLE
Fixed #119: Show what happens for block local statics.

### DIFF
--- a/InsightsHelpers.cpp
+++ b/InsightsHelpers.cpp
@@ -436,12 +436,9 @@ static bool IsTrivialStaticClassVarDecl(const DeclRefExpr& declRefExpr)
 
 bool IsTrivialStaticClassVarDecl(const VarDecl& varDecl)
 {
-    auto&      langOpts{GetLangOpts(varDecl)};
-    const bool haveCpp11{true == langOpts.CPlusPlus11};
-
-    if(haveCpp11 && varDecl.isStaticLocal()) {
+    if(varDecl.isStaticLocal()) {
         if(const auto* cxxRecordDecl = varDecl.getType()->getAsCXXRecordDecl()) {
-            if(cxxRecordDecl->hasNonTrivialDestructor()) {
+            if(cxxRecordDecl->hasNonTrivialDestructor() || cxxRecordDecl->hasNonTrivialDefaultConstructor()) {
                 return true;
             }
         }

--- a/tests/StaticHandler4Test.cpp
+++ b/tests/StaticHandler4Test.cpp
@@ -1,0 +1,14 @@
+void X() noexcept(false) { throw; }
+
+class Sing
+{
+public:
+    Sing() { X(); }
+};
+
+Sing & Test()
+{
+    static Sing s;
+
+    return s;
+}

--- a/tests/StaticHandler5Test.cpp
+++ b/tests/StaticHandler5Test.cpp
@@ -1,0 +1,15 @@
+// cmdline:-std=c++98
+void X() { throw; }
+
+class Sing
+{
+public:
+    Sing() { X(); }
+};
+
+Sing & Test()
+{
+    static Sing s;
+
+    return s;
+}

--- a/tests/StaticHandler6Test.cpp
+++ b/tests/StaticHandler6Test.cpp
@@ -1,0 +1,14 @@
+void X() noexcept(true);
+
+class Sing
+{
+public:
+    Sing() noexcept { X(); }
+};
+
+Sing & Test()
+{
+    static Sing s;
+
+    return s;
+}

--- a/tests/StaticHandler6Test.expect
+++ b/tests/StaticHandler6Test.expect
@@ -1,0 +1,34 @@
+#include <new> // for thread-safe static's placement new
+void X() noexcept(true);
+
+
+class Sing
+{
+public:
+    inline Sing() noexcept
+    {
+      X();
+    }
+    
+    
+// public: inline constexpr Sing(const Sing &);
+// public: inline constexpr Sing(Sing &&);
+};
+
+Sing & Test()
+{
+  static uint64_t __sGuard;
+  alignas(Sing) static char __s[sizeof(Sing)];
+  
+  if( ! __sGuard )
+  {
+    if( __cxa_guard_acquire(&__sGuard) )
+    {
+      new (&__s) Sing();
+      __sGuard = true;
+      __cxa_guard_release(&__sGuard);
+    }
+  }
+  return *reinterpret_cast<Sing*>(__s);
+}
+

--- a/tests/StaticHandlerTest.expect
+++ b/tests/StaticHandlerTest.expect
@@ -1,3 +1,4 @@
+#include <new> // for thread-safe static's placement new
 #include <cstdio>
 #include <cstring>
 #include <new> // need this for after the transformation when a placement new is used
@@ -38,13 +39,17 @@ static size_t counter = 0;
 
 Singleton & Singleton::Instance()
 {
-  static bool __singletonB;
-  static char __singleton[sizeof(Singleton)];
+  static uint64_t __singletonGuard;
+  alignas(Singleton) static char __singleton[sizeof(Singleton)];
   
-  if( ! __singletonB )
+  if( ! __singletonGuard )
   {
-    new (&__singleton) Singleton;
-    __singletonB = true;
+    if( __cxa_guard_acquire(&__singletonGuard) )
+    {
+      new (&__singleton) Singleton();
+      __singletonGuard = true;
+      __cxa_guard_release(&__singletonGuard);
+    }
   }
   static bool passed = true;
   return *reinterpret_cast<Singleton*>(__singleton);
@@ -83,26 +88,34 @@ private:
 
 void B()
 {
-  static bool __bbB;
-  static char __bb[sizeof(Bingleton)];
+  static uint64_t __bbGuard;
+  alignas(Bingleton) static char __bb[sizeof(Bingleton)];
   
-  if( ! __bbB )
+  if( ! __bbGuard )
   {
-    new (&__bb) Bingleton;
-    __bbB = true;
+    if( __cxa_guard_acquire(&__bbGuard) )
+    {
+      new (&__bb) Bingleton();
+      __bbGuard = true;
+      __cxa_guard_release(&__bbGuard);
+    }
   }
 }
 
 
 Bingleton * B(bool c)
 {
-  static bool __bbB;
-  static char __bb[sizeof(Bingleton)];
+  static uint64_t __bbGuard;
+  alignas(Bingleton) static char __bb[sizeof(Bingleton)];
   
-  if( ! __bbB )
+  if( ! __bbGuard )
   {
-    new (&__bb) Bingleton;
-    __bbB = true;
+    if( __cxa_guard_acquire(&__bbGuard) )
+    {
+      new (&__bb) Bingleton();
+      __bbGuard = true;
+      __cxa_guard_release(&__bbGuard);
+    }
   }
   if(c) {
     return nullptr;
@@ -115,13 +128,17 @@ Bingleton * B(bool c)
 
 Bingleton & BB(bool c)
 {
-  static bool __bbB;
-  static char __bb[sizeof(Bingleton)];
+  static uint64_t __bbGuard;
+  alignas(Bingleton) static char __bb[sizeof(Bingleton)];
   
-  if( ! __bbB )
+  if( ! __bbGuard )
   {
-    new (&__bb) Bingleton;
-    __bbB = true;
+    if( __cxa_guard_acquire(&__bbGuard) )
+    {
+      new (&__bb) Bingleton();
+      __bbGuard = true;
+      __cxa_guard_release(&__bbGuard);
+    }
   }
   if(c) {
     return *reinterpret_cast<Bingleton*>(__bb);

--- a/tests/StaticInLambdaTest.expect
+++ b/tests/StaticInLambdaTest.expect
@@ -1,3 +1,4 @@
+#include <new> // for thread-safe static's placement new
 #include <cstdio>
 #include <cstring>
 #include <new> // need this for after the transformation when a placement new is used
@@ -38,13 +39,17 @@ static size_t counter = 0;
 
 Singleton & Singleton::Instance()
 {
-  static bool __singletonB;
-  static char __singleton[sizeof(Singleton)];
+  static uint64_t __singletonGuard;
+  alignas(Singleton) static char __singleton[sizeof(Singleton)];
   
-  if( ! __singletonB )
+  if( ! __singletonGuard )
   {
-    new (&__singleton) Singleton;
-    __singletonB = true;
+    if( __cxa_guard_acquire(&__singletonGuard) )
+    {
+      new (&__singleton) Singleton();
+      __singletonGuard = true;
+      __cxa_guard_release(&__singletonGuard);
+    }
   }
   static bool passed = true;
   return *reinterpret_cast<Singleton*>(__singleton);
@@ -88,13 +93,17 @@ int main()
   {
     public: inline Bingleton operator()(bool c) const
     {
-      static bool __bbB;
-      static char __bb[sizeof(Bingleton)];
+      static uint64_t __bbGuard;
+      alignas(Bingleton) static char __bb[sizeof(Bingleton)];
       
-      if( ! __bbB )
+      if( ! __bbGuard )
       {
-        new (&__bb) Bingleton;
-        __bbB = true;
+        if( __cxa_guard_acquire(&__bbGuard) )
+        {
+          new (&__bb) Bingleton();
+          __bbGuard = true;
+          __cxa_guard_release(&__bbGuard);
+        }
       }
       if(c) {
         return Bingleton(*reinterpret_cast<Bingleton*>(__bb));
@@ -111,13 +120,17 @@ int main()
     
     private: static inline Bingleton __invoke(bool c)
     {
-      static bool __bbB;
-      static char __bb[sizeof(Bingleton)];
+      static uint64_t __bbGuard;
+      alignas(Bingleton) static char __bb[sizeof(Bingleton)];
       
-      if( ! __bbB )
+      if( ! __bbGuard )
       {
-        new (&__bb) Bingleton;
-        __bbB = true;
+        if( __cxa_guard_acquire(&__bbGuard) )
+        {
+          new (&__bb) Bingleton();
+          __bbGuard = true;
+          __cxa_guard_release(&__bbGuard);
+        }
       }
       if(c) {
         return Bingleton(*reinterpret_cast<Bingleton*>(__bb));
@@ -135,13 +148,17 @@ int main()
   {
     public: inline Bingleton * operator()(bool c) const
     {
-      static bool __bbB;
-      static char __bb[sizeof(Bingleton)];
+      static uint64_t __bbGuard;
+      alignas(Bingleton) static char __bb[sizeof(Bingleton)];
       
-      if( ! __bbB )
+      if( ! __bbGuard )
       {
-        new (&__bb) Bingleton;
-        __bbB = true;
+        if( __cxa_guard_acquire(&__bbGuard) )
+        {
+          new (&__bb) Bingleton();
+          __bbGuard = true;
+          __cxa_guard_release(&__bbGuard);
+        }
       }
       if(c) {
         return &*reinterpret_cast<Bingleton*>(__bb);
@@ -158,13 +175,17 @@ int main()
     
     private: static inline Bingleton * __invoke(bool c)
     {
-      static bool __bbB;
-      static char __bb[sizeof(Bingleton)];
+      static uint64_t __bbGuard;
+      alignas(Bingleton) static char __bb[sizeof(Bingleton)];
       
-      if( ! __bbB )
+      if( ! __bbGuard )
       {
-        new (&__bb) Bingleton;
-        __bbB = true;
+        if( __cxa_guard_acquire(&__bbGuard) )
+        {
+          new (&__bb) Bingleton();
+          __bbGuard = true;
+          __cxa_guard_release(&__bbGuard);
+        }
       }
       if(c) {
         return &*reinterpret_cast<Bingleton*>(__bb);

--- a/tests/runTest.py
+++ b/tests/runTest.py
@@ -34,7 +34,12 @@ def testCompare(tmpFileName, stdout, expectFile, f, args, time):
 #------------------------------------------------------------------------------
 
 def testCompile(tmpFileName, f, args, fileName, cppStd):
-    cmd = [args['cxx'], cppStd, '-m64', '-c', tmpFileName]
+    alignAs = ''
+
+    if '-std=c++98' == cppStd:
+        alignAs = '-Dalignas(x)='
+
+    cmd = [args['cxx'], cppStd, '-m64', '-D__cxa_guard_acquire(x)=true', '-D__cxa_guard_release(x)', '-D__cxa_guard_abort(x)', alignAs, '-c', tmpFileName]
     p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     stdout, stderr = p.communicate()
 
@@ -146,7 +151,7 @@ def main():
         else:
                 cmd   = [insightsPath, f, '--', cppStd, '-m64'] + defaultIncludeDirs
                 begin = datetime.datetime.now()
-                p     = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                p   = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
                 end   = datetime.datetime.now()
                 stdout, stderr = p.communicate()
 


### PR DESCRIPTION
Since C++11 block local statics with a non-trivial constructor or
destructor are thread-safe. Since the beginning the compiler needs to
keep track whether the variable was already initialized. This patch
adds support to show whats is happening in those places.