### PR TITLE
[gitpod] Locate build folder in /workspace to survive workspace restarts

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,6 +3,7 @@ image:
   file: .gitpod/Dockerfile
   # Context is optional, defaults to an empty context
   context: docker
+workspaceLocation: "."
 
 tasks:
-    - command: "cd ~/build && cmake -G Ninja -DINSIGHTS_STATIC=Yes -DINSIGHTS_COVERAGE=No -DINSIGHTS_LLVM_CONFIG=/usr/bin/llvm-config /workspace/cppinsights && echo \"Run: ninja -j2\""
+    - init: "mkdir /workspace/build && cd /workspace/build && cmake -G Ninja -DINSIGHTS_STATIC=Yes -DINSIGHTS_COVERAGE=No -DINSIGHTS_LLVM_CONFIG=/usr/bin/llvm-config /workspace/cppinsights && echo \"Run: ninja -j2\""

--- a/.gitpod/Dockerfile
+++ b/.gitpod/Dockerfile
@@ -32,8 +32,6 @@ WORKDIR $HOME
 # custom Bash prompt
 RUN { echo && echo "PS1='\[\e]0;\u \w\a\]\[\033[01;32m\]\u\[\033[00m\] \[\033[01;34m\]\w\[\033[00m\] \\\$ '" ; } >> .bashrc
 
-RUN mkdir /home/gitpod/build && chown -R gitpod:gitpod /home/gitpod/build
-
 ### Gitpod user (2) ###
 USER gitpod
 # use sudo so that user does not get sudo usage info on (the first) login


### PR DESCRIPTION
Hello! 

Moritz here, I work on Gitpod and I noticed that you configured you build folder to be in `~/home/gitpod/build`. In that location, unfortunately, the contents of that folder will not survive stopping/starting the workspace. 

This PR fixes this by moving the folder to `/workspace/build`. 

Also, this PR changes the workspace-folder in the IDE to be `/workspace` instead of `/workspace/cppinsights`. This way the `build` folder also becomes visible in the IDE's File View.

Also I see that you compile CPP code when the workspace opens. If you wan, this could be done *before* you open a gitpod workspace - just like in CI/CD. If that's something you like, you'd need to configure [the gitpod.io app](https://github.com/apps/gitpod-io) on this repo.

greetings and I hope you find this useful,
  Moritz
