### PR TITLE
Fixed #45: Support showing for-loops as their while-loop representation.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,6 @@ llvm_current_packages: &all_llvm_current_packages
 matrix:
   include:
 
-    # OSX clang 7 build
-  - env: COMPILER='clang++' COMPILER_CC='clang' LLVM_CONFIG='llvm-config' LLVM_VERSION='7.0.0' COVERAGE='No' STATIC='No' DEBUG='No' UPLOAD='No' SKIP_TESTS='Yes' TIDY='No' SHACMD='shasum -a 256'
-    os: osx
-    osx_image: xcode9.3
-    compiler: clang
-
     # OSX clang 8 build
   - env: COMPILER='clang++' COMPILER_CC='clang' LLVM_CONFIG='llvm-config' LLVM_VERSION='8.0.0' COVERAGE='No' STATIC='No' DEBUG='No' UPLOAD='Yes' SKIP_TESTS='No' TIDY='No' SHACMD='shasum -a 256'
     os: osx
@@ -81,19 +75,6 @@ matrix:
           key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
     env: COMPILER='g++-8' COMPILER_CC='gcc-8' LLVM_CONFIG='/usr/bin/llvm-config-8' COVERAGE='No' STATIC='No' DEBUG='No' TIDY='No'
 
-  # Debug build with coverage
-  - os: linux
-    compiler: gcc
-    addons:
-      apt:
-        sources: *all_sources
-        packages:
-        - g++-7
-        - libstdc++-6-dev
-        - *all_llvm_current_packages
-        - lcov
-    env: COMPILER='g++-7' COMPILER_CC='gcc-7' LLVM_CONFIG=${LLVM_CONFIG_CURRENT} COVERAGE='Yes' STATIC='No' DEBUG='Yes' TIDY='No'
-
   # Clang-tidy analysis
   - os: linux
     compiler: gcc
@@ -106,10 +87,10 @@ matrix:
     addons: *clang80
     env: COMPILER='g++-8' COMPILER_CC='gcc-8' LLVM_CONFIG='/usr/bin/llvm-config-8' COVERAGE='No' STATIC='No' DEBUG='No' TIDY='No' CFORMAT='Yes' CFORMAT_NAME='clang-format-8'
 
-    # Linux Clang Coverage Build
+  # Debug build with coverage
   - os: linux
     compiler: gcc
-    addons:
+    addons: &covcurrent
       apt:
         sources: *all_sources
         packages:
@@ -117,6 +98,12 @@ matrix:
         - libstdc++-6-dev
         - *all_llvm_current_packages
         - lcov
+    env: COMPILER='g++-7' COMPILER_CC='gcc-7' LLVM_CONFIG=${LLVM_CONFIG_CURRENT} COVERAGE='Yes' STATIC='No' DEBUG='Yes' TIDY='No'
+
+    # Linux Clang Coverage Build
+  - os: linux
+    compiler: gcc
+    addons: *covcurrent
     env: COMPILER='g++-7' COMPILER_CC='gcc-7' LLVM_CONFIG=${LLVM_CONFIG_CURRENT} STATIC='No' COVERAGE='Yes' DEBUG='No' TIDY='No'
 
 install:

--- a/Insights.cpp
+++ b/Insights.cpp
@@ -28,6 +28,7 @@
 #include "CompilerGeneratedHandler.h"
 #include "FunctionDeclHandler.h"
 #include "GlobalVariableHandler.h"
+#include "Insights.h"
 #include "StaticAssertHandler.h"
 #include "TemplateHandler.h"
 #include "version.h"
@@ -38,6 +39,15 @@ using namespace clang::ast_matchers;
 using namespace clang::driver;
 using namespace clang::tooling;
 using namespace clang::insights;
+//-----------------------------------------------------------------------------
+
+static InsightsOptions gInsightsOptions{};
+//-----------------------------------------------------------------------------
+
+const InsightsOptions& GetInsightsOptions()
+{
+    return gInsightsOptions;
+}
 //-----------------------------------------------------------------------------
 
 static llvm::cl::OptionCategory gInsightCategory("Insights");
@@ -51,6 +61,18 @@ static llvm::cl::opt<bool> gStdinMode("stdin",
                                                      "used for editor integration."),
                                       llvm::cl::init(false),
                                       llvm::cl::cat(gInsightCategory));
+//-----------------------------------------------------------------------------
+
+#define INSIGHTS_OPT(option, name, deflt, description)                                                                 \
+    static llvm::cl::opt<bool, true> g##name(option,                                                                   \
+                                             llvm::cl::desc(description),                                              \
+                                             llvm::cl::NotHidden,                                                      \
+                                             llvm::cl::location(gInsightsOptions.name),                                \
+                                             llvm::cl::init(deflt),                                                    \
+                                             llvm::cl::cat(gInsightCategory));
+//-----------------------------------------------------------------------------
+
+#include "InsightsOptions.def"
 //-----------------------------------------------------------------------------
 
 class CppInsightASTConsumer final : public ASTConsumer
@@ -71,6 +93,7 @@ public:
 
     void HandleTranslationUnit(ASTContext& context) override
     {
+        gAST = &context;
         mMatcher.matchAST(context);
 
         // Check whether we had static local variables which we transformed. Then for the placement-new we need to

--- a/Insights.cpp
+++ b/Insights.cpp
@@ -75,6 +75,13 @@ static llvm::cl::opt<bool> gStdinMode("stdin",
 #include "InsightsOptions.def"
 //-----------------------------------------------------------------------------
 
+static const ASTContext* gAST{};
+const ASTContext&        GetGlobalAST()
+{
+    return *gAST;
+}
+//-----------------------------------------------------------------------------
+
 class CppInsightASTConsumer final : public ASTConsumer
 {
 public:

--- a/Insights.h
+++ b/Insights.h
@@ -9,6 +9,9 @@
 #define INSIGHTS_H
 //-----------------------------------------------------------------------------
 
+#include "clang/AST/ASTContext.h"
+//-----------------------------------------------------------------------------
+
 /// \brief Global C++ Insights command line options.
 struct InsightsOptions
 {
@@ -18,7 +21,11 @@ struct InsightsOptions
 //-----------------------------------------------------------------------------
 
 /// \brief Get the global C++ Insights options.
-const InsightsOptions& GetInsightsOptions();
+extern const InsightsOptions& GetInsightsOptions();
+//-----------------------------------------------------------------------------
+
+/// \brief Get access to the ASTContext
+extern const clang::ASTContext& GetGlobalAST();
 //-----------------------------------------------------------------------------
 
 #endif /* INSIGHTS_H */

--- a/Insights.h
+++ b/Insights.h
@@ -1,0 +1,24 @@
+///////////////////////////////////////////////////////////////////////////////
+//
+// C++ Insights, copyright (C) by Andreas Fertig
+// Distributed under an MIT license. See LICENSE for details
+//
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef INSIGHTS_H
+#define INSIGHTS_H
+//-----------------------------------------------------------------------------
+
+/// \brief Global C++ Insights command line options.
+struct InsightsOptions
+{
+#define INSIGHTS_OPT(opt, name, deflt, description) bool name;
+#include "InsightsOptions.def"
+};
+//-----------------------------------------------------------------------------
+
+/// \brief Get the global C++ Insights options.
+const InsightsOptions& GetInsightsOptions();
+//-----------------------------------------------------------------------------
+
+#endif /* INSIGHTS_H */

--- a/InsightsOptions.def
+++ b/InsightsOptions.def
@@ -10,4 +10,6 @@
 #define INSIGHTS_OPT(opt, name, deflt, description)
 #endif
 
+INSIGHTS_OPT("alt-syntax-for", UseAltForSyntax, false, "Transform all for-loops into their equivalent while-loop.")
+
 #undef INSIGHTS_OPT

--- a/InsightsOptions.def
+++ b/InsightsOptions.def
@@ -1,0 +1,13 @@
+///////////////////////////////////////////////////////////////////////////////
+//
+// C++ Insights, copyright (C) by Andreas Fertig
+// Distributed under an MIT license. See LICENSE for details
+//
+///////////////////////////////////////////////////////////////////////////////
+
+/// \brief C++ Insights options definition
+#ifndef INSIGHTS_OPT
+#define INSIGHTS_OPT(opt, name, deflt, description)
+#endif
+
+#undef INSIGHTS_OPT

--- a/OutputFormatHelper.cpp
+++ b/OutputFormatHelper.cpp
@@ -73,16 +73,4 @@ void OutputFormatHelper::RemoveIndent()
 }
 //-----------------------------------------------------------------------------
 
-void OutputFormatHelper::RemoveIndentIncludingLastNewLine()
-{
-
-    while('\n' != mOutput.back()) {
-        RemoveIndent();
-    }
-
-    mOutput.pop_back();
-    mOutput += ' ';
-}
-//-----------------------------------------------------------------------------
-
 }  // namespace clang::insights

--- a/OutputFormatHelper.h
+++ b/OutputFormatHelper.h
@@ -57,8 +57,6 @@ public:
         }
     }
 
-    void RemoveIndentIncludingLastNewLine();
-
     /// \brief Check whether the buffer is empty.
     ///
     /// This also treats a string of just whitespaces as empty.

--- a/tests/ForStmtMultipleInitsTest.cpp
+++ b/tests/ForStmtMultipleInitsTest.cpp
@@ -1,0 +1,13 @@
+int main()
+{
+    int x = 0;
+
+    for(int i = 0, y=2, t=4, o=5; i < 20; ++i) {
+        x += i;
+    }
+
+    for(int *i = &x, *y=&x , *z=&x; i ; ++i) {
+        x += *i;
+    }
+}
+

--- a/tests/ForStmtMultipleInitsTest.expect
+++ b/tests/ForStmtMultipleInitsTest.expect
@@ -1,0 +1,16 @@
+int main()
+{
+  int x = 0;
+  for(int i = 0, y = 2, t = 4, o = 5; i < 20; ++i) 
+  {
+    x += i;
+  }
+  
+  for(int * i = &x, *y = &x, *z = &x; i; ++i) 
+  {
+    x += *i;
+  }
+  
+}
+
+

--- a/tests/ForStmtWithLambdaInInitTest.cpp
+++ b/tests/ForStmtWithLambdaInInitTest.cpp
@@ -1,0 +1,25 @@
+#include <cstdio>
+
+int main()
+{
+    int x = 0;
+
+    for(int i = [&]{ return x*2; }(); i < 20; ++i) {
+        x += i;
+    }
+
+    for(int i = [&]{ return x*2; }(), z = [&]{ return x*2; }(); i < 20; ++i) {
+        x += i;
+    }
+
+    for([]{printf("started\n");}(); [&]{ return --x; }(); []{printf("after\n");}())
+    {}
+
+
+    for([]{printf("started\n");}(),
+        []{printf("started\n");}(); [&]{ return --x; }(); []{printf("after\n");}())
+    {}
+    
+}
+
+

--- a/tests/ForStmtWithLambdaInInitTest.expect
+++ b/tests/ForStmtWithLambdaInInitTest.expect
@@ -1,0 +1,212 @@
+#include <cstdio>
+
+int main()
+{
+  int x = 0;
+      
+  class __lambda_7_17
+  {
+    int & x;
+    public: inline /*constexpr */ int operator()() const
+    {
+      return x * 2;
+    }
+    
+    public: __lambda_7_17(int & _x)
+    : x{_x}
+    {}
+    
+  } __lambda_7_17{x};
+  
+  for(int i = __lambda_7_17.operator()(); i < 20; ++i) 
+  {
+    x += i;
+  }
+  
+      
+  class __lambda_11_17
+  {
+    int & x;
+    public: inline /*constexpr */ int operator()() const
+    {
+      return x * 2;
+    }
+    
+    public: __lambda_11_17(int & _x)
+    : x{_x}
+    {}
+    
+  } __lambda_11_17{x};
+  
+    
+  class __lambda_11_43
+  {
+    int & x;
+    public: inline /*constexpr */ int operator()() const
+    {
+      return x * 2;
+    }
+    
+    public: __lambda_11_43(int & _x)
+    : x{_x}
+    {}
+    
+  } __lambda_11_43{x};
+  
+  for(int i = __lambda_11_17.operator()(), z = __lambda_11_43.operator()(); i < 20; ++i) 
+  {
+    x += i;
+  }
+  
+      
+  class __lambda_15_9
+  {
+    public: inline /*constexpr */ void operator()() const
+    {
+      printf("started\n");
+    }
+    
+    public: using retType_15_9 = auto (*)() -> void;
+    inline /*constexpr */ operator retType_15_9 () const
+    {
+      return __invoke;
+    };
+    
+    private: static inline void __invoke()
+    {
+      printf("started\n");
+    }
+    
+    
+  } __lambda_15_9{};
+  
+    
+  class __lambda_15_37
+  {
+    int & x;
+    public: inline /*constexpr */ int operator()() const
+    {
+      return --x;
+    }
+    
+    public: __lambda_15_37(int & _x)
+    : x{_x}
+    {}
+    
+  } __lambda_15_37{x};
+  
+    
+  class __lambda_15_59
+  {
+    public: inline /*constexpr */ void operator()() const
+    {
+      printf("after\n");
+    }
+    
+    public: using retType_15_59 = auto (*)() -> void;
+    inline /*constexpr */ operator retType_15_59 () const
+    {
+      return __invoke;
+    };
+    
+    private: static inline void __invoke()
+    {
+      printf("after\n");
+    }
+    
+    
+  } __lambda_15_59{};
+  
+  for(__lambda_15_9.operator()(); static_cast<bool>(__lambda_15_37.operator()()); __lambda_15_59.operator()()) 
+  {
+  }
+  
+      
+  class __lambda_19_9
+  {
+    public: inline /*constexpr */ void operator()() const
+    {
+      printf("started\n");
+    }
+    
+    public: using retType_19_9 = auto (*)() -> void;
+    inline /*constexpr */ operator retType_19_9 () const
+    {
+      return __invoke;
+    };
+    
+    private: static inline void __invoke()
+    {
+      printf("started\n");
+    }
+    
+    
+  } __lambda_19_9{};
+  
+    
+  class __lambda_20_9
+  {
+    public: inline /*constexpr */ void operator()() const
+    {
+      printf("started\n");
+    }
+    
+    public: using retType_20_9 = auto (*)() -> void;
+    inline /*constexpr */ operator retType_20_9 () const
+    {
+      return __invoke;
+    };
+    
+    private: static inline void __invoke()
+    {
+      printf("started\n");
+    }
+    
+    
+  } __lambda_20_9{};
+  
+    
+  class __lambda_20_37
+  {
+    int & x;
+    public: inline /*constexpr */ int operator()() const
+    {
+      return --x;
+    }
+    
+    public: __lambda_20_37(int & _x)
+    : x{_x}
+    {}
+    
+  } __lambda_20_37{x};
+  
+    
+  class __lambda_20_59
+  {
+    public: inline /*constexpr */ void operator()() const
+    {
+      printf("after\n");
+    }
+    
+    public: using retType_20_59 = auto (*)() -> void;
+    inline /*constexpr */ operator retType_20_59 () const
+    {
+      return __invoke;
+    };
+    
+    private: static inline void __invoke()
+    {
+      printf("after\n");
+    }
+    
+    
+  } __lambda_20_59{};
+  
+  for(__lambda_19_9.operator()() , __lambda_20_9.operator()(); static_cast<bool>(__lambda_20_37.operator()()); __lambda_20_59.operator()()) 
+  {
+  }
+  
+}
+
+
+

--- a/tests/ForStmtWithRefVarDeclTest.cpp
+++ b/tests/ForStmtWithRefVarDeclTest.cpp
@@ -1,0 +1,7 @@
+// cmdlineinsights:-alt-syntax-for
+int main()
+{
+    int x{};
+    
+    for(int& z=x, &y=z; true;) {}
+}

--- a/tests/ForStmtWithRefVarDeclTest.expect
+++ b/tests/ForStmtWithRefVarDeclTest.expect
@@ -1,0 +1,14 @@
+// cmdlineinsights:-alt-syntax-for
+int main()
+{
+  int x = {};
+  {
+    int & z = x;
+    int & y = z;
+    while(true) {
+    }
+    
+  }
+  
+}
+

--- a/tests/Issue116.expect
+++ b/tests/Issue116.expect
@@ -10,13 +10,13 @@ int main()
     std::unordered_map<std::basic_string<char>, std::basic_string<char>, std::hash<std::basic_string<char> >, std::equal_to<std::basic_string<char> >, std::allocator<std::pair<const std::basic_string<char>, std::basic_string<char> > > > & __range1 = m;
     std::__hash_map_iterator<std::__hash_iterator<std::__hash_node<std::__hash_value_type<std::basic_string<char>, std::basic_string<char> >, void *> *> > __begin1 = __range1.begin();
     std::__hash_map_iterator<std::__hash_iterator<std::__hash_node<std::__hash_value_type<std::basic_string<char>, std::basic_string<char> >, void *> *> > __end1 = __range1.end();
-    
-    for( ; operator!=(__begin1, __end1); __begin1.operator++() )
+    for(; operator!=(__begin1, __end1); __begin1.operator++()) 
     {
       std::pair<const std::basic_string<char>, std::basic_string<char> > & __operator9 = __begin1.operator*();
       const std::basic_string<char>& key = std::get<0ul>(__operator9);
       std::basic_string<char>& value = std::get<1ul>(__operator9);
     }
+    
   }
 }
 

--- a/tests/Issue45Example.cpp
+++ b/tests/Issue45Example.cpp
@@ -1,0 +1,28 @@
+int main()
+{
+    int x = 0;
+
+    for(; x < 20; ++x) {
+        x += x;
+    }
+
+    for(int i=0; x < 20; ++x) {
+        x += i;
+    }
+
+    for(int i = 0, y=2, t=4, o=5; i < 20; ++i) {
+        x += i;
+    }
+
+    for(int *i = &x, *y=&x; i ; ++i) {
+        x += *i;
+    }
+
+    for(;;);
+
+
+    char data[5]{};
+    for(auto& x : data) {
+        x = 2;
+    }
+}

--- a/tests/Issue45Example.expect
+++ b/tests/Issue45Example.expect
@@ -1,0 +1,39 @@
+int main()
+{
+  int x = 0;
+  for(; x < 20; ++x) 
+  {
+    x += x;
+  }
+  
+  for(int i = 0; x < 20; ++x) 
+  {
+    x += i;
+  }
+  
+  for(int i = 0, y = 2, t = 4, o = 5; i < 20; ++i) 
+  {
+    x += i;
+  }
+  
+  for(int * i = &x, *y = &x; i; ++i) 
+  {
+    x += *i;
+  }
+  
+  for(; ; ) ;
+  
+  char data[5] = {'\0', '\0', '\0', '\0', '\0'};
+  {
+    char (&__range1)[5] = data;
+    char * __begin1 = __range1;
+    char * __end1 = __range1 + 5l;
+    for(; __begin1 != __end1; ++__begin1) 
+    {
+      char & x = *__begin1;
+      x = 2;
+    }
+    
+  }
+}
+

--- a/tests/Issue45Example11.cpp
+++ b/tests/Issue45Example11.cpp
@@ -1,0 +1,29 @@
+// cmdline:-std=c++11
+int main()
+{
+    int x = 0;
+
+    for(; x < 20; ++x) {
+        x += x;
+    }
+
+    for(int i=0; x < 20; ++x) {
+        x += i;
+    }
+
+    for(int i = 0, y=2, t=4, o=5; i < 20; ++i) {
+        x += i;
+    }
+
+    for(int *i = &x, *y=&x; i ; ++i) {
+        x += *i;
+    }
+
+    for(;;);
+
+
+    char data[5]{};
+    for(auto& x : data) {
+        x = 2;
+    }
+}

--- a/tests/Issue45Example11.expect
+++ b/tests/Issue45Example11.expect
@@ -1,0 +1,38 @@
+// cmdline:-std=c++11
+int main()
+{
+  int x = 0;
+  for(; x < 20; ++x) 
+  {
+    x += x;
+  }
+  
+  for(int i = 0; x < 20; ++x) 
+  {
+    x += i;
+  }
+  
+  for(int i = 0, y = 2, t = 4, o = 5; i < 20; ++i) 
+  {
+    x += i;
+  }
+  
+  for(int * i = &x, *y = &x; i; ++i) 
+  {
+    x += *i;
+  }
+  
+  for(; ; ) ;
+  
+  char data[5] = {'\0', '\0', '\0', '\0', '\0'};
+  {
+    char (&__range1)[5] = data;
+    for(char * __begin1 = __range1, *__end1 = __range1 + 5l; __begin1 != __end1; ++__begin1) 
+    {
+      char & x = *__begin1;
+      x = 2;
+    }
+    
+  }
+}
+

--- a/tests/Issue45ExampleFor2While.cpp
+++ b/tests/Issue45ExampleFor2While.cpp
@@ -1,0 +1,29 @@
+// cmdlineinsights:-alt-syntax-for
+int main()
+{
+    int x = 0;
+
+    for(; x < 20; ++x) {
+        x += x;
+    }
+
+    for(int i=0; x < 20; ++x) {
+        x += i;
+    }
+
+    for(int i = 0, y=2, t=4, o=5; i < 20; ++i) {
+        x += i;
+    }
+
+    for(int *i = &x, *y=&x; i ; ++i) {
+        x += *i;
+    }
+
+    for(;;);
+
+
+    char data[5]{};
+    for(auto& x : data) {
+        x = 2;
+    }
+}

--- a/tests/Issue45ExampleFor2While.expect
+++ b/tests/Issue45ExampleFor2While.expect
@@ -1,0 +1,66 @@
+// cmdlineinsights:-alt-syntax-for
+int main()
+{
+  int x = 0;
+  {
+    while(x < 20) {
+      x += x;
+      ++x;
+    }
+    
+  }
+  
+  {
+    int i = 0;
+    while(x < 20) {
+      x += i;
+      ++x;
+    }
+    
+  }
+  
+  {
+    int i = 0;
+    int y = 2;
+    int t = 4;
+    int o = 5;
+    while(i < 20) {
+      x += i;
+      ++i;
+    }
+    
+  }
+  
+  {
+    int * i = &x;
+    int * y = &x;
+    while(i) {
+      x += *i;
+      ++i;
+    }
+    
+  }
+  
+  {
+    while(true) {
+    }
+    
+  }
+  
+  char data[5] = {'\0', '\0', '\0', '\0', '\0'};
+  {
+    char (&__range1)[5] = data;
+    char * __begin1 = __range1;
+    char * __end1 = __range1 + 5l;
+    {
+      while(__begin1 != __end1) {
+        char & x = *__begin1;
+        x = 2;
+        ++__begin1;
+      }
+      
+    }
+    
+  }
+}
+

--- a/tests/LambdaHandler9Test.expect
+++ b/tests/LambdaHandler9Test.expect
@@ -12,12 +12,12 @@ int main()
         char volatile (&__range1)[10] = buffer;
         volatile char * __begin1 = __range1;
         volatile char * __end1 = __range1 + 10l;
-        
-        for( ; __begin1 != __end1; ++__begin1 )
+        for(; __begin1 != __end1; ++__begin1) 
         {
           volatile char & c = *__begin1;
           c = 1;
         }
+        
       }
     }
     

--- a/tests/LambdaInVarDeclTest.expect
+++ b/tests/LambdaInVarDeclTest.expect
@@ -5,8 +5,7 @@ int main()
     char (&__range1)[4] = buffer;
     char * __begin1 = __range1;
     char * __end1 = __range1 + 4l;
-    
-    for( ; __begin1 != __end1; ++__begin1 )
+    for(; __begin1 != __end1; ++__begin1) 
     {
       char & c = *__begin1;
                   
@@ -26,6 +25,7 @@ int main()
       
       int x = static_cast<int>(__lambda_6_17.operator()());
     }
+    
   }
 }
 

--- a/tests/RangeForStmtHandler2Test.expect
+++ b/tests/RangeForStmtHandler2Test.expect
@@ -10,35 +10,32 @@ int main()
     char (&__range1)[10] = arr;
     char * __begin1 = __range1;
     char * __end1 = __range1 + 10l;
-    
-    for( ; __begin1 != __end1; ++__begin1 )
+    for(; __begin1 != __end1; ++__begin1) 
     {
       char c = *__begin1;
-      ;
     }
+    
   }
   std::vector<int> v = std::vector<int, std::allocator<int> >{std::initializer_list<int>{1, 2, 3, 5}};
   {
     std::vector<int, std::allocator<int> > & __range1 = v;
     std::__wrap_iter<int *> __begin1 = __range1.begin();
     std::__wrap_iter<int *> __end1 = __range1.end();
-    
-    for( ; std::operator!=(__begin1, __end1); __begin1.operator++() )
+    for(; std::operator!=(__begin1, __end1); __begin1.operator++()) 
     {
       int & vv = __begin1.operator*();
-      ;
     }
+    
   }
   {
     std::vector<int, std::allocator<int> > & __range1 = v;
     std::__wrap_iter<int *> __begin1 = __range1.begin();
     std::__wrap_iter<int *> __end1 = __range1.end();
-    
-    for( ; std::operator!=(__begin1, __end1); __begin1.operator++() )
+    for(; std::operator!=(__begin1, __end1); __begin1.operator++()) 
     {
       int & vv = __begin1.operator*();
-      ;
     }
+    
   }
 }
 

--- a/tests/RangeForStmtHandler2_11Test.expect
+++ b/tests/RangeForStmtHandler2_11Test.expect
@@ -8,34 +8,28 @@ int main()
   char arr[10] = {2, 4, 6, 8, 10, 12, 14, 16, 18, 20};
   {
     char (&__range1)[10] = arr;
-    
-    for( char * __begin1 = __range1, *__end1 = __range1 + 10l;
-    __begin1 != __end1; ++__begin1 )
+    for(char * __begin1 = __range1, *__end1 = __range1 + 10l; __begin1 != __end1; ++__begin1) 
     {
       char c = *__begin1;
-      ;
     }
+    
   }
   std::vector<int> v = std::vector<int, std::allocator<int> >{std::initializer_list<int>{1, 2, 3, 5}};
   {
     std::vector<int, std::allocator<int> > & __range1 = v;
-    
-    for( std::__wrap_iter<int *> __begin1 = std::__wrap_iter<int *>(__range1.begin()), __end1 = std::__wrap_iter<int *>(__range1.end());
-    std::operator!=(__begin1, __end1); __begin1.operator++() )
+    for(std::__wrap_iter<int *> __begin1 = std::__wrap_iter<int *>(__range1.begin()), __end1 = std::__wrap_iter<int *>(__range1.end()); std::operator!=(__begin1, __end1); __begin1.operator++()) 
     {
       int & vv = __begin1.operator*();
-      ;
     }
+    
   }
   {
     std::vector<int, std::allocator<int> > & __range1 = v;
-    
-    for( std::__wrap_iter<int *> __begin1 = std::__wrap_iter<int *>(__range1.begin()), __end1 = std::__wrap_iter<int *>(__range1.end());
-    std::operator!=(__begin1, __end1); __begin1.operator++() )
+    for(std::__wrap_iter<int *> __begin1 = std::__wrap_iter<int *>(__range1.begin()), __end1 = std::__wrap_iter<int *>(__range1.end()); std::operator!=(__begin1, __end1); __begin1.operator++()) 
     {
       int & vv = __begin1.operator*();
-      ;
     }
+    
   }
 }
 

--- a/tests/RangeForStmtHandler3Test.expect
+++ b/tests/RangeForStmtHandler3Test.expect
@@ -100,12 +100,12 @@ int main()
     str_view<char> && __range1 = str_view<char>{"hello world\n"};
     const char * __begin1 = __range1.begin();
     null_sentinal_t __end1 = __range1.end();
-    
-    for( ; operator!=(__begin1, null_sentinal_t(__end1)); ++__begin1 )
+    for(; operator!=(__begin1, null_sentinal_t(__end1)); ++__begin1) 
     {
       char c = *__begin1;
       std::operator<<(std::cout, c);
     }
+    
   }
 }
 

--- a/tests/RangeForStmtHandler4Test.expect
+++ b/tests/RangeForStmtHandler4Test.expect
@@ -46,11 +46,11 @@ int main()
     MyArrayWrapper<int> & __range1 = arr;
     int * __begin1 = __range1.begin();
     int * __end1 = __range1.end();
-    
-    for( ; __begin1 != __end1; ++__begin1 )
+    for(; __begin1 != __end1; ++__begin1) 
     {
       int i = *__begin1;
     }
+    
   }
 }
 

--- a/tests/RangeForStmtHandler5Test.expect
+++ b/tests/RangeForStmtHandler5Test.expect
@@ -27,11 +27,11 @@ int main()
     MyArrayWrapper & __range1 = arr;
     int * __begin1 = __range1.begin();
     int * __end1 = __range1.end();
-    
-    for( ; __begin1 != __end1; ++__begin1 )
+    for(; __begin1 != __end1; ++__begin1) 
     {
       int i = *__begin1;
     }
+    
   }
 }
 

--- a/tests/RangeForStmtHandler7Test.expect
+++ b/tests/RangeForStmtHandler7Test.expect
@@ -8,34 +8,28 @@ int main()
   char arr[10] = {2, 4, 6, 8, 10, 12, 14, 16, 18, 20};
   {
     char (&__range1)[10] = arr;
-    
-    for( char * __begin1 = __range1, *__end1 = __range1 + 10l;
-    __begin1 != __end1; ++__begin1 )
+    for(char * __begin1 = __range1, *__end1 = __range1 + 10l; __begin1 != __end1; ++__begin1) 
     {
       char c = *__begin1;
-      ;
     }
+    
   }
   std::vector<int> v = std::vector<int, std::allocator<int> >{std::initializer_list<int>{1, 2, 3, 5}};
   {
     std::vector<int, std::allocator<int> > & __range1 = v;
-    
-    for( std::__wrap_iter<int *> __begin1 = std::__wrap_iter<int *>(__range1.begin()), __end1 = std::__wrap_iter<int *>(__range1.end());
-    std::operator!=(__begin1, __end1); __begin1.operator++() )
+    for(std::__wrap_iter<int *> __begin1 = std::__wrap_iter<int *>(__range1.begin()), __end1 = std::__wrap_iter<int *>(__range1.end()); std::operator!=(__begin1, __end1); __begin1.operator++()) 
     {
       int & vv = __begin1.operator*();
-      ;
     }
+    
   }
   {
     std::vector<int, std::allocator<int> > & __range1 = v;
-    
-    for( std::__wrap_iter<int *> __begin1 = std::__wrap_iter<int *>(__range1.begin()), __end1 = std::__wrap_iter<int *>(__range1.end());
-    std::operator!=(__begin1, __end1); __begin1.operator++() )
+    for(std::__wrap_iter<int *> __begin1 = std::__wrap_iter<int *>(__range1.begin()), __end1 = std::__wrap_iter<int *>(__range1.end()); std::operator!=(__begin1, __end1); __begin1.operator++()) 
     {
       int & vv = __begin1.operator*();
-      ;
     }
+    
   }
 }
 

--- a/tests/RangeForStmtHandler8Test.expect
+++ b/tests/RangeForStmtHandler8Test.expect
@@ -49,12 +49,12 @@ int main()
     A & __range1 = a;
     A __begin1 = A(__range1.begin());
     int __end1 = __range1.end();
-    
-    for( ; operator!=(__begin1, __end1); __begin1.operator++() )
+    for(; operator!=(__begin1, __end1); __begin1.operator++()) 
     {
       const int & it = __begin1.operator*();
       std::cout.operator<<(it).operator<<(std::endl);
     }
+    
   }
 }
 

--- a/tests/RangeForStmtHandlerTest.expect
+++ b/tests/RangeForStmtHandlerTest.expect
@@ -103,61 +103,60 @@ int main()
     char (&__range1)[10] = arr;
     char * __begin1 = __range1;
     char * __end1 = __range1 + 10l;
-    
-    for( ; __begin1 != __end1; ++__begin1 )
+    for(; __begin1 != __end1; ++__begin1) 
     {
       char c = *__begin1;
       printf("%#x\n", static_cast<int>(c));
       c++;
       printf("%#x\n", static_cast<int>(c));
     }
+    
   }
   std::vector<int> v = std::vector<int, std::allocator<int> >{std::initializer_list<int>{1, 2, 3, 5}};
   {
     std::vector<int, std::allocator<int> > & __range1 = v;
     std::__wrap_iter<int *> __begin1 = __range1.begin();
     std::__wrap_iter<int *> __end1 = __range1.end();
-    
-    for( ; std::operator!=(__begin1, __end1); __begin1.operator++() )
+    for(; std::operator!=(__begin1, __end1); __begin1.operator++()) 
     {
       int & vv = __begin1.operator*();
       printf("%d\n", vv);
     }
+    
   }
   {
     std::vector<int, std::allocator<int> > & __range1 = v;
     std::__wrap_iter<int *> __begin1 = __range1.begin();
     std::__wrap_iter<int *> __end1 = __range1.end();
-    
-    for( ; std::operator!=(__begin1, __end1); __begin1.operator++() )
+    for(; std::operator!=(__begin1, __end1); __begin1.operator++()) 
     {
       int & v2 = __begin1.operator*();
-      printf("%d\n", v2);
     }
+    
   }
   A a = A();
   {
     A & __range1 = a;
     int * __begin1 = begin(__range1);
     int * __end1 = end(__range1);
-    
-    for( ; __begin1 != __end1; ++__begin1 )
+    for(; __begin1 != __end1; ++__begin1) 
     {
       int it = *__begin1;
       printf("%d\n", it);
     }
+    
   }
   B b = B();
   {
     B & __range1 = b;
     int * __begin1 = __range1.begin();
     int * __end1 = __range1.end();
-    
-    for( ; __begin1 != __end1; ++__begin1 )
+    for(; __begin1 != __end1; ++__begin1) 
     {
       int bit = *__begin1;
       printf("%d\n", bit);
     }
+    
   }
 }
 

--- a/tests/TupeInRangeBasedForTest.expect
+++ b/tests/TupeInRangeBasedForTest.expect
@@ -26,14 +26,14 @@ int main()
     std::vector<std::tuple<std::basic_string<char>, int>, std::allocator<std::tuple<std::basic_string<char>, int> > > & __range1 = tuples;
     std::__wrap_iter<std::tuple<std::basic_string<char>, int> *> __begin1 = __range1.begin();
     std::__wrap_iter<std::tuple<std::basic_string<char>, int> *> __end1 = __range1.end();
-    
-    for( ; std::operator!=(__begin1, __end1); __begin1.operator++() )
+    for(; std::operator!=(__begin1, __end1); __begin1.operator++()) 
     {
       std::tuple<std::basic_string<char>, int> __operator15 = std::tuple<std::basic_string<char>, int>(__begin1.operator*());
       std::basic_string<char>& s = std::get<0ul>(__operator15);
       std::tuple_element<1, std::tuple<std::basic_string<char>, int> >::type& n = std::get<1ul>(__operator15);
       printf("c=%s, n=%d\n", s.c_str(), n);
     }
+    
   }
 }
 

--- a/tests/runTest.py
+++ b/tests/runTest.py
@@ -127,16 +127,23 @@ def main():
 
     defaultIncludeDirs = getDefaultIncludeDirs(args['cxx'])
 
-    regEx = re.compile('.*cmdline:(.*)')
+    regEx         = re.compile('.*cmdline:(.*)')
+    regExInsights = re.compile('.*cmdlineinsights:(.*)')
+
     for f in sorted(cppFiles):
-        fileName   = os.path.splitext(f)[0]
-        expectFile = os.path.join(mypath, fileName + '.expect')
-        cppStd     = defaultCppStd
+        fileName     = os.path.splitext(f)[0]
+        expectFile   = os.path.join(mypath, fileName + '.expect')
+        cppStd       = defaultCppStd
+        insightsOpts = ''
 
         fileHeader = open(f, 'r').readline().strip()
         m = regEx.match(fileHeader)
         if None != m:
             cppStd = m.group(1)
+
+        m = regExInsights.match(fileHeader)
+        if None != m:
+            insightsOpts = m.group(1)
 
         if not os.path.isfile(expectFile):
             print 'Missing expect for: %s' %(f)
@@ -149,7 +156,12 @@ def main():
                 p   = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
                 stdout, stderr = p.communicate(input=data)
         else:
-                cmd   = [insightsPath, f, '--', cppStd, '-m64'] + defaultIncludeDirs
+#                cmd   = [insightsPath, f, '-for2while', '--', cppStd, '-m64'] + defaultIncludeDirs
+                if '' == insightsOpts:
+                    cmd   = [insightsPath, f, '--', cppStd, '-m64'] + defaultIncludeDirs
+                else:
+                    cmd   = [insightsPath, f, insightsOpts, '--', cppStd, '-m64'] + defaultIncludeDirs
+
                 begin = datetime.datetime.now()
                 p   = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
                 end   = datetime.datetime.now()


### PR DESCRIPTION
As requested in #45 this patch adds an option to let C++ Insights
transform for-loops (including range-based for-loops) into their
equivalent while-loop representation. This behavior is enabled by a 
new command line option `-alt-syntax-for` which needs to be passed 
to `insights` directly ) before the `--`.