### PR TITLE
Fixed #193: Expand global declaration wrapped in a macro.

### DIFF
--- a/FunctionDeclHandler.cpp
+++ b/FunctionDeclHandler.cpp
@@ -28,7 +28,7 @@ FunctionDeclHandler::FunctionDeclHandler(Rewriter& rewrite, MatchFinder& matcher
                                                  isTemplate,
                                                  hasAncestor(friendDecl()),    // friendDecl has functionDecl as child
                                                  hasAncestor(functionDecl()),  // prevent forward declarations
-                                                 isMacroOrInvalidLocation())))
+                                                 isInvalidLocation())))
                            .bind("funcDecl"),
                        this);
 
@@ -42,7 +42,7 @@ FunctionDeclHandler::FunctionDeclHandler(Rewriter& rewrite, MatchFinder& matcher
                                                isTemplate,
                                                hasTemplateDescendant,
                                                hasAncestor(functionDecl()),  // prevent forward declarations
-                                               isMacroOrInvalidLocation())))
+                                               isInvalidLocation())))
                            .bind("friendDecl"),
                        this);
 }
@@ -59,13 +59,10 @@ void FunctionDeclHandler::run(const MatchFinder::MatchResult& result)
 
         // Find the correct ending of the source range. In case of a declaration we need to find the ending semi,
         // otherwise the provided source range is correct.
-        const auto sr = [&]() {
-            if(!funcDecl->doesThisDeclarationHaveABody()) {
-                return GetSourceRangeAfterSemi(funcDecl->getSourceRange(), result);
-            }
-
-            return funcDecl->getSourceRange();
-        }();
+        const auto sr =
+            GetSourceRangeAfterSemi(funcDecl->getSourceRange(),
+                                    result,
+                                    funcDecl->doesThisDeclarationHaveABody() ? RequireSemi::No : RequireSemi::Yes);
 
         // DPrint("fd rw:  %d %s\n", (sr.getBegin() == sr.getEnd()), outputFormatHelper.GetString());
 

--- a/GlobalVariableHandler.cpp
+++ b/GlobalVariableHandler.cpp
@@ -31,7 +31,7 @@ GlobalVariableHandler::GlobalVariableHandler(Rewriter& rewrite, MatchFinder& mat
     matcher.addMatcher(
         varDecl(unless(anyOf(
                     isExpansionInSystemHeader(),
-                    isMacroOrInvalidLocation(),
+                    isInvalidLocation(),
                     hasAncestor(varTemplateDecl()),
                     hasAncestor(functionDecl()),
                     hasAncestor(cxxRecordDecl()),

--- a/InsightsHelpers.cpp
+++ b/InsightsHelpers.cpp
@@ -102,7 +102,25 @@ SourceRange GetSourceRangeAfterSemi(const SourceRange                           
 {
     const SourceLocation locEnd = FindLocationAfterSemi(range.getEnd(), result, requireSemi);
 
-    return {range.getBegin(), locEnd};
+    // Special handling for macro locations.
+    const auto startLoc = [&] {
+        if(range.getBegin().isMacroID()) {
+            return GetSM(result).getImmediateExpansionRange(range.getBegin()).getBegin();
+        }
+
+        return range.getBegin();
+    }();
+
+    // Special handling for macro locations.
+    const auto locEnd2 = [&] {
+        if(locEnd.isMacroID()) {
+            return GetSM(result).getImmediateExpansionRange(locEnd).getEnd();
+        }
+
+        return locEnd;
+    }();
+
+    return {startLoc, locEnd2};
 }
 //-----------------------------------------------------------------------------
 

--- a/InsightsMatchers.h
+++ b/InsightsMatchers.h
@@ -84,6 +84,13 @@ AST_POLYMORPHIC_MATCHER(isMacroOrInvalidLocation, AST_POLYMORPHIC_SUPPORTED_TYPE
             insights::IsInvalidLocation(insights::GetBeginLoc(Node)));
 }
 
+AST_POLYMORPHIC_MATCHER(isInvalidLocation, AST_POLYMORPHIC_SUPPORTED_TYPES(Decl, Stmt))
+{
+    SILENCE;
+
+    return insights::IsInvalidLocation(insights::GetBeginLoc(Node));
+}
+
 }  // namespace ast_matchers
 }  // namespace clang
 //-----------------------------------------------------------------------------

--- a/tests/ClassOperatorHandler4Test.expect
+++ b/tests/ClassOperatorHandler4Test.expect
@@ -20,7 +20,7 @@ bool operator==(const Foo & left, const Foo & right)
 {
   return left.mX == right.mX;
 }
-;
+
 
 
 

--- a/tests/FunctionDeclInMacroLocTest.cpp
+++ b/tests/FunctionDeclInMacroLocTest.cpp
@@ -1,0 +1,3 @@
+#define MACRO(name) void name(int) {}
+
+MACRO(test)

--- a/tests/FunctionDeclInMacroLocTest.expect
+++ b/tests/FunctionDeclInMacroLocTest.expect
@@ -1,0 +1,6 @@
+#define MACRO(name) void name(int) {}
+
+void test(int)
+                    {
+                    }
+                    

--- a/tests/Issue193.cpp
+++ b/tests/Issue193.cpp
@@ -1,0 +1,16 @@
+struct cppcmb_rule_tag16{};
+
+template <typename Val, typename Tag>
+class rule_t {};
+
+#define cppcmb_prelude_cat(x, y) x ## y
+
+#define cppcmb_cat(x, y) cppcmb_prelude_cat(x, y)
+
+#define cppcmb_unique_id(prefix) cppcmb_cat(prefix, __LINE__)
+
+#define cppcmb_decl(name, ...) \
+auto const name =              \
+rule_t<__VA_ARGS__, struct cppcmb_unique_id(cppcmb_rule_tag)>()
+
+cppcmb_decl(expr_top, int);

--- a/tests/Issue193.expect
+++ b/tests/Issue193.expect
@@ -1,0 +1,35 @@
+struct cppcmb_rule_tag16
+{
+};
+
+
+
+template <typename Val, typename Tag>
+class rule_t {};
+
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+class rule_t<int, cppcmb_rule_tag16>
+{
+  public: 
+  // inline constexpr rule_t() noexcept = default;
+  // inline constexpr rule_t(const rule_t<int, cppcmb_rule_tag16> &) = default;
+  // inline constexpr rule_t(rule_t<int, cppcmb_rule_tag16> &&) = default;
+  // inline ~rule_t() noexcept = default;
+};
+
+#endif
+
+
+#define cppcmb_prelude_cat(x, y) x ## y
+
+#define cppcmb_cat(x, y) cppcmb_prelude_cat(x, y)
+
+#define cppcmb_unique_id(prefix) cppcmb_cat(prefix, __LINE__)
+
+#define cppcmb_decl(name, ...) \
+auto const name =              \
+rule_t<__VA_ARGS__, struct cppcmb_unique_id(cppcmb_rule_tag)>()
+
+const rule_t<int, cppcmb_rule_tag16> expr_top = rule_t<int, cppcmb_rule_tag16>();
+

--- a/tests/NamespaceWithClassOperatorsTest.expect
+++ b/tests/NamespaceWithClassOperatorsTest.expect
@@ -5,7 +5,7 @@ std::chrono::duration<double, std::ratio<1, 1> > Bar()
   std::chrono::time_point<std::chrono::system_clock, std::chrono::duration<long long, std::ratio<1, 1000000> > > begin = std::chrono::system_clock::now();
   return std::chrono::duration<double, std::ratio<1, 1> >(std::chrono::operator-(std::chrono::system_clock::now(), begin), 0);
 }
-;
+
 
 
 void Foo()


### PR DESCRIPTION
A global declaration wrapped in a macro was not expanded due to a wrong
starting SourceLocation. This fix considers a starting location which is
inside a macro.