### PR TITLE
Use upper-case letters for builtin suffixes.

### DIFF
--- a/CodeGenerator.cpp
+++ b/CodeGenerator.cpp
@@ -2859,13 +2859,13 @@ const char* CodeGenerator::GetBuiltinTypeSuffix(const BuiltinType::Kind& kind)
 #define CASE(K, retVal)                                                                                                \
     case BuiltinType::K: return retVal
     switch(kind) {
-        CASE(UInt, "u");
-        CASE(ULong, "ul");
-        CASE(ULongLong, "ull");
-        CASE(UInt128, "ulll");
-        CASE(Long, "l");
-        CASE(LongLong, "ll");
-        CASE(Float, "f");
+        CASE(UInt, "U");
+        CASE(ULong, "UL");
+        CASE(ULongLong, "ULL");
+        CASE(UInt128, "ULLL");
+        CASE(Long, "L");
+        CASE(LongLong, "LL");
+        CASE(Float, "F");
         CASE(LongDouble, "L");
         default: return "";
     }

--- a/tests/AutoHandlerTest.expect
+++ b/tests/AutoHandlerTest.expect
@@ -65,11 +65,11 @@ int main()
   const char * pp = p;
   const char * cp = p;
   const volatile char * vcp = p;
-  float f = 1.0f;
+  float f = 1.0F;
   char c = 'c';
-  unsigned int u = 0u;
+  unsigned int u = 0U;
   decltype(u) uu = u;
-  unsigned int mu = 0u;
+  unsigned int mu = 0U;
   decltype(u) muu = u;
 }
 

--- a/tests/CharLiteralTest.expect
+++ b/tests/CharLiteralTest.expect
@@ -99,11 +99,11 @@ class Test
     data[static_cast<int>(this->GetLength().operator int()) + 1].operator=(u8'\n');
     data[static_cast<int>(this->GetLength().operator int()) + 1].operator=(static_cast<char>(u'\n'));
     data[static_cast<int>(this->GetLength().operator int()) + 1].operator=(static_cast<char>(U'\n'));
-    data[static_cast<int>(this->GetLength().operator int()) + 1].operator=(3u);
-    data[static_cast<int>(this->GetLength().operator int()) + 1].operator=(3ul);
-    data[static_cast<int>(this->GetLength().operator int()) + 1].operator=(3ull);
-    data[static_cast<int>(this->GetLength().operator int()) + 1].operator=(3ll);
-    data[static_cast<int>(this->GetLength().operator int()) + 1].operator=(3l);
+    data[static_cast<int>(this->GetLength().operator int()) + 1].operator=(3U);
+    data[static_cast<int>(this->GetLength().operator int()) + 1].operator=(3UL);
+    data[static_cast<int>(this->GetLength().operator int()) + 1].operator=(3ULL);
+    data[static_cast<int>(this->GetLength().operator int()) + 1].operator=(3LL);
+    data[static_cast<int>(this->GetLength().operator int()) + 1].operator=(3L);
   }
   
   inline Foo<int> GetLength() const

--- a/tests/ConstexprFunctionHandlerTest.expect
+++ b/tests/ConstexprFunctionHandlerTest.expect
@@ -6,7 +6,7 @@ inline constexpr int factorial(int n)
 
 inline constexpr float factorialFloat(int n)
 {
-  return n <= 1 ? 1.0f : (static_cast<float>(n) * factorialFloat(n - 1));
+  return n <= 1 ? 1.0F : (static_cast<float>(n) * factorialFloat(n - 1));
 }
 
 
@@ -20,7 +20,7 @@ int dummy(int n)
 
 inline constexpr float Get()
 {
-  return 23.9699993f;
+  return 23.9699993F;
 }
 
 

--- a/tests/FunctionalCast2Test.expect
+++ b/tests/FunctionalCast2Test.expect
@@ -16,7 +16,7 @@ namespace details::array_single_compare {
   template<>
   inline constexpr bool Compare<unsigned char, 6, int, 0, 1, 2, 3, 4, 5>(const unsigned char (&ar)[6], const int & to, std::integer_sequence<unsigned long, 0, 1, 2, 3, 4, 5>)
   {
-    return (to == static_cast<int>(ar[0ul])) && (to == static_cast<int>(ar[1ul])) && (to == static_cast<int>(ar[2ul])) && (to == static_cast<int>(ar[3ul])) && (to == static_cast<int>(ar[4ul])) && (to == static_cast<int>(ar[5ul]));
+    return (to == static_cast<int>(ar[0UL])) && (to == static_cast<int>(ar[1UL])) && (to == static_cast<int>(ar[2UL])) && (to == static_cast<int>(ar[3UL])) && (to == static_cast<int>(ar[4UL])) && (to == static_cast<int>(ar[5UL]));
   }
   #endif
   
@@ -50,7 +50,7 @@ namespace details::array_compare {
   template<>
   inline constexpr bool Compare<unsigned char, 6, 0, 1, 2, 3, 4, 5>(const unsigned char (&ar)[6], const unsigned char (&to)[6], std::integer_sequence<unsigned long, 0, 1, 2, 3, 4, 5>)
   {
-    return (static_cast<int>(to[0ul]) == static_cast<int>(ar[0ul])) && (static_cast<int>(to[1ul]) == static_cast<int>(ar[1ul])) && (static_cast<int>(to[2ul]) == static_cast<int>(ar[2ul])) && (static_cast<int>(to[3ul]) == static_cast<int>(ar[3ul])) && (static_cast<int>(to[4ul]) == static_cast<int>(ar[4ul])) && (static_cast<int>(to[5ul]) == static_cast<int>(ar[5ul]));
+    return (static_cast<int>(to[0UL]) == static_cast<int>(ar[0UL])) && (static_cast<int>(to[1UL]) == static_cast<int>(ar[1UL])) && (static_cast<int>(to[2UL]) == static_cast<int>(ar[2UL])) && (static_cast<int>(to[3UL]) == static_cast<int>(ar[3UL])) && (static_cast<int>(to[4UL]) == static_cast<int>(ar[4UL])) && (static_cast<int>(to[5UL]) == static_cast<int>(ar[5UL]));
   }
   #endif
   

--- a/tests/ImplicitCast2Test.expect
+++ b/tests/ImplicitCast2Test.expect
@@ -26,7 +26,7 @@ struct A
 
 int main()
 {
-  float f = 1.0f;
+  float f = 1.0F;
   FloatingCast(static_cast<double>(f));
   int i = 1;
   IntegralToBoolean(static_cast<bool>(i));

--- a/tests/InitializerListTest.expect
+++ b/tests/InitializerListTest.expect
@@ -105,7 +105,7 @@ void foo()
   takes_y({1, 2});
   bar(std::initializer_list<int>{1, 2});
   something(std::initializer_list<int>{1, 2});
-  something(std::initializer_list<float>{1.0f, 2.0f});
+  something(std::initializer_list<float>{1.0F, 2.0F});
   V v = V{std::initializer_list<int>{1}};
   V vv = V{std::initializer_list<int>{1, 2}};
 }

--- a/tests/Issue116.expect
+++ b/tests/Issue116.expect
@@ -13,8 +13,8 @@ int main()
     for(; operator!=(__begin1, __end1); __begin1.operator++()) 
     {
       std::pair<const std::basic_string<char>, std::basic_string<char> > & __operator9 = __begin1.operator*();
-      const std::basic_string<char>& key = std::get<0ul>(__operator9);
-      std::basic_string<char>& value = std::get<1ul>(__operator9);
+      const std::basic_string<char>& key = std::get<0UL>(__operator9);
+      std::basic_string<char>& value = std::get<1UL>(__operator9);
     }
     
   }

--- a/tests/Issue131.expect
+++ b/tests/Issue131.expect
@@ -4,6 +4,6 @@ std::tuple<int, float> foo();
 
  
 std::tuple<int, float> __foo5 = foo();
-std::tuple_element<0, std::tuple<int, float> >::type& a = std::get<0ul>(__foo5);
-std::tuple_element<1, std::tuple<int, float> >::type& b = std::get<1ul>(__foo5);
+std::tuple_element<0, std::tuple<int, float> >::type& a = std::get<0UL>(__foo5);
+std::tuple_element<1, std::tuple<int, float> >::type& b = std::get<1UL>(__foo5);
 

--- a/tests/Issue15.expect
+++ b/tests/Issue15.expect
@@ -50,10 +50,10 @@ inline constexpr int operator""_x<char, 49, 50, 51, 52, 53>()
 int main()
 {
   using namespace std::literals;
-  std::chrono::seconds t = std::operator""s(98291919ull);
+  std::chrono::seconds t = std::operator""s(98291919ULL);
   int t4 = operator""_x<char, 49, 50, 51, 52, 53>();
-  std::basic_string<char> str = operator""_str("abcd", 4ul);
-  std::chrono::duration<long long, std::ratio<1, 1> > sec = operator""_s(4ull);
+  std::basic_string<char> str = operator""_str("abcd", 4UL);
+  std::chrono::duration<long long, std::ratio<1, 1> > sec = operator""_s(4ULL);
   int cookedTemplateLiteral = operator""_cs<'4', '5', '6', '7'>();
 }
 

--- a/tests/Issue161.expect
+++ b/tests/Issue161.expect
@@ -6,7 +6,7 @@ int main(int argc, char ** argv)
   {
     char (&__range1)[10] = arr;
     char * __begin1 = __range1;
-    char * __end1 = __range1 + 10l;
+    char * __end1 = __range1 + 10L;
     for(; __begin1 != __end1; ++__begin1) 
     {
       char i = *__begin1;

--- a/tests/Issue20.expect
+++ b/tests/Issue20.expect
@@ -4,7 +4,7 @@ int main()
 {
   std::map<int, int> map = std::map<int, int, std::less<int>, std::allocator<std::pair<const int, int> > >{std::initializer_list<std::pair<const int, int> >{std::pair<const int, int>{1, 2}}, std::less<int>()};
   std::pair<const int, int> __operator6 = std::pair<const int, int>(map.begin().operator*());
-  std::tuple_element<0, std::pair<const int, int> >::type& key = std::get<0ul>(__operator6);
-  std::tuple_element<1, std::pair<const int, int> >::type& value = std::get<1ul>(__operator6);
+  std::tuple_element<0, std::pair<const int, int> >::type& key = std::get<0UL>(__operator6);
+  std::tuple_element<1, std::pair<const int, int> >::type& value = std::get<1UL>(__operator6);
 }
 

--- a/tests/Issue28.expect
+++ b/tests/Issue28.expect
@@ -4,6 +4,6 @@
 int main()
 {
   using namespace std::string_literals;
-  std::vector<std::string> foo = std::vector<std::basic_string<char>, std::allocator<std::basic_string<char> > >{std::initializer_list<std::basic_string<char> >{std::operator""s("foo", 3ul), std::operator""s("bar", 3ul)}};
+  std::vector<std::string> foo = std::vector<std::basic_string<char>, std::allocator<std::basic_string<char> > >{std::initializer_list<std::basic_string<char> >{std::operator""s("foo", 3UL), std::operator""s("bar", 3UL)}};
 }
 

--- a/tests/Issue45Example.expect
+++ b/tests/Issue45Example.expect
@@ -27,7 +27,7 @@ int main()
   {
     char (&__range1)[5] = data;
     char * __begin1 = __range1;
-    char * __end1 = __range1 + 5l;
+    char * __end1 = __range1 + 5L;
     for(; __begin1 != __end1; ++__begin1) 
     {
       char & x = *__begin1;

--- a/tests/Issue45Example11.expect
+++ b/tests/Issue45Example11.expect
@@ -27,7 +27,7 @@ int main()
   char data[5] = {'\0', '\0', '\0', '\0', '\0'};
   {
     char (&__range1)[5] = data;
-    for(char * __begin1 = __range1, *__end1 = __range1 + 5l; __begin1 != __end1; ++__begin1) 
+    for(char * __begin1 = __range1, *__end1 = __range1 + 5L; __begin1 != __end1; ++__begin1) 
     {
       char & x = *__begin1;
       x = 2;

--- a/tests/Issue45ExampleFor2While.expect
+++ b/tests/Issue45ExampleFor2While.expect
@@ -51,7 +51,7 @@ int main()
   {
     char (&__range1)[5] = data;
     char * __begin1 = __range1;
-    char * __end1 = __range1 + 5l;
+    char * __end1 = __range1 + 5L;
     {
       while(__begin1 != __end1) {
         char & x = *__begin1;

--- a/tests/LambdaHandler9Test.expect
+++ b/tests/LambdaHandler9Test.expect
@@ -12,7 +12,7 @@ int main()
       {
         char volatile (&__range1)[10] = buffer;
         volatile char * __begin1 = __range1;
-        volatile char * __end1 = __range1 + 10l;
+        volatile char * __end1 = __range1 + 10L;
         for(; __begin1 != __end1; ++__begin1) 
         {
           volatile char & c = *__begin1;

--- a/tests/LambdaInVarDeclTest.expect
+++ b/tests/LambdaInVarDeclTest.expect
@@ -4,7 +4,7 @@ int main()
   {
     char (&__range1)[4] = buffer;
     char * __begin1 = __range1;
-    char * __end1 = __range1 + 4l;
+    char * __end1 = __range1 + 4L;
     for(; __begin1 != __end1; ++__begin1) 
     {
       char & c = *__begin1;

--- a/tests/RangeForStmtHandler2Test.expect
+++ b/tests/RangeForStmtHandler2Test.expect
@@ -9,7 +9,7 @@ int main()
   {
     char (&__range1)[10] = arr;
     char * __begin1 = __range1;
-    char * __end1 = __range1 + 10l;
+    char * __end1 = __range1 + 10L;
     for(; __begin1 != __end1; ++__begin1) 
     {
       char c = *__begin1;

--- a/tests/RangeForStmtHandler2_11Test.expect
+++ b/tests/RangeForStmtHandler2_11Test.expect
@@ -8,7 +8,7 @@ int main()
   char arr[10] = {2, 4, 6, 8, 10, 12, 14, 16, 18, 20};
   {
     char (&__range1)[10] = arr;
-    for(char * __begin1 = __range1, *__end1 = __range1 + 10l; __begin1 != __end1; ++__begin1) 
+    for(char * __begin1 = __range1, *__end1 = __range1 + 10L; __begin1 != __end1; ++__begin1) 
     {
       char c = *__begin1;
     }

--- a/tests/RangeForStmtHandler6Test.expect
+++ b/tests/RangeForStmtHandler6Test.expect
@@ -7,7 +7,7 @@ int main()
     int pos = 0;
     int (&__range1)[5] = ar;
     int * __begin1 = __range1;
-    int * __end1 = __range1 + 5l;
+    int * __end1 = __range1 + 5L;
     for(; __begin1 != __end1; ++__begin1) 
     {
       const int v = *__begin1;
@@ -19,7 +19,7 @@ int main()
   {
     int (&__range1)[5] = ar;
     int * __begin1 = __range1;
-    int * __end1 = __range1 + 5l;
+    int * __end1 = __range1 + 5L;
     for(; __begin1 != __end1; ++__begin1) 
     {
       const int v = *__begin1;

--- a/tests/RangeForStmtHandler7Test.expect
+++ b/tests/RangeForStmtHandler7Test.expect
@@ -8,7 +8,7 @@ int main()
   char arr[10] = {2, 4, 6, 8, 10, 12, 14, 16, 18, 20};
   {
     char (&__range1)[10] = arr;
-    for(char * __begin1 = __range1, *__end1 = __range1 + 10l; __begin1 != __end1; ++__begin1) 
+    for(char * __begin1 = __range1, *__end1 = __range1 + 10L; __begin1 != __end1; ++__begin1) 
     {
       char c = *__begin1;
     }

--- a/tests/RangeForStmtHandlerTest.expect
+++ b/tests/RangeForStmtHandlerTest.expect
@@ -98,7 +98,7 @@ int main()
   {
     char (&__range1)[10] = arr;
     char * __begin1 = __range1;
-    char * __end1 = __range1 + 10l;
+    char * __end1 = __range1 + 10L;
     for(; __begin1 != __end1; ++__begin1) 
     {
       char c = *__begin1;

--- a/tests/StringViewLiteralTest.expect
+++ b/tests/StringViewLiteralTest.expect
@@ -5,7 +5,7 @@ int main()
 {
   using namespace std::literals;
   std::string_view s1 = std::basic_string_view<char, std::char_traits<char> >("abc\000\000def");
-  std::string_view s2 = std::operator""sv("abc\000\000def", 8ul);
+  std::string_view s2 = std::operator""sv("abc\000\000def", 8UL);
   std::operator<<(std::operator<<(std::operator<<(std::operator<<(std::cout, "s1: ").operator<<(s1.size()), " \""), std::basic_string_view<char, std::char_traits<char> >(s1)), "\"\n");
   std::operator<<(std::operator<<(std::operator<<(std::operator<<(std::cout, "s2: ").operator<<(s2.size()), " \""), std::basic_string_view<char, std::char_traits<char> >(s2)), "\"\n");
 }

--- a/tests/StructuredBindingsHandler3Test.cerr
+++ b/tests/StructuredBindingsHandler3Test.cerr
@@ -13,70 +13,70 @@ struct tuple_element<N, constant::Q>
 namespace std { template<size_t, typename> struct tuple_element;
                                                   ^
 .tmp.cpp:101:46: error: no matching function for call to 'get'
-std::tuple_element<0, constant::Q>::type a = constant::get<0ul>(constant::__q17);
+std::tuple_element<0, constant::Q>::type a = constant::get<0UL>(constant::__q17);
                                              ^~~~~~~~~~~~~~~~~~
 .tmp.cpp:50:33: note: candidate function template not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
   template<int N> constexpr int get(Q &&) { return N * N; }
                                 ^
 .tmp.cpp:102:46: error: no matching function for call to 'get'
-std::tuple_element<1, constant::Q>::type b = constant::get<1ul>(constant::__q17);
+std::tuple_element<1, constant::Q>::type b = constant::get<1UL>(constant::__q17);
                                              ^~~~~~~~~~~~~~~~~~
 .tmp.cpp:50:33: note: candidate function template not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
   template<int N> constexpr int get(Q &&) { return N * N; }
                                 ^
 .tmp.cpp:103:65: error: use of undeclared identifier 'conststd'
-std::tuple_element<2, constant::Q>::type c = constant::get<2ul>(conststd::tuple_element<0, constant::Q>::type && a = constant::get<0ul>(constant::);
+std::tuple_element<2, constant::Q>::type c = constant::get<2UL>(conststd::tuple_element<0, constant::Q>::type && a = constant::get<0UL>(constant::);
                                                                 ^
 .tmp.cpp:103:103: error: expected '(' for function-style cast or type construction
-std::tuple_element<2, constant::Q>::type c = constant::get<2ul>(conststd::tuple_element<0, constant::Q>::type && a = constant::get<0ul>(constant::);
+std::tuple_element<2, constant::Q>::type c = constant::get<2UL>(conststd::tuple_element<0, constant::Q>::type && a = constant::get<0UL>(constant::);
                                                                                            ~~~~~~~~~~~^
 .tmp.cpp:103:106: error: no member named 'type' in the global namespace
-std::tuple_element<2, constant::Q>::type c = constant::get<2ul>(conststd::tuple_element<0, constant::Q>::type && a = constant::get<0ul>(constant::);
+std::tuple_element<2, constant::Q>::type c = constant::get<2UL>(conststd::tuple_element<0, constant::Q>::type && a = constant::get<0UL>(constant::);
                                                                                                        ~~^
 .tmp.cpp:103:147: error: expected unqualified-id
-std::tuple_element<2, constant::Q>::type c = constant::get<2ul>(conststd::tuple_element<0, constant::Q>::type && a = constant::get<0ul>(constant::);
+std::tuple_element<2, constant::Q>::type c = constant::get<2UL>(conststd::tuple_element<0, constant::Q>::type && a = constant::get<0UL>(constant::);
                                                                                                                                                   ^
 .tmp.cpp:104:36: error: expected '(' for function-style cast or type construction
-ntstd::tuple_element<1, constant::Q>::type && b = constant::get<1ul>(constant::);
+ntstd::tuple_element<1, constant::Q>::type && b = constant::get<1UL>(constant::);
                         ~~~~~~~~~~~^
 .tmp.cpp:104:39: error: no member named 'type' in the global namespace
-ntstd::tuple_element<1, constant::Q>::type && b = constant::get<1ul>(constant::);
+ntstd::tuple_element<1, constant::Q>::type && b = constant::get<1UL>(constant::);
                                     ~~^
 .tmp.cpp:104:80: error: expected unqualified-id
-ntstd::tuple_element<1, constant::Q>::type && b = constant::get<1ul>(constant::);
+ntstd::tuple_element<1, constant::Q>::type && b = constant::get<1UL>(constant::);
                                                                                ^
 .tmp.cpp:105:36: error: expected '(' for function-style cast or type construction
-:_std::tuple_element<2, constant::Q>::type && c = constant::get<2ul>(constant::);
+:_std::tuple_element<2, constant::Q>::type && c = constant::get<2UL>(constant::);
                         ~~~~~~~~~~~^
 .tmp.cpp:105:39: error: no member named 'type' in the global namespace
-:_std::tuple_element<2, constant::Q>::type && c = constant::get<2ul>(constant::);
+:_std::tuple_element<2, constant::Q>::type && c = constant::get<2UL>(constant::);
                                     ~~^
 .tmp.cpp:105:80: error: expected unqualified-id
-:_std::tuple_element<2, constant::Q>::type && c = constant::get<2ul>(constant::);
+:_std::tuple_element<2, constant::Q>::type && c = constant::get<2UL>(constant::);
                                                                                ^
 .tmp.cpp:111:50: error: no matching function for call to 'get'
-    std::tuple_element<0, constant::Q>::type a = constant::get<0ul>(__q19);
+    std::tuple_element<0, constant::Q>::type a = constant::get<0UL>(__q19);
                                                  ^~~~~~~~~~~~~~~~~~
 .tmp.cpp:50:33: note: candidate function template not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
   template<int N> constexpr int get(Q &&) { return N * N; }
                                 ^
 .tmp.cpp:112:50: error: no matching function for call to 'get'
-    std::tuple_element<1, constant::Q>::type b = constant::get<1ul>(__q19);
+    std::tuple_element<1, constant::Q>::type b = constant::get<1UL>(__q19);
                                                  ^~~~~~~~~~~~~~~~~~
 .tmp.cpp:50:33: note: candidate function template not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
   template<int N> constexpr int get(Q &&) { return N * N; }
                                 ^
 .tmp.cpp:113:50: error: no matching function for call to 'get'
-    std::tuple_element<2, constant::Q>::type c = constant::get<2ul>(__q19);
+    std::tuple_element<2, constant::Q>::type c = constant::get<2UL>(__q19);
                                                  ^~~~~~~~~~~~~~~~~~
 .tmp.cpp:50:33: note: candidate function template not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
   template<int N> constexpr int get(Q &&) { return N * N; }
                                 ^
 .tmp.cpp:111:46: error: variables defined in a constexpr function must be initialized
-    std::tuple_element<0, constant::Q>::type a = constant::get<0ul>(__q19);
+    std::tuple_element<0, constant::Q>::type a = constant::get<0UL>(__q19);
                                              ^
 .tmp.cpp:123:52: error: no matching function for call to 'get'
-      std::tuple_element<0, constant::Q>::type a = constant::get<0ul>(__q26);
+      std::tuple_element<0, constant::Q>::type a = constant::get<0UL>(__q26);
                                                    ^~~~~~~~~~~~~~~~~~
 .tmp.cpp:50:33: note: candidate function template not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
   template<int N> constexpr int get(Q &&) { return N * N; }

--- a/tests/StructuredBindingsHandler3Test.expect
+++ b/tests/StructuredBindingsHandler3Test.expect
@@ -98,19 +98,19 @@ namespace constant {
 
   // This creates and lifetime-extends a temporary to hold the result of each get() call.
   constant::Q __q17 = constant::Q(constant::q);
-std::tuple_element<0, constant::Q>::type a = constant::get<0ul>(constant::__q17);
-std::tuple_element<1, constant::Q>::type b = constant::get<1ul>(constant::__q17);
-std::tuple_element<2, constant::Q>::type c = constant::get<2ul>(conststd::tuple_element<0, constant::Q>::type && a = constant::get<0ul>(constant::);
-ntstd::tuple_element<1, constant::Q>::type && b = constant::get<1ul>(constant::);
-:_std::tuple_element<2, constant::Q>::type && c = constant::get<2ul>(constant::);
+std::tuple_element<0, constant::Q>::type a = constant::get<0UL>(constant::__q17);
+std::tuple_element<1, constant::Q>::type b = constant::get<1UL>(constant::__q17);
+std::tuple_element<2, constant::Q>::type c = constant::get<2UL>(conststd::tuple_element<0, constant::Q>::type && a = constant::get<0UL>(constant::);
+ntstd::tuple_element<1, constant::Q>::type && b = constant::get<1UL>(constant::);
+:_std::tuple_element<2, constant::Q>::type && c = constant::get<2UL>(constant::);
 q17);
     // expected-note {{temporary}}
   inline constexpr bool f()
   {
     constant::Q __q19 = constant::Q(constant::q);
-    std::tuple_element<0, constant::Q>::type a = constant::get<0ul>(__q19);
-    std::tuple_element<1, constant::Q>::type b = constant::get<1ul>(__q19);
-    std::tuple_element<2, constant::Q>::type c = constant::get<2ul>(__q19);
+    std::tuple_element<0, constant::Q>::type a = constant::get<0UL>(__q19);
+    std::tuple_element<1, constant::Q>::type b = constant::get<1UL>(__q19);
+    std::tuple_element<2, constant::Q>::type c = constant::get<2UL>(__q19);
     return a == 0 && b == 1 && c == 4;
   }
   
@@ -120,9 +120,9 @@ q17);
     int * p = nullptr;
     {
       constant::Q __q26 = constant::Q(constant::q);
-      std::tuple_element<0, constant::Q>::type a = constant::get<0ul>(__q26);
-      std::tuple_element<1, constant::Q>::type b = constant::get<1ul>(__q26);
-      std::tuple_element<2, constant::Q>::type c = constant::get<2ul>(__q26);
+      std::tuple_element<0, constant::Q>::type a = constant::get<0UL>(__q26);
+      std::tuple_element<1, constant::Q>::type b = constant::get<1UL>(__q26);
+      std::tuple_element<2, constant::Q>::type c = constant::get<2UL>(__q26);
       p = &c;
     };
     return *p;

--- a/tests/StructuredBindingsHandler5Test.expect
+++ b/tests/StructuredBindingsHandler5Test.expect
@@ -76,9 +76,9 @@ class Point
   template<>
   inline constexpr double & get<0>() noexcept
   {
-    if constexpr(0ul == 1) ;
+    if constexpr(0UL == 1) ;
     else /* constexpr */ {
-      if constexpr(0ul == 0) {
+      if constexpr(0UL == 0) {
         return (this->mY);
       }
       
@@ -94,7 +94,7 @@ class Point
   template<>
   inline constexpr double get<1>() noexcept
   {
-    if constexpr(1ul == 1) {
+    if constexpr(1UL == 1) {
       return this->GetX();
     }
     
@@ -121,9 +121,9 @@ class Point
   template<>
   inline constexpr const double & get<0>() const noexcept
   {
-    if constexpr(0ul == 1) ;
+    if constexpr(0UL == 1) ;
     else /* constexpr */ {
-      if constexpr(0ul == 0) {
+      if constexpr(0UL == 0) {
         return (this->mY);
       }
       
@@ -139,7 +139,7 @@ class Point
   template<>
   inline constexpr double get<1>() const noexcept
   {
-    if constexpr(1ul == 1) {
+    if constexpr(1UL == 1) {
       return this->GetX();
     }
     

--- a/tests/StructuredBindingsHandler6Test.expect
+++ b/tests/StructuredBindingsHandler6Test.expect
@@ -85,9 +85,9 @@ class Point
   template<>
   inline constexpr double get<0>() const noexcept
   {
-    if constexpr(0ul == 1) ;
+    if constexpr(0UL == 1) ;
     else /* constexpr */ {
-      if constexpr(0ul == 0) {
+      if constexpr(0UL == 0) {
         return this->mY;
       }
       
@@ -103,7 +103,7 @@ class Point
   template<>
   inline constexpr double get<1>() const noexcept
   {
-    if constexpr(1ul == 1) {
+    if constexpr(1UL == 1) {
       return this->GetX();
     }
     
@@ -145,12 +145,12 @@ int main()
   const char& a19 = __aa75[1];
   std::tuple<int, char, double> muple = std::make_tuple(1, 'a', 2.2999999999999998);
   std::tuple<int, char, double> & __muple80 = muple;
-  std::tuple_element<0, std::tuple<int, char, double> >::type& i = std::get<0ul>(__muple80);
-  std::tuple_element<1, std::tuple<int, char, double> >::type& c = std::get<1ul>(__muple80);
-  std::tuple_element<2, std::tuple<int, char, double> >::type& d = std::get<2ul>(__muple80);
+  std::tuple_element<0, std::tuple<int, char, double> >::type& i = std::get<0UL>(__muple80);
+  std::tuple_element<1, std::tuple<int, char, double> >::type& c = std::get<1UL>(__muple80);
+  std::tuple_element<2, std::tuple<int, char, double> >::type& d = std::get<2UL>(__muple80);
   std::tuple<int, char, double> __muple82 = std::tuple<int, char, double>(muple);
-  std::tuple_element<0, std::tuple<int, char, double> >::type& ii = std::get<0ul>(__muple82);
-  std::tuple_element<1, std::tuple<int, char, double> >::type& cc = std::get<1ul>(__muple82);
-  std::tuple_element<2, std::tuple<int, char, double> >::type& dd = std::get<2ul>(__muple82);
+  std::tuple_element<0, std::tuple<int, char, double> >::type& ii = std::get<0UL>(__muple82);
+  std::tuple_element<1, std::tuple<int, char, double> >::type& cc = std::get<1UL>(__muple82);
+  std::tuple_element<2, std::tuple<int, char, double> >::type& dd = std::get<2UL>(__muple82);
 }
 

--- a/tests/StructuredBindingsHandler9Test.expect
+++ b/tests/StructuredBindingsHandler9Test.expect
@@ -4,12 +4,12 @@ std::tuple<int, float> foo = std::tuple<int, float>();
 
  
 std::tuple<int, float> __foo5 = std::tuple<int, float>(foo);
-std::tuple_element<0, std::tuple<int, float> >::type& a = std::get<0ul>(__foo5);
-std::tuple_element<1, std::tuple<int, float> >::type& b = std::get<1ul>(__foo5);
+std::tuple_element<0, std::tuple<int, float> >::type& a = std::get<0UL>(__foo5);
+std::tuple_element<1, std::tuple<int, float> >::type& b = std::get<1UL>(__foo5);
 
 std::tuple<int, float> & __foo6 = foo;
-std::tuple_element<0, std::tuple<int, float> >::type& ra = std::get<0ul>(__foo6);
-std::tuple_element<1, std::tuple<int, float> >::type& rb = std::get<1ul>(__foo6);
+std::tuple_element<0, std::tuple<int, float> >::type& ra = std::get<0UL>(__foo6);
+std::tuple_element<1, std::tuple<int, float> >::type& rb = std::get<1UL>(__foo6);
 
 
 
@@ -33,6 +33,6 @@ std::tuple<int, float> Func();
 
  
 const std::tuple<int, float> & __Func18 = Func();
-std::tuple_element<0, const std::tuple<int, float> >::type& fa = std::get<0ul>(__Func18);
-std::tuple_element<1, const std::tuple<int, float> >::type& fb = std::get<1ul>(__Func18);
+std::tuple_element<0, const std::tuple<int, float> >::type& fa = std::get<0UL>(__Func18);
+std::tuple_element<1, const std::tuple<int, float> >::type& fb = std::get<1UL>(__Func18);
 

--- a/tests/TemplateExpansion2Test.expect
+++ b/tests/TemplateExpansion2Test.expect
@@ -43,9 +43,9 @@ struct remove_reference<T &&>
   template<>
   struct extent<int [16], 0>
   {
-    inline static constexpr const size_t value = 16ul;
+    inline static constexpr const size_t value = 16UL;
     
-    /* PASSED: static_assert(16ul != 0, "Arrays only"); */
+    /* PASSED: static_assert(16UL != 0, "Arrays only"); */
   };
   
   #endif

--- a/tests/TupeInRangeBasedForTest.expect
+++ b/tests/TupeInRangeBasedForTest.expect
@@ -29,8 +29,8 @@ int main()
     for(; std::operator!=(__begin1, __end1); __begin1.operator++()) 
     {
       std::tuple<std::basic_string<char>, int> __operator15 = std::tuple<std::basic_string<char>, int>(__begin1.operator*());
-      std::basic_string<char>& s = std::get<0ul>(__operator15);
-      std::tuple_element<1, std::tuple<std::basic_string<char>, int> >::type& n = std::get<1ul>(__operator15);
+      std::basic_string<char>& s = std::get<0UL>(__operator15);
+      std::tuple_element<1, std::tuple<std::basic_string<char>, int> >::type& n = std::get<1UL>(__operator15);
       printf("c=%s, n=%d\n", s.c_str(), n);
     }
     

--- a/tests/UserDefinedLiteral2Test.expect
+++ b/tests/UserDefinedLiteral2Test.expect
@@ -10,6 +10,6 @@ inline constexpr std::chrono::duration<long long, std::ratio<1, 1> > operator""_
 
 int main()
 {
-  std::chrono::duration<long long, std::ratio<1, 1> > s = operator""_s(1ull);
+  std::chrono::duration<long long, std::ratio<1, 1> > s = operator""_s(1ULL);
 }
 

--- a/tests/UserDefinedLiteralTest.expect
+++ b/tests/UserDefinedLiteralTest.expect
@@ -16,6 +16,6 @@ inline constexpr std::chrono::duration<long double, std::ratio<1, 1> > operator"
 
 //------------------------------------------------------------------------------
 
-static constexpr const seconds_t TIMEOUT = {operator""_s(1ull)};
+static constexpr const seconds_t TIMEOUT = {operator""_s(1ULL)};
 
 

--- a/tests/UsingDeclTest.expect
+++ b/tests/UsingDeclTest.expect
@@ -122,7 +122,7 @@ int main()
   std::string str = std::basic_string<char>("Example");
   D<int> d = D<int>();
   using namespace std::string_literals;
-  std::basic_string<char> str2 = std::operator""s("abc", 3ul);
+  std::basic_string<char> str2 = std::operator""s("abc", 3UL);
   using Vec = Test::Alloc;
   Vec v = Vec();
   using W = Test::West;

--- a/tests/constexprPoint.expect
+++ b/tests/constexprPoint.expect
@@ -44,7 +44,7 @@
 int main()
 {
   constexpr const Point p = Point{2.0, 3.0};
-  constexpr const double x = static_cast<const double>(2.0f);
+  constexpr const double x = static_cast<const double>(2.0F);
   return static_cast<int>(p.GetX());
 }
 


### PR DESCRIPTION
The lower version is sometimes troublesome to identify like when it
comes to the lower L. In numbers like 10l is sometimes looks like
another 1 (one).