### PR TITLE
Fixed `SimpleTypePrinter`.

### DIFF
--- a/InsightsHelpers.cpp
+++ b/InsightsHelpers.cpp
@@ -390,12 +390,11 @@ private:
 
         mSkipSpace = true;
         for(unsigned i = 0, e = type->getNumParams(); i != e; ++i) {
-
-            HandleType(type->getParamType(i).getTypePtrOrNull());
-
             if(needsComma) {
                 mData.Append(", ");
             }
+
+            HandleType(type->getParamType(i).getTypePtrOrNull());
         }
 
         mSkipSpace = false;

--- a/tests/LambdaAsTemplateArgTest.cpp
+++ b/tests/LambdaAsTemplateArgTest.cpp
@@ -9,7 +9,7 @@ int main()
 {
     int y = 2;
     int z = 3;
-    auto l = [&](int x) { return x + y; };
+    auto l = [&](int x, int b) { return x + y + b; };
 
     FunctionArgs<decltype(&decltype(l)::operator())> a;
 }

--- a/tests/LambdaAsTemplateArgTest.expect
+++ b/tests/LambdaAsTemplateArgTest.expect
@@ -4,11 +4,11 @@ struct FunctionArgs  {};
 /* First instantiated from: LambdaAsTemplateArgTest.cpp:14 */
 #ifdef INSIGHTS_USE_TEMPLATE
 template<>
-struct FunctionArgs<int (__lambda_12_14::*)(int) const>
+struct FunctionArgs<int (__lambda_12_14::*)(int, int) const>
 {
   // inline constexpr FunctionArgs() noexcept = default;
-  // inline constexpr FunctionArgs(const FunctionArgs<int (__lambda_12_14::*)(int) const> &) = default;
-  // inline constexpr FunctionArgs(FunctionArgs<int (__lambda_12_14::*)(int) const> &&) = default;
+  // inline constexpr FunctionArgs(const FunctionArgs<int (__lambda_12_14::*)(int, int) const> &) = default;
+  // inline constexpr FunctionArgs(FunctionArgs<int (__lambda_12_14::*)(int, int) const> &&) = default;
 };
 
 #endif
@@ -33,9 +33,9 @@ int main()
   {
     int & y;
     public: 
-    inline /*constexpr */ int operator()(int x) const
+    inline /*constexpr */ int operator()(int x, int b) const
     {
-      return x + y;
+      return x + y + b;
     }
     
     public: __lambda_12_14(int & _y)
@@ -45,6 +45,6 @@ int main()
   };
   
   __lambda_12_14 l = __lambda_12_14{y};
-  FunctionArgs<decltype(&decltype(l)::operator())> a = FunctionArgs<int (__lambda_12_14::*)(int) const>();
+  FunctionArgs<decltype(&decltype(l)::operator())> a = FunctionArgs<int (__lambda_12_14::*)(int, int) const>();
 }
 


### PR DESCRIPTION
In case of a `FunctionProtoType` with multiple parameters, wrong code was
generated.