### PR TITLE
Fixed #199: An additional `,` was added after a template parameter.

### DIFF
--- a/OutputFormatHelper.h
+++ b/OutputFormatHelper.h
@@ -19,6 +19,11 @@
 namespace clang::insights {
 //-----------------------------------------------------------------------------
 
+// Workaround to keep clang 6 Linux build alive
+template<class T, class U>
+inline constexpr bool is_same_v = std::is_same<T, U>::value;  // NOLINT
+//-----------------------------------------------------------------------------
+
 /// \brief The C++ Insights formatter.
 ///
 /// Most of the code is handed to \ref OutputFormatHelper for easy code formatting.
@@ -157,6 +162,12 @@ public:
     {
         OnceFalse needsComma{};
         for(const auto& arg : arguments) {
+            if constexpr(is_same_v<const TemplateArgument&, decltype(arg)>) {
+                if((TemplateArgument::Pack == arg.getKind()) && (0 == arg.pack_size())) {
+                    break;
+                }
+            }
+
             if(needsComma) {
                 outputFormatHelper.Append(", ");
             }

--- a/TemplateHandler.cpp
+++ b/TemplateHandler.cpp
@@ -26,11 +26,6 @@ const internal::VariadicDynCastAllOfMatcher<Decl, VarTemplateDecl> varTemplateDe
 
 namespace clang::insights {
 
-// Workaround to keep clang 6 Linux build alive
-template<class T, class U>
-inline constexpr bool is_same_v = std::is_same<T, U>::value;  // NOLINT
-//-----------------------------------------------------------------------------
-
 /// \brief Insert the instantiated template with the resulting code.
 template<typename T>
 static OutputFormatHelper InsertInstantiatedTemplate(const T& decl)

--- a/tests/CXXScalarValueInitExprTest.expect
+++ b/tests/CXXScalarValueInitExprTest.expect
@@ -8,7 +8,7 @@ T create(Args&& ... args){
 /* First instantiated from: CXXScalarValueInitExprTest.cpp:10 */
 #ifdef INSIGHTS_USE_TEMPLATE
 template<>
-double create<double, >()
+double create<double>()
 {
   return double();
 }

--- a/tests/Issue199.cpp
+++ b/tests/Issue199.cpp
@@ -1,0 +1,11 @@
+template<typename U, typename ...T>
+void f(U, T... rest)
+{
+  if constexpr (sizeof...(rest) != 0)
+    f(rest...);
+}
+
+int main()
+{
+    f(0, 1);
+}

--- a/tests/Issue199.expect
+++ b/tests/Issue199.expect
@@ -1,0 +1,36 @@
+template<typename U, typename ...T>
+void f(U, T... rest)
+{
+  if constexpr (sizeof...(rest) != 0)
+    f(rest...);
+}
+
+/* First instantiated from: Issue199.cpp:10 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+void f<int, int>(int, int __rest1)
+{
+  if constexpr(1 != 0) f(__rest1);
+  
+  
+}
+#endif
+
+
+/* First instantiated from: Issue199.cpp:5 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+void f<int>(int)
+{
+  if constexpr(0 != 0) ;
+  
+  
+}
+#endif
+
+
+int main()
+{
+  f(0, 1);
+}
+

--- a/tests/NonTypeTemplateParameterPackTest.expect
+++ b/tests/NonTypeTemplateParameterPackTest.expect
@@ -42,7 +42,7 @@ class Test
   /* First instantiated from: NonTypeTemplateParameterPackTest.cpp:7 */
   #ifdef INSIGHTS_USE_TEMPLATE
   template<>
-  inline int sum<7, >()
+  inline int sum<7>()
   {
     if constexpr(0 > 0) ;
     else /* constexpr */ {
@@ -92,7 +92,7 @@ class Test
   /* First instantiated from: NonTypeTemplateParameterPackTest.cpp:18 */
   #ifdef INSIGHTS_USE_TEMPLATE
   template<>
-  inline int summ<int &, >(int & i)
+  inline int summ<int &>(int & i)
   {
     if constexpr(0 > 0) ;
     else /* constexpr */ {

--- a/tests/TemplateHandlerTest.expect
+++ b/tests/TemplateHandlerTest.expect
@@ -182,7 +182,7 @@ void tprintf<char, int>(const char * format, char value, int __Fargs2)
 /* First instantiated from: TemplateHandlerTest.cpp:44 */
 #ifdef INSIGHTS_USE_TEMPLATE
 template<>
-void tprintf<int, >(const char * format, int value)
+void tprintf<int>(const char * format, int value)
 {
   for(; static_cast<int>(*format) != static_cast<int>('\0'); format++) 
   {


### PR DESCRIPTION
If a template parameter was followed by an empty parameter pack an
additional comma was inserted in the template specialization.