### PR TITLE
Simplified DecompositionDecl handling.

### DIFF
--- a/CodeGenerator.h
+++ b/CodeGenerator.h
@@ -246,22 +246,6 @@ protected:
 };
 //-----------------------------------------------------------------------------
 
-class StructuredBindingsCodeGenerator final : public CodeGenerator
-{
-    const std::string& mVarName;
-
-public:
-    StructuredBindingsCodeGenerator(OutputFormatHelper& _outputFormatHelper, const std::string& varName)
-    : CodeGenerator{_outputFormatHelper}
-    , mVarName{varName}
-    {
-    }
-
-    using CodeGenerator::InsertArg;
-    void InsertArg(const DeclRefExpr* stmt) override;
-};
-//-----------------------------------------------------------------------------
-
 class LambdaCodeGenerator final : public CodeGenerator
 {
 public:

--- a/CodeGeneratorTypes.h
+++ b/CodeGeneratorTypes.h
@@ -20,7 +20,6 @@ IGNORED_STMT(OMPParallelForDirective)
 IGNORED_DECL(UsingShadowDecl)
 IGNORED_DECL(UsingPackDecl)
 
-SUPPORTED_DECL(DecompositionDecl)
 SUPPORTED_DECL(VarDecl)
 SUPPORTED_DECL(TypeAliasDecl)
 SUPPORTED_DECL(TypedefDecl)

--- a/Insights.cpp
+++ b/Insights.cpp
@@ -21,6 +21,8 @@
 #include "llvm/Support/Signals.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include "DPrint.h"
+
 #include "CodeGenerator.h"
 #include "CompilerGeneratedHandler.h"
 #include "DPrint.h"


### PR DESCRIPTION
Let VarDecl do the init stuff and only insert the BindingDecls as a
specialty.