### PR TITLE
Fixed #91: Add parentheses for BinaryOperator with `+` or `-`.

### DIFF
--- a/CodeGenerator.cpp
+++ b/CodeGenerator.cpp
@@ -472,7 +472,13 @@ void CodeGenerator::InsertArg(const BinaryOperator* stmt)
 
     InsertArg(stmt->getLHS());
     mOutputFormatHelper.Append(" ", stmt->getOpcodeStr(), " ");
-    InsertArg(stmt->getRHS());
+
+    // For + and - add the parentheses, if not already supplied. It looks like fold-expression to not carry them.
+    const bool needParens{
+        isa<BinaryOperator>(stmt->getRHS()->IgnoreImpCasts()) &&
+        ((BinaryOperatorKind::BO_Add == stmt->getOpcode()) || (BinaryOperatorKind::BO_Sub == stmt->getOpcode()))};
+
+    WrapInParensIfNeeded(needParens, [&] { InsertArg(stmt->getRHS()); });
 }
 //-----------------------------------------------------------------------------
 

--- a/tests/Issue91.cpp
+++ b/tests/Issue91.cpp
@@ -1,0 +1,20 @@
+template<int... Ints>
+constexpr int fold_minus_impl() {
+    return (Ints - ... - 5);
+}
+
+template<int... Ints>
+constexpr int fold_minus() {
+    return fold_minus_impl<0, Ints...>();
+}
+
+static_assert(fold_minus() == -5);
+
+template <int b>
+class print_int;
+
+int i = fold_minus<0>();
+static_assert(fold_minus<0>() == 5);
+static_assert(0 - 0 - 5 == -5);
+
+//print_int<fold_minus<0>()> p;

--- a/tests/Issue91.expect
+++ b/tests/Issue91.expect
@@ -1,0 +1,64 @@
+template<int... Ints>
+constexpr int fold_minus_impl() {
+    return (Ints - ... - 5);
+}
+
+/* First instantiated from: Issue91.cpp:8 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+inline constexpr int fold_minus_impl<0>()
+{
+  return 0 - 5;
+}
+#endif
+
+
+/* First instantiated from: Issue91.cpp:8 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+inline constexpr int fold_minus_impl<0, 0>()
+{
+  return 0 - (0 - 5);
+}
+#endif
+
+
+template<int... Ints>
+constexpr int fold_minus() {
+    return fold_minus_impl<0, Ints...>();
+}
+
+/* First instantiated from: Issue91.cpp:11 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+inline constexpr int fold_minus<>()
+{
+  return fold_minus_impl<0>();
+}
+#endif
+
+
+/* First instantiated from: Issue91.cpp:16 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+inline constexpr int fold_minus<0>()
+{
+  return fold_minus_impl<0, 0>();
+}
+#endif
+
+
+/* PASSED: static_assert(fold_minus() == -5); */
+
+
+template <int b>
+class print_int;
+
+int i = fold_minus<0>();
+
+/* PASSED: static_assert(fold_minus<0>() == 5); */
+
+/* PASSED: static_assert(0 - 0 - 5 == -5); */
+
+
+//print_int<fold_minus<0>()> p;

--- a/tests/VariadicTemplateRightFoldPlusTest.cpp
+++ b/tests/VariadicTemplateRightFoldPlusTest.cpp
@@ -1,0 +1,17 @@
+#define INSIGHTS_USE_TEMPLATE
+
+template<int... Ints>
+constexpr int fold_minus_impl_rf() {
+    return ( 5 - ... - Ints);
+}
+
+static_assert(fold_minus_impl_rf<0>() == 5);
+static_assert(fold_minus_impl_rf<0,1>() == 4);
+
+template<int... Ints>
+constexpr int fold_negative_minus_impl_rf() {
+    return ( -5 - ... - Ints);
+}
+
+static_assert(fold_negative_minus_impl_rf<0>() == -5);
+static_assert(fold_negative_minus_impl_rf<0,1>() == -6);

--- a/tests/VariadicTemplateRightFoldPlusTest.expect
+++ b/tests/VariadicTemplateRightFoldPlusTest.expect
@@ -1,0 +1,61 @@
+#define INSIGHTS_USE_TEMPLATE
+
+template<int... Ints>
+constexpr int fold_minus_impl_rf() {
+    return ( 5 - ... - Ints);
+}
+
+/* First instantiated from: VariadicTemplateRightFoldPlusTest.cpp:8 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+inline constexpr int fold_minus_impl_rf<0>()
+{
+  return 5 - 0;
+}
+#endif
+
+
+/* First instantiated from: VariadicTemplateRightFoldPlusTest.cpp:9 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+inline constexpr int fold_minus_impl_rf<0, 1>()
+{
+  return 5 - 0 - 1;
+}
+#endif
+
+
+/* PASSED: static_assert(fold_minus_impl_rf<0>() == 5); */
+
+/* PASSED: static_assert(fold_minus_impl_rf<0, 1>() == 4); */
+
+
+template<int... Ints>
+constexpr int fold_negative_minus_impl_rf() {
+    return ( -5 - ... - Ints);
+}
+
+/* First instantiated from: VariadicTemplateRightFoldPlusTest.cpp:16 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+inline constexpr int fold_negative_minus_impl_rf<0>()
+{
+  return -5 - 0;
+}
+#endif
+
+
+/* First instantiated from: VariadicTemplateRightFoldPlusTest.cpp:17 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+inline constexpr int fold_negative_minus_impl_rf<0, 1>()
+{
+  return -5 - 0 - 1;
+}
+#endif
+
+
+/* PASSED: static_assert(fold_negative_minus_impl_rf<0>() == -5); */
+
+/* PASSED: static_assert(fold_negative_minus_impl_rf<0, 1>() == -6); */
+


### PR DESCRIPTION
At least in variadic templates with fold expressions the expanded
version does not carry parentheses. For certain operations like `+` and
`-` this leads to wrong results. This fix adds the required parentheses
in the case we have a BinaryOperator and if it is either a `+` or `-`..

See also N4800 [temp.variadic] p10.1 - p10.2.