### PR TITLE
Fixed #223 and #134: Suppress implicit casts which are part of a explicit cast.

### DIFF
--- a/CodeGenerator.cpp
+++ b/CodeGenerator.cpp
@@ -1129,10 +1129,16 @@ void CodeGenerator::InsertArg(const ImplicitCastExpr* stmt)
 {
     const Expr* subExpr  = stmt->getSubExpr();
     const auto  castKind = stmt->getCastKind();
+    const bool  hideImplicitCasts{not GetInsightsOptions().ShowAllImplicitCasts};
 
     if(!clang::ast_matchers::IsMatchingCast(castKind)) {
         InsertArg(subExpr);
-    } else if(isa<IntegerLiteral>(subExpr) && not GetInsightsOptions().ShowAllImplicitCasts) {
+    } else if(isa<IntegerLiteral>(subExpr) && hideImplicitCasts) {
+        InsertArg(stmt->IgnoreCasts());
+
+        // If this is part of an explicit cast, for example a CStyleCast ignore it, if ShowAllImplicitCasts is not
+        // selected
+    } else if(stmt->isPartOfExplicitCast() && hideImplicitCasts) {
         InsertArg(stmt->IgnoreCasts());
 
     } else {

--- a/tests/CharLiteral2Test.expect
+++ b/tests/CharLiteral2Test.expect
@@ -1,6 +1,6 @@
 int main()
 {
-  if(1 == static_cast<int>((static_cast<unsigned char>(static_cast<unsigned char>(255))))) {
+  if(1 == static_cast<int>((static_cast<unsigned char>(255)))) {
   }
   
 }

--- a/tests/ClassOperatorHandler5Test.expect
+++ b/tests/ClassOperatorHandler5Test.expect
@@ -8,11 +8,11 @@ std::basic_string<char> trim(const std::basic_string<char> & input)
   
   std::string final = std::basic_string<char>(input);
   int i = 0;
-  while(i < static_cast<int>(static_cast<int>(input.length())) && static_cast<int>(input.operator[](i)) <= static_cast<int>(' ')) {
+  while(i < static_cast<int>(input.length()) && static_cast<int>(input.operator[](i)) <= static_cast<int>(' ')) {
     i++;
   }
   
-  if(i >= static_cast<int>(static_cast<int>(input.length()))) {
+  if(i >= static_cast<int>(input.length())) {
     return std::basic_string<char>("");
   }
   
@@ -20,7 +20,7 @@ std::basic_string<char> trim(const std::basic_string<char> & input)
     final.operator=(input.substr(static_cast<unsigned long>(i), input.length() - static_cast<unsigned long>(i)));
   }
   
-  i = static_cast<int>(static_cast<int>(final.length())) - 1;
+  i = static_cast<int>(final.length()) - 1;
   while(i >= 0 && static_cast<int>(final.operator[](i)) <= static_cast<int>(' ')) {
     i--;
   }

--- a/tests/ClassOperatorHandler6Test.expect
+++ b/tests/ClassOperatorHandler6Test.expect
@@ -128,7 +128,7 @@ int main()
   const bool b4 = f1.operator==(NULL);
   const bool b5 = f1.operator==(static_cast<const int>((t == nullptr)));
   unsigned long l = 2;
-  const bool b6 = f1.operator==(static_cast<int>(static_cast<int>(l)));
+  const bool b6 = f1.operator==(static_cast<int>(l));
   const bool b7 = f1.operator==(dynamic_cast<Bar *>(&f2));
   const bool b8 = f1.operator==(reinterpret_cast<char *>(t));
   const bool b9 = f1.operator==(new char[2]);

--- a/tests/FunctionalCastTest.expect
+++ b/tests/FunctionalCastTest.expect
@@ -1,6 +1,6 @@
 int main()
 {
   int x;
-  x = int(static_cast<int>(0.5));
+  x = int(0.5);
 }
 

--- a/tests/ImplicitCast2Test.expect
+++ b/tests/ImplicitCast2Test.expect
@@ -30,6 +30,6 @@ int main()
   FloatingCast(static_cast<double>(f));
   int i = 1;
   IntegralToBoolean(static_cast<bool>(i));
-  int ii = int(static_cast<int>(A().operator int()));
+  int ii = int(A().operator int());
 }
 

--- a/tests/Issue223.cpp
+++ b/tests/Issue223.cpp
@@ -1,0 +1,7 @@
+#include <cstdio>
+
+int main()
+{
+  float f = (float)(3.0);
+  return f;
+}

--- a/tests/Issue223_2.cpp
+++ b/tests/Issue223_2.cpp
@@ -1,0 +1,8 @@
+// cmdlineinsights:-show-all-implicit-casts
+#include <cstdio>
+
+int main()
+{
+  float f = (float)(3.0);
+  return f;
+}

--- a/tests/Issue223_2.expect
+++ b/tests/Issue223_2.expect
@@ -1,0 +1,9 @@
+// cmdlineinsights:-show-all-implicit-casts
+#include <cstdio>
+
+int main()
+{
+  float f = static_cast<float>(static_cast<float>((3.0)));
+  return static_cast<int>(f);
+}
+

--- a/tests/VarTemplateDecl3Test.expect
+++ b/tests/VarTemplateDecl3Test.expect
@@ -5,7 +5,7 @@ template<class T>
 constexpr T pi = T(3.1415926535897932385L);
 
 template<>
-constexpr const int pi<int> = int(static_cast<int>(3.14159265358979323851L));
+constexpr const int pi<int> = int(3.14159265358979323851L);
 
  
 template<class T>

--- a/tests/VarTemplateWithLambdaTest.expect
+++ b/tests/VarTemplateWithLambdaTest.expect
@@ -19,7 +19,7 @@ class __lambda_5_23
   template<>
   inline /*constexpr */ double operator()(int x) const
   {
-    return double(static_cast<double>(x));
+    return double(x);
   }
   #endif
   


### PR DESCRIPTION
Both issues raised that there is a second `static_cast` after a C-style
cast. It turns out, that an `ImplicitCastExpr` has a method
`isPartOfExplicitCast`. This method together which the
`-show-all-implicit-casts` option is used to suppress the second cast
per default.