### PR TITLE
Fixed #178, 184: Provide the functions pulled in from a base class via using

### DIFF
--- a/CodeGenerator.h
+++ b/CodeGenerator.h
@@ -154,6 +154,7 @@ protected:
     virtual bool InsertVarDecl() { return true; }
     virtual bool InsertComma() { return false; }
     virtual bool InsertSemi() { return true; }
+    virtual bool InsertNamespace() const { return false; }
 
     void HandleTemplateParameterPack(const ArrayRef<TemplateArgument>& args);
     void HandleCompoundStmt(const CompoundStmt* stmt);
@@ -187,6 +188,9 @@ protected:
 
     void PrintNamespace(const NestedNameSpecifier* namespaceSpecifier);
     void ParseDeclContext(const DeclContext* Ctx);
+
+    STRONG_BOOL(SkipBody);
+    void InsertCXXMethodDecl(const CXXMethodDecl* stmt, SkipBody skipBody);
 
     /// \brief Check whether or not this statement will add curlys or parentheses and add them only if required.
     void InsertCurlysIfRequired(const Stmt* stmt);

--- a/tests/Issue178.cpp
+++ b/tests/Issue178.cpp
@@ -1,0 +1,10 @@
+struct X{
+  int f();
+  int f(int);
+  int f(double);
+};
+
+struct Y:X {
+  int f(float);
+  using X::f;
+};

--- a/tests/Issue184.cpp
+++ b/tests/Issue184.cpp
@@ -1,0 +1,38 @@
+#include <string>
+#include <unordered_set>
+
+class Customer{
+std::string name;
+public:
+Customer(const std::string &n) : name(n){}
+std::string getName()const{return name;}
+};
+
+struct CustomerEq{
+bool operator()(const Customer&c0,const Customer&c1)const{
+return c0.getName() == c1.getName();
+}
+};
+
+struct CustomerHash{
+std::size_t operator()(const Customer& c) const{
+return std::hash<std::string>()(c.getName());
+}
+};
+
+template<typename ... Bases>
+struct ManyParentsWithOperator : Bases...{
+using Bases::operator()...;//C++17
+};
+
+int main()
+{
+    std::unordered_set<Customer, CustomerHash, CustomerEq> set1;
+    std::unordered_set<Customer, ManyParentsWithOperator<CustomerHash, CustomerEq>, ManyParentsWithOperator<CustomerHash, CustomerEq>> set2;
+    std::unordered_set<Customer, ManyParentsWithOperator<CustomerEq, CustomerHash>, ManyParentsWithOperator<CustomerEq, CustomerHash>> set3;
+
+    set1.emplace("Test");
+    set2.emplace("Test");
+    set3.emplace("Test");
+    return 0;
+}

--- a/tests/UsingDecl2Test.cerr
+++ b/tests/UsingDecl2Test.cerr
@@ -1,0 +1,7 @@
+.tmp.cpp:85:63: error: 'protectedMember' is a protected member of 'ProtectedMember'
+  static_cast<ProtectedMember&>(usingProtectedToPublicMember).protectedMember = 1;
+                                                              ^
+.tmp.cpp:58:7: note: declared protected here
+  int protectedMember;
+      ^
+1 error generated.

--- a/tests/UsingDecl2Test.cpp
+++ b/tests/UsingDecl2Test.cpp
@@ -1,0 +1,45 @@
+struct B {
+    virtual void f(int) {  }
+    void g(char)        {  }
+    void h(int)         {  }
+};
+ 
+struct D : B {
+    using B::f;
+    void f(int) {  }
+    using B::g;
+    void g(int) {  }
+    using B::h;
+    void h(int) {  }
+};
+
+struct ProtectedMember
+{
+protected:
+    int protectedMember;
+    typedef int value_type;
+};
+
+struct UsingProtectedToPublicMember : ProtectedMember
+{
+    using ProtectedMember::protectedMember;
+    using ProtectedMember::value_type; 
+};
+
+int main()
+{
+    UsingProtectedToPublicMember usingProtectedToPublicMember;
+    usingProtectedToPublicMember.protectedMember = 1;
+    
+
+    D d;
+    B& b = d;
+ 
+    b.f(1);
+    d.f(1);
+    d.g(1);
+    d.g('a');
+    b.h(1);
+    d.h(1);
+}
+

--- a/tests/UsingDecl2Test.expect
+++ b/tests/UsingDecl2Test.expect
@@ -1,0 +1,96 @@
+struct B
+{
+  inline virtual void f(int)
+  {
+  }
+  
+  inline void g(char)
+  {
+  }
+  
+  inline void h(int)
+  {
+  }
+  
+  // inline constexpr B & operator=(const B &) = default;
+  // inline constexpr B & operator=(B &&) = default;
+  // inline ~B() = default;
+  // inline constexpr B() noexcept = default;
+  // inline constexpr B(const B &) = default;
+  // inline constexpr B(B &&) = default;
+};
+
+
+ 
+struct D : public B
+{
+  using B::f;
+  inline virtual void f(int)
+  {
+  }
+  
+  using B::g;
+  // inline void B::g(char);
+  
+  inline void g(int)
+  {
+  }
+  
+  using B::h;
+  inline void h(int)
+  {
+  }
+  
+  // inline constexpr D & operator=(const D &) = default;
+  // inline constexpr D & operator=(D &&) = default;
+  // inline ~D() = default;
+  // inline constexpr D() noexcept = default;
+  // inline constexpr D(const D &) = default;
+  // inline constexpr D(D &&) = default;
+};
+
+
+
+struct ProtectedMember
+{
+  
+  protected: 
+  int protectedMember;
+  using value_type = int;
+  public: 
+  // inline ProtectedMember() noexcept = default;
+  // inline ~ProtectedMember() = default;
+  // inline constexpr ProtectedMember(const ProtectedMember &) = default;
+  // inline constexpr ProtectedMember(ProtectedMember &&) = default;
+};
+
+
+
+struct UsingProtectedToPublicMember : public ProtectedMember
+{
+  using ProtectedMember::protectedMember;
+  // int protectedMember;
+  
+  using ProtectedMember::value_type;
+  // inline UsingProtectedToPublicMember() noexcept = default;
+  // inline constexpr UsingProtectedToPublicMember(const UsingProtectedToPublicMember &) = default;
+  // inline constexpr UsingProtectedToPublicMember(UsingProtectedToPublicMember &&) = default;
+};
+
+
+
+int main()
+{
+  UsingProtectedToPublicMember usingProtectedToPublicMember = UsingProtectedToPublicMember();
+  static_cast<ProtectedMember&>(usingProtectedToPublicMember).protectedMember = 1;
+  D d = D();
+  B & b = static_cast<B&>(d);
+  b.f(1);
+  d.f(1);
+  d.g(1);
+  static_cast<B&>(d).g('a');
+  b.h(1);
+  d.h(1);
+}
+
+

--- a/tests/UsingDeclTest.expect
+++ b/tests/UsingDeclTest.expect
@@ -52,18 +52,22 @@ struct D : B {
 template<>
 struct D<int> : public B
 {
-  using D<int>::m;
-  using D<int>::value_type;
-  using D<int>::f;
+  using B::m;
+  // int m;
+  
+  using B::value_type;
+  using B::f;
   inline virtual void f(int)
   {
     std::operator<<(std::cout, "D::f\n");
   }
   
-  using D<int>::g;
+  using B::g;
+  // inline void B::g(char);
+  
   inline void g(int);
   
-  using D<int>::h;
+  using B::h;
   inline void h(int);
   
   // inline D<int> & operator=(const D<int> &) = default;

--- a/tests/VisitorTest.expect
+++ b/tests/VisitorTest.expect
@@ -5,8 +5,12 @@ template<class... Ts> struct visitor: Ts... { using Ts::operator()...; };
 template<>
 struct visitor<__lambda_8_7, __lambda_9_7> : public __lambda_8_7, public __lambda_9_7
 {
-  using visitor<__lambda_8_7, __lambda_9_7>::operator();
-  using visitor<__lambda_8_7, __lambda_9_7>::operator();
+  using __lambda_8_7::operator();
+  // inline /*constexpr */ void ::operator()(int value) const;
+  
+  using __lambda_9_7::operator();
+  // inline /*constexpr */ void ::operator()(const char * value) const;
+  
   // inline constexpr visitor<__lambda_8_7, __lambda_9_7> & operator=(visitor<__lambda_8_7, __lambda_9_7> &&) = default;
   // inline ~visitor() noexcept = default;
 };


### PR DESCRIPTION
Fixed #178, 184: Provide the functions pulled in from a base class via using.

For example:
```
struct X {
  int f(int);
  int f(double);
protected:
  int x;
};

struct Y: X {
  using X::f;
  using X::x;
};
```

Will make the functions `f(int)` and `f(double)` available in `Y` as
well as it moves `X::x` from `protected` to `public` in `Y`. All these
functions or members are shown as comments only.

Fixed #184 which points out the invalid prefix from a using decl.