### PR TITLE
Fixed #44: Support alternative representation for a subscription expression.

### DIFF
--- a/CodeGenerator.cpp
+++ b/CodeGenerator.cpp
@@ -934,11 +934,21 @@ void CodeGenerator::InsertArg(const ArrayInitIndexExpr* stmt)
 
 void CodeGenerator::InsertArg(const ArraySubscriptExpr* stmt)
 {
-    InsertArg(stmt->getLHS());
+    if((not GetInsightsOptions().UseAltArraySubscriptionSyntax) || stmt->getLHS()->isLValue()) {
+        InsertArg(stmt->getLHS());
 
-    mOutputFormatHelper.Append('[');
-    InsertArg(stmt->getRHS());
-    mOutputFormatHelper.Append(']');
+        mOutputFormatHelper.Append('[');
+        InsertArg(stmt->getRHS());
+        mOutputFormatHelper.Append(']');
+    } else {
+
+        mOutputFormatHelper.Append("(*(");
+        InsertArg(stmt->getLHS());
+        mOutputFormatHelper.Append(" + ");
+
+        InsertArg(stmt->getRHS());
+        mOutputFormatHelper.Append("))");
+    }
 }
 //-----------------------------------------------------------------------------
 

--- a/InsightsOptions.def
+++ b/InsightsOptions.def
@@ -11,5 +11,9 @@
 #endif
 
 INSIGHTS_OPT("alt-syntax-for", UseAltForSyntax, false, "Transform all for-loops into their equivalent while-loop.")
+INSIGHTS_OPT("alt-syntax-subscription",
+             UseAltArraySubscriptionSyntax,
+             false,
+             "Transform array subscriptions E1[E2] into (*(E1 + E2)).")
 
 #undef INSIGHTS_OPT

--- a/tests/Issue44.cpp
+++ b/tests/Issue44.cpp
@@ -1,0 +1,11 @@
+// cmdlineinsights:-alt-syntax-subscription
+int main()
+{
+    int E1[2]{ 0, 2 };
+
+    #define E2 1
+
+        
+    E1[E2] = 1;
+}
+

--- a/tests/Issue44.expect
+++ b/tests/Issue44.expect
@@ -1,0 +1,8 @@
+// cmdlineinsights:-alt-syntax-subscription
+int main()
+{
+  int E1[2] = {0, 2};
+  (*(E1 + 1)) = 1;
+}
+
+


### PR DESCRIPTION
Subscriptions `E1[E2]` can also be written in the form `*(E1 = E2)`.
This patch adds a command line option (`-alt-syntax-subscription`) 
to select this transformation.