### PR TITLE
Fixed #238: Prevent crash of a range-based for-loop in an unevaluated context.

### DIFF
--- a/CodeGenerator.cpp
+++ b/CodeGenerator.cpp
@@ -258,8 +258,13 @@ void CodeGenerator::InsertArg(const CXXForRangeStmt* rangeForStmt)
     AddBodyStmts(bodyStmts, rwStmt->getBody());
 
     const auto& ctx = rangeForStmt->getLoopVariable()->getASTContext();
-    Decl*       decls[2]{rwStmt->getBeginStmt()->getSingleDecl(), rwStmt->getEndStmt()->getSingleDecl()};
-    auto        dgRef = DeclGroupRef::Create(const_cast<ASTContext&>(ctx), decls, 2);
+
+    // In case of a range-based for-loop inside an unevaluated template the begin and end statements are not present. In
+    // this case just add a nullptr.
+    Decl* decls[2]{rwStmt->getBeginStmt() ? rwStmt->getBeginStmt()->getSingleDecl() : nullptr,
+                   rwStmt->getEndStmt() ? rwStmt->getEndStmt()->getSingleDecl() : nullptr};
+
+    auto dgRef = DeclGroupRef::Create(const_cast<ASTContext&>(ctx), decls, 2);
 
     auto* declStmt = [&]() -> DeclStmt* {
         if(onlyCpp11) {

--- a/tests/Issue238.cerr
+++ b/tests/Issue238.cerr
@@ -1,0 +1,13 @@
+.tmp.cpp:7:5: error: templates cannot be declared inside of a local class
+    template<class type_parameter_0_0>
+    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.tmp.cpp:20:5: error: templates cannot be declared inside of a local class
+    template<class type_parameter_0_0>
+    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.tmp.cpp:14:16: error: declaration of variable 'test' with deduced type 'auto' requires an initializer
+          auto test;
+               ^
+.tmp.cpp:27:16: error: declaration of variable 'test' with deduced type 'auto' requires an initializer
+          auto test;
+               ^
+4 errors generated.

--- a/tests/Issue238.cpp
+++ b/tests/Issue238.cpp
@@ -1,0 +1,1 @@
+void f() { auto lambda = [](auto container) { for(auto test : container) { } }; }

--- a/tests/Issue238.expect
+++ b/tests/Issue238.expect
@@ -1,0 +1,37 @@
+void f()
+{
+    
+  class __lambda_1_26
+  {
+    public: 
+    template<class type_parameter_0_0>
+    inline /*constexpr */ auto operator()(type_parameter_0_0 container) const
+    {
+      {
+        auto && __range1 = container;
+        for(; ; ) 
+        {
+          auto test;
+        }
+        
+      }
+    }
+    private: 
+    template<class type_parameter_0_0>
+    static inline auto __invoke(type_parameter_0_0 container)
+    {
+      {
+        auto && __range1 = container;
+        for(; ; ) 
+        {
+          auto test;
+        }
+        
+      }
+    }
+    
+  };
+  
+  __lambda_1_26 lambda = __lambda_1_26{};
+}
+

--- a/tests/Issue238_2.cerr
+++ b/tests/Issue238_2.cerr
@@ -1,0 +1,16 @@
+.tmp.cpp:48:5: error: templates cannot be declared inside of a local class
+    template<class type_parameter_0_0>
+    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.tmp.cpp:80:5: error: templates cannot be declared inside of a local class
+    template<class type_parameter_0_0>
+    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.tmp.cpp:55:16: error: declaration of variable 'test' with deduced type 'auto' requires an initializer
+          auto test;
+               ^
+.tmp.cpp:87:16: error: declaration of variable 'test' with deduced type 'auto' requires an initializer
+          auto test;
+               ^
+.tmp.cpp:97:10: error: no matching member function for call to 'operator()'
+  lambda.operator()(MyArrayWrapper<int>(vec));
+  ~~~~~~~^~~~~~~~~~
+5 errors generated.

--- a/tests/Issue238_2.cpp
+++ b/tests/Issue238_2.cpp
@@ -1,0 +1,21 @@
+// dummy to have a range-based for ready container link thing
+template<class T>
+class MyArrayWrapper {
+   T* data;
+   int size;
+
+public:
+   int* begin() { return size>0 ? &data[0] : nullptr; }
+   int* end()   { return size>0 ? &data[size-1] : nullptr; }
+};
+
+
+
+void f() {
+  auto lambda = [](auto container) {
+    for(auto test : container) { }
+  };
+
+  MyArrayWrapper<int> vec{};
+  lambda(vec);
+}

--- a/tests/Issue238_2.expect
+++ b/tests/Issue238_2.expect
@@ -1,0 +1,99 @@
+// dummy to have a range-based for ready container link thing
+template<class T>
+class MyArrayWrapper {
+   T* data;
+   int size;
+
+public:
+   int* begin() { return size>0 ? &data[0] : nullptr; }
+   int* end()   { return size>0 ? &data[size-1] : nullptr; }
+};
+
+/* First instantiated from: Issue238_2.cpp:19 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+class MyArrayWrapper<int>
+{
+  int * data;
+  int size;
+  
+  public: 
+  inline int * begin()
+  {
+    return this->size > 0 ? &this->data[0] : nullptr;
+  }
+  
+  inline int * end()
+  {
+    return this->size > 0 ? &this->data[this->size - 1] : nullptr;
+  }
+  
+  // inline MyArrayWrapper() noexcept = default;
+  // inline constexpr MyArrayWrapper(const MyArrayWrapper<int> &) noexcept = default;
+  // inline constexpr MyArrayWrapper(MyArrayWrapper<int> &&) = default;
+  // inline ~MyArrayWrapper() noexcept = default;
+};
+
+#endif
+
+
+
+
+void f()
+{
+    
+  class __lambda_15_17
+  {
+    public: 
+    template<class type_parameter_0_0>
+    inline /*constexpr */ auto operator()(type_parameter_0_0 container) const
+    {
+      {
+        auto && __range1 = container;
+        for(; ; ) 
+        {
+          auto test;
+        }
+        
+      }
+    }
+    
+    /* First instantiated from: Issue238_2.cpp:20 */
+    #ifdef INSIGHTS_USE_TEMPLATE
+    template<>
+    inline /*constexpr */ void operator()(MyArrayWrapper<int> container) const
+    {
+      {
+        MyArrayWrapper<int> & __range1 = container;
+        int * __begin0 = __range1.begin();
+        int * __end0 = __range1.end();
+        for(; __begin0 != __end0; ++__begin0) 
+        {
+          int test = *__begin0;
+        }
+        
+      }
+    }
+    #endif
+    
+    private: 
+    template<class type_parameter_0_0>
+    static inline auto __invoke(type_parameter_0_0 container)
+    {
+      {
+        auto && __range1 = container;
+        for(; ; ) 
+        {
+          auto test;
+        }
+        
+      }
+    }
+    
+  };
+  
+  __lambda_15_17 lambda = __lambda_15_17{};
+  MyArrayWrapper<int> vec = MyArrayWrapper<int>{};
+  lambda.operator()(MyArrayWrapper<int>(vec));
+}
+

--- a/tests/Issue238_3.cerr
+++ b/tests/Issue238_3.cerr
@@ -1,0 +1,13 @@
+.tmp.cpp:8:5: error: templates cannot be declared inside of a local class
+    template<class type_parameter_0_0, class type_parameter_0_1>
+    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.tmp.cpp:22:5: error: templates cannot be declared inside of a local class
+    template<class type_parameter_0_0, class type_parameter_0_1>
+    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.tmp.cpp:16:16: error: declaration of variable 'test' with deduced type 'auto' requires an initializer
+          auto test;
+               ^
+.tmp.cpp:30:16: error: declaration of variable 'test' with deduced type 'auto' requires an initializer
+          auto test;
+               ^
+4 errors generated.

--- a/tests/Issue238_3.cpp
+++ b/tests/Issue238_3.cpp
@@ -1,0 +1,2 @@
+// cmdline:-std=c++2a
+void f() { auto lambda = [](auto init, auto container) { for(auto i=init; auto test : container) { } }; }

--- a/tests/Issue238_3.expect
+++ b/tests/Issue238_3.expect
@@ -1,0 +1,40 @@
+// cmdline:-std=c++2a
+void f()
+{
+    
+  class __lambda_2_26
+  {
+    public: 
+    template<class type_parameter_0_0, class type_parameter_0_1>
+    inline /*constexpr */ auto operator()(type_parameter_0_0 init, type_parameter_0_1 container) const
+    {
+      {
+        auto i = init;
+        auto && __range1 = container;
+        for(; ; ) 
+        {
+          auto test;
+        }
+        
+      }
+    }
+    private: 
+    template<class type_parameter_0_0, class type_parameter_0_1>
+    static inline auto __invoke(type_parameter_0_0 init, type_parameter_0_1 container)
+    {
+      {
+        auto i = init;
+        auto && __range1 = container;
+        for(; ; ) 
+        {
+          auto test;
+        }
+        
+      }
+    }
+    
+  };
+  
+  __lambda_2_26 lambda = __lambda_2_26{};
+}
+


### PR DESCRIPTION
In case of a range-based for-loop in something like a template the types
of range statements are not known. In this case just omit them as they
are not there.