### PR TITLE
Fixed #161: Show single-line body of for or range-based for loops.

### DIFF
--- a/CodeGenerator.cpp
+++ b/CodeGenerator.cpp
@@ -151,6 +151,8 @@ static void AddBodyStmts(std::vector<Stmt*>& v, Stmt* body)
         for(auto* st : b->children()) {
             v.push_back(st);
         }
+    } else if(not isa<NullStmt>(body)) {
+        v.push_back(body);
     }
 }
 //-----------------------------------------------------------------------------

--- a/tests/Issue161.cpp
+++ b/tests/Issue161.cpp
@@ -1,0 +1,8 @@
+#include <iostream>
+
+int main(int argc, char** argv)
+{
+    char arr[10]{2,4,6,8};
+    for (auto i : arr)
+        std::cout << i << " ";
+}

--- a/tests/Issue161.expect
+++ b/tests/Issue161.expect
@@ -1,0 +1,18 @@
+#include <iostream>
+
+int main(int argc, char ** argv)
+{
+  char arr[10] = {2, 4, 6, 8, '\0', '\0', '\0', '\0', '\0', '\0'};
+  {
+    char (&__range1)[10] = arr;
+    char * __begin1 = __range1;
+    char * __end1 = __range1 + 10l;
+    for(; __begin1 != __end1; ++__begin1) 
+    {
+      char i = *__begin1;
+      std::operator<<(std::operator<<(std::cout, i), " ");
+    }
+    
+  }
+}
+

--- a/tests/RangeForStmtHandlerTest.expect
+++ b/tests/RangeForStmtHandlerTest.expect
@@ -131,6 +131,7 @@ int main()
     for(; std::operator!=(__begin1, __end1); __begin1.operator++()) 
     {
       int & v2 = __begin1.operator*();
+      printf("%d\n", v2);
     }
     
   }


### PR DESCRIPTION
Some of the recent changes dropped support for single-line range-based
or traditional for-loops. Only `CompoundStmt`s haven been considered.