### PR TITLE
Fixed #205: Make lambdas as in class initializer work.

### DIFF
--- a/CodeGenerator.h
+++ b/CodeGenerator.h
@@ -40,6 +40,7 @@ protected:
         LambdaExpr,
         ReturnStmt,
         BinaryOperator,
+        CXXMethodDecl,
     };
 
     class LambdaHelper : public StackListEntry<LambdaHelper>
@@ -182,6 +183,10 @@ protected:
     void InsertTemplateArg(const TemplateArgument& arg);
     bool InsertLambdaStaticInvoker(const CXXMethodDecl* cxxMethodDecl);
     void InsertTemplateParameters(const TemplateParameterList& list);
+
+    /// For a special case, when a LambdaExpr occurs in a Constructor from an
+    /// in class initializer, there is a need for a more narrow scope for the \c LAMBDA_SCOPE_HELPER.
+    void InsertCXXMethodHeader(const CXXMethodDecl* stmt, OutputFormatHelper& initOutputFormatHelper);
 
     void InsertTemplateGuardBegin(const FunctionDecl* stmt);
     void InsertTemplateGuardEnd(const FunctionDecl* stmt);

--- a/tests/Issue205.cpp
+++ b/tests/Issue205.cpp
@@ -1,0 +1,15 @@
+#include <functional>
+#include <iostream>
+class EventContainer {
+    private:
+        int val = 1234;
+        std::function<void()> something = [=]() {
+            std::cout << this->val;
+        };
+};
+
+int main() {
+  // get the default constructor generated.
+  EventContainer e;
+  return 0;
+}

--- a/tests/Issue205.expect
+++ b/tests/Issue205.expect
@@ -1,0 +1,46 @@
+#include <functional>
+#include <iostream>
+class EventContainer
+{
+  
+  private: 
+  int val;
+  std::function<void ()> something;
+  public: 
+  // inline EventContainer(const EventContainer &) = default;
+  // inline EventContainer(EventContainer &&) = default;
+  // inline EventContainer & operator=(EventContainer &&) = default;
+  // inline ~EventContainer() noexcept = default;
+  
+  public: 
+    
+  class __lambda_6_43
+  {
+    EventContainer * __this;
+    public: 
+    inline /*constexpr */ void operator()() const
+    {
+      std::cout.operator<<(__this->val);
+    }
+    
+    // inline /*constexpr */ __lambda_6_43 & operator=(const __lambda_6_43 &) = default;
+    // inline /*constexpr */ __lambda_6_43(const __lambda_6_43 &) noexcept = default;
+    // inline /*constexpr */ __lambda_6_43(__lambda_6_43 &&) noexcept = default;
+    public: __lambda_6_43(EventContainer * _this)
+    : __this{_this}
+
+    {}
+    
+  } __lambda_6_43{this};
+  
+  // inline constexpr EventContainer() noexcept(false) = default;
+};
+
+
+
+int main()
+{
+  EventContainer e = EventContainer();
+  return 0;
+}
+

--- a/tests/Issue205_2.cpp
+++ b/tests/Issue205_2.cpp
@@ -1,0 +1,17 @@
+#include <functional>
+#include <iostream>
+class EventContainer {
+    private:
+        int val = 1234;
+        std::function<void()> something = [=]() {
+            std::cout << this->val;
+        };
+
+    public:
+    EventContainer() : val{1235}{}
+};
+
+int main() {
+  // get the default constructor generated.
+  EventContainer e;
+}

--- a/tests/Issue205_2.expect
+++ b/tests/Issue205_2.expect
@@ -1,0 +1,50 @@
+#include <functional>
+#include <iostream>
+class EventContainer
+{
+  
+  private: 
+  int val;
+  std::function<void ()> something;
+  
+  public: 
+    
+  class __lambda_6_43
+  {
+    EventContainer * __this;
+    public: 
+    inline /*constexpr */ void operator()() const
+    {
+      std::cout.operator<<(__this->val);
+    }
+    
+    // inline /*constexpr */ __lambda_6_43 & operator=(const __lambda_6_43 &) = default;
+    // inline /*constexpr */ __lambda_6_43(const __lambda_6_43 &) noexcept = default;
+    // inline /*constexpr */ __lambda_6_43(__lambda_6_43 &&) noexcept = default;
+    public: __lambda_6_43(EventContainer * _this)
+    : __this{_this}
+
+    {}
+    
+  } __lambda_6_43{this};
+  
+  inline EventContainer()
+  : val{1235}
+  , something{std::function<void ()>(__lambda_6_43)}
+  {
+  }
+  
+  // inline EventContainer(const EventContainer &) = default;
+  // inline EventContainer(EventContainer &&) = default;
+  // inline EventContainer & operator=(EventContainer &&) = default;
+  // inline ~EventContainer() noexcept = default;
+  
+};
+
+
+
+int main()
+{
+  EventContainer e = EventContainer();
+}
+

--- a/tests/LambdaAndInClassInitializerTest.cpp
+++ b/tests/LambdaAndInClassInitializerTest.cpp
@@ -1,0 +1,25 @@
+// std::function mock up
+template<typename ReturnValue, typename... Args>
+class function
+{
+public:
+    function() = default;
+
+    template<typename T>
+    function(T&& f)
+    {}
+};
+
+// part of #205
+class EventContainer {
+    private:
+        int val = 1234;
+        function<void()> something = [=]() {
+            this->val;
+        };
+};
+
+int main() {
+  // get the default constructor generated.
+  EventContainer e;
+}

--- a/tests/LambdaAndInClassInitializerTest.expect
+++ b/tests/LambdaAndInClassInitializerTest.expect
@@ -1,0 +1,93 @@
+// std::function mock up
+template<typename ReturnValue, typename... Args>
+class function
+{
+public:
+    function() = default;
+
+    template<typename T>
+    function(T&& f)
+    {}
+};
+
+/* First instantiated from: LambdaAndInClassInitializerTest.cpp:17 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+class function<void ()>
+{
+  
+  public: 
+  inline constexpr function() = default;
+  template<typename T>
+  inline function(T && f);
+  
+  
+  /* First instantiated from: LambdaAndInClassInitializerTest.cpp:17 */
+  #ifdef INSIGHTS_USE_TEMPLATE
+  template<>
+  inline function<__lambda_17_38>(__lambda_17_38 && f)
+  {
+  }
+  #endif
+  
+  
+  
+  #ifdef INSIGHTS_USE_TEMPLATE
+  template<>
+  inline function<const function<void ()> &>(function<void ()> & f);
+  #endif
+  
+  
+  
+  #ifdef INSIGHTS_USE_TEMPLATE
+  template<>
+  inline function<function<void ()> >(function<void ()> && f);
+  #endif
+  
+  
+  // inline constexpr function(const function<void ()> &) = default;
+  // inline constexpr function(function<void ()> &&) = default;
+  // inline ~function() noexcept = default;
+};
+
+#endif
+
+
+// part of #205
+class EventContainer
+{
+  
+  private: 
+  int val;
+  function<void ()> something;
+  
+  public: 
+    
+  class __lambda_17_38
+  {
+    EventContainer * __this;
+    public: 
+    inline /*constexpr */ void operator()() const
+    {
+      __this->val;
+    }
+    
+    public: __lambda_17_38(EventContainer * _this)
+    : __this{_this}
+
+    {}
+    
+  } __lambda_17_38{this};
+  
+  // inline constexpr EventContainer() noexcept(false) = default;
+  // inline constexpr EventContainer(const EventContainer &) = default;
+  // inline constexpr EventContainer(EventContainer &&) = default;
+};
+
+
+
+int main()
+{
+  EventContainer e = EventContainer();
+}
+


### PR DESCRIPTION
Lambdas as an in class initializer cause a `LambdaExpr` to occur in a
`CXXConstructorDecl`s initializer list. This causes the lambda to be
placed at a wrong location.

It also triggers a behaviour where the `LambdaExpr` occurs twice. Once
in the in class initializer as written and later in the `CXXConstructorDecl`.
The first one cause a crash due to a `nullptr` access. This patch
filters these lambdas out.