### PR TITLE
Fixed TypeAliasTemplateDecl.

### DIFF
--- a/CodeGenerator.cpp
+++ b/CodeGenerator.cpp
@@ -2219,6 +2219,8 @@ void CodeGenerator::InsertArg(const FunctionTemplateDecl* stmt)
 
 void CodeGenerator::InsertArg(const TypeAliasTemplateDecl* stmt)
 {
+    InsertTemplateParameters(*stmt->getTemplateParameters());
+
     InsertArg(stmt->getTemplatedDecl());
 }
 //-----------------------------------------------------------------------------

--- a/tests/TypeAliasTemplate2Test.cpp
+++ b/tests/TypeAliasTemplate2Test.cpp
@@ -1,0 +1,10 @@
+struct templateTypeAliasTest {
+  template<typename T>
+  using result = T;
+};
+
+int main()
+{
+    templateTypeAliasTest::result<int> x;
+
+}

--- a/tests/TypeAliasTemplate2Test.expect
+++ b/tests/TypeAliasTemplate2Test.expect
@@ -1,0 +1,13 @@
+struct templateTypeAliasTest
+{
+  template<typename T>
+  using result = T;
+};
+
+
+
+int main()
+{
+  templateTypeAliasTest::result<int> x;
+}
+

--- a/tests/TypeAliasTemplateTest.expect
+++ b/tests/TypeAliasTemplateTest.expect
@@ -19,6 +19,7 @@ struct F
 template<>
 struct F<int>
 {
+  template<typename ... B>
   using SameSize = bool_constant<1 == sizeof...(B)>;
   template<typename ... B, typename type_parameter_0_1 = SameSize<B...>>
   inline F(B...);


### PR DESCRIPTION
The template keyword plus all the template parameters were missing. This
patch adds them as it is done for all other templates.