### PR TITLE
Fixed user-provided template specializations should be without guard.

### DIFF
--- a/CodeGenerator.cpp
+++ b/CodeGenerator.cpp
@@ -730,7 +730,7 @@ InsertInstantiationPoint(OutputFormatHelper& outputFormatHelper, const SourceMan
 
 void CodeGenerator::InsertTemplateGuardBegin(const FunctionDecl* stmt)
 {
-    if(stmt->isFunctionTemplateSpecialization()) {
+    if(stmt->isTemplateInstantiation() && stmt->isFunctionTemplateSpecialization()) {
         InsertInstantiationPoint(mOutputFormatHelper, GetSM(*stmt), stmt->getPointOfInstantiation());
         mOutputFormatHelper.AppendNewLine("#ifdef INSIGHTS_USE_TEMPLATE");
     }
@@ -739,7 +739,7 @@ void CodeGenerator::InsertTemplateGuardBegin(const FunctionDecl* stmt)
 
 void CodeGenerator::InsertTemplateGuardEnd(const FunctionDecl* stmt)
 {
-    if(stmt->isFunctionTemplateSpecialization()) {
+    if(stmt->isTemplateInstantiation() && stmt->isFunctionTemplateSpecialization()) {
         mOutputFormatHelper.AppendNewLine("#endif");
     }
 }

--- a/tests/Issue200.expect
+++ b/tests/Issue200.expect
@@ -17,12 +17,10 @@ void f<int, int>(int, int __rest1)
 #endif
 
 
-#ifdef INSIGHTS_USE_TEMPLATE
 template<>
 void f<int>(int)
 {
 }
-#endif
 
 
 int main()


### PR DESCRIPTION
With fix for #200 user-provided template specializations where guarded
by an `#if` which does modify the original code. This patch reverts that
behaviour and leaves the rest of the #200 fix as it is.