### PR TITLE
Fixed auto generation of release info.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -123,7 +123,9 @@ install:
 
     mkdir current
     tar -xJf $HOME/Library/Caches/Homebrew/clang+llvm-${LLVM_VERSION}-x86_64-apple-darwin.tar.xz -C current --strip-components 1
-  elif [[ "${DEPLOY}" == "Yes" ]]; then
+  fi
+- |
+  if [[ "${UPLOAD}" = "Yes" ]]; then
     npm install github-release-notes -g
   fi
     


### PR DESCRIPTION
The macos build also needs to install gren.