### PR TITLE
Fixed #201: Position the `volatile` keyword at the right side.

### DIFF
--- a/CodeGenerator.cpp
+++ b/CodeGenerator.cpp
@@ -2874,10 +2874,6 @@ void CodeGenerator::InsertAccessModifierAndNameWithReturnType(const FunctionDecl
             mOutputFormatHelper.Append(kwVirtualSpace);
         }
 
-        if(methodDecl->isVolatile()) {
-            mOutputFormatHelper.Append(kwVolatileSpace);
-        }
-
         if(const auto* ctorDecl = dyn_cast_or_null<CXXConstructorDecl>(methodDecl)) {
             if(isFirstCxxMethodDecl && ctorDecl->isExplicit()) {
                 mOutputFormatHelper.Append("explicit ");
@@ -2958,6 +2954,10 @@ void CodeGenerator::InsertAccessModifierAndNameWithReturnType(const FunctionDecl
     }
 
     mOutputFormatHelper.Append(GetConst(decl));
+
+    if(methodDecl && methodDecl->isVolatile()) {
+        mOutputFormatHelper.Append(kwSpaceVolatile);
+    }
 
     switch(decl.getType()->getAs<FunctionProtoType>()->getRefQualifier()) {
         case RQ_None: break;

--- a/InsightsStaticStrings.h
+++ b/InsightsStaticStrings.h
@@ -38,7 +38,6 @@ static constexpr const char kwExtern[] = KW_EXTERN;
 static constexpr const char kwConstSpace[] = BUILD_WITH_SPACE_AFTER(KW_CONST);
 // static constexpr const char kwAutoSpace[]      = BUILD_WITH_SPACE_AFTER(KW_AUTO);
 static constexpr const char kwConstExprSpace[] = BUILD_WITH_SPACE_AFTER(KW_CONSTEXPR);
-static constexpr const char kwVolatileSpace[]  = BUILD_WITH_SPACE_AFTER(KW_VOLATILE);
 static constexpr const char kwStaticSpace[]    = BUILD_WITH_SPACE_AFTER(KW_STATIC);
 static constexpr const char kwExternSpace[]    = BUILD_WITH_SPACE_AFTER(KW_EXTERN);
 // static constexpr const char kwNoexceptSpace[]  = BUILD_WITH_SPACE_AFTER(KW_NOEXCEPT);
@@ -50,6 +49,7 @@ static constexpr const char kwInlineSpace[]  = BUILD_WITH_SPACE_AFTER(KW_INLINE)
 static constexpr const char kwSpaceNoexcept[]  = BUILD_WITH_SPACE_BEFORE(KW_NOEXCEPT);
 static constexpr const char kwSpaceConst[]     = BUILD_WITH_SPACE_BEFORE(KW_CONST);
 static constexpr const char kwSpaceConstExpr[] = BUILD_WITH_SPACE_BEFORE(KW_CONSTEXPR);
+static constexpr const char kwSpaceVolatile[]  = BUILD_WITH_SPACE_BEFORE(KW_VOLATILE);
 //-----------------------------------------------------------------------------
 
 #endif /* INSIGHTS_STATIC_STRINGS_H */

--- a/tests/CharLiteralTest.expect
+++ b/tests/CharLiteralTest.expect
@@ -39,7 +39,7 @@ struct Foo<int>
   inline constexpr Foo<int> & operator=(const Foo<int> & rhs) = default;
   inline Foo<int> & operator=(int v);
   
-  inline volatile void operator=(int v);
+  inline void operator=(int v) volatile;
   
   // inline ~Foo() noexcept = default;
 };
@@ -67,7 +67,7 @@ struct Foo<char>
     return *this;
   }
   
-  inline volatile void operator=(char v);
+  inline void operator=(char v) volatile;
   
   // inline ~Foo() = default;
 };

--- a/tests/Issue201.cpp
+++ b/tests/Issue201.cpp
@@ -1,0 +1,4 @@
+struct S
+{
+  void f() volatile;
+};

--- a/tests/Issue201.expect
+++ b/tests/Issue201.expect
@@ -1,0 +1,7 @@
+struct S
+{
+  void f() volatile;
+  
+};
+
+


### PR DESCRIPTION
The keyword `volatile` was position at the front of a CXXMethodDecl
instead of at the end. This patch corrects the insertion point.