### PR TITLE
Fixed #233: Show when the compiler deletes a special member.

### DIFF
--- a/CodeGenerator.cpp
+++ b/CodeGenerator.cpp
@@ -1875,10 +1875,11 @@ void CodeGenerator::InsertCXXMethodHeader(const CXXMethodDecl* stmt, OutputForma
     InsertTemplateGuardBegin(stmt);
     InsertAccessModifierAndNameWithReturnType(*stmt, SkipAccess::Yes, cxxInheritedCtorDecl);
 
-    if(stmt->isDefaulted()) {
-        mOutputFormatHelper.AppendNewLine(" = default;");
-    } else if(stmt->isDeleted()) {
+    if(stmt->isDeleted()) {
         mOutputFormatHelper.AppendNewLine(" = delete;");
+
+    } else if(stmt->isDefaulted()) {
+        mOutputFormatHelper.AppendNewLine(" = default;");
     }
 }
 //-----------------------------------------------------------------------------

--- a/tests/Class2Test.expect
+++ b/tests/Class2Test.expect
@@ -62,7 +62,7 @@ struct S
 {
   Test count;
   // inline S(S &) = default;
-  // inline constexpr S(S &&) = default;
+  // inline constexpr S(S &&) = delete;
   // inline S & operator=(S &&) = default;
   // inline S() noexcept(false) = default;
 };

--- a/tests/Issue2.expect
+++ b/tests/Issue2.expect
@@ -36,7 +36,7 @@ int main()
     {
     }
     
-    // inline __lambda_20_16(const __lambda_20_16 &) = default;
+    // inline __lambda_20_16(const __lambda_20_16 &) = delete;
     // inline __lambda_20_16(__lambda_20_16 &&) = default;
     public: __lambda_20_16(Movable _x, int _c)
     : x{_x}

--- a/tests/Issue205.expect
+++ b/tests/Issue205.expect
@@ -23,7 +23,7 @@ class EventContainer
       std::cout.operator<<(__this->val);
     }
     
-    // inline /*constexpr */ __lambda_6_43 & operator=(const __lambda_6_43 &) = default;
+    // inline /*constexpr */ __lambda_6_43 & operator=(const __lambda_6_43 &) = delete;
     // inline /*constexpr */ __lambda_6_43(const __lambda_6_43 &) noexcept = default;
     // inline /*constexpr */ __lambda_6_43(__lambda_6_43 &&) noexcept = default;
     public: __lambda_6_43(EventContainer * _this)

--- a/tests/Issue205_2.expect
+++ b/tests/Issue205_2.expect
@@ -18,7 +18,7 @@ class EventContainer
       std::cout.operator<<(__this->val);
     }
     
-    // inline /*constexpr */ __lambda_6_43 & operator=(const __lambda_6_43 &) = default;
+    // inline /*constexpr */ __lambda_6_43 & operator=(const __lambda_6_43 &) = delete;
     // inline /*constexpr */ __lambda_6_43(const __lambda_6_43 &) noexcept = default;
     // inline /*constexpr */ __lambda_6_43(__lambda_6_43 &&) noexcept = default;
     public: __lambda_6_43(EventContainer * _this)

--- a/tests/Issue233.cpp
+++ b/tests/Issue233.cpp
@@ -1,0 +1,12 @@
+struct C { 
+  int &i; 
+  C() = default;
+  C(C const&) = default;
+};
+
+int main() {
+    int i;
+	C c{i};
+  
+}
+

--- a/tests/Issue233.expect
+++ b/tests/Issue233.expect
@@ -1,0 +1,16 @@
+struct C
+{
+  int & i;
+  inline C() = delete;
+  inline constexpr C(const C &) = default;
+};
+
+
+
+int main()
+{
+  int i;
+  C c = {i};
+}
+
+

--- a/tests/SpecialMemberTest.expect
+++ b/tests/SpecialMemberTest.expect
@@ -5,7 +5,7 @@ class C
 {
   
   public: 
-  inline C() = default;
+  inline C() = delete;
   
   private: 
   const int i;
@@ -22,7 +22,7 @@ class D
   private: 
   std::unique_ptr<int, std::default_delete<int> > p;
   public: 
-  // inline constexpr D(const D &) = default;
+  // inline constexpr D(const D &) = delete;
   // inline D(D &&) = default;
   // inline D & operator=(D &&) = default;
   // inline ~D() = default;

--- a/tests/VisitorTest.expect
+++ b/tests/VisitorTest.expect
@@ -11,7 +11,7 @@ struct visitor<__lambda_8_7, __lambda_9_7> : public __lambda_8_7, public __lambd
   using __lambda_9_7::operator();
   // inline /*constexpr */ void ::operator()(const char * value) const;
   
-  // inline constexpr visitor<__lambda_8_7, __lambda_9_7> & operator=(visitor<__lambda_8_7, __lambda_9_7> &&) = default;
+  // inline constexpr visitor<__lambda_8_7, __lambda_9_7> & operator=(visitor<__lambda_8_7, __lambda_9_7> &&) = delete;
   // inline ~visitor() noexcept = default;
 };
 
@@ -37,7 +37,7 @@ int main()
     {
     }
     
-    // inline /*constexpr */ __lambda_8_7 & operator=(const __lambda_8_7 &) = default;
+    // inline /*constexpr */ __lambda_8_7 & operator=(const __lambda_8_7 &) = delete;
     // inline /*constexpr */ __lambda_8_7(const __lambda_8_7 &) = default;
     // inline /*constexpr */ __lambda_8_7(__lambda_8_7 &&) noexcept = default;
     
@@ -51,7 +51,7 @@ int main()
     {
     }
     
-    // inline /*constexpr */ __lambda_9_7 & operator=(const __lambda_9_7 &) = default;
+    // inline /*constexpr */ __lambda_9_7 & operator=(const __lambda_9_7 &) = delete;
     // inline /*constexpr */ __lambda_9_7(const __lambda_9_7 &) = default;
     // inline /*constexpr */ __lambda_9_7(__lambda_9_7 &&) noexcept = default;
     

--- a/tests/usingConstructorTest.expect
+++ b/tests/usingConstructorTest.expect
@@ -22,7 +22,7 @@ class Bar : public Foo
   
   public: 
   int mX;
-  // inline Bar() = default;
+  // inline Bar() = delete;
   // inline constexpr Bar(const Bar &) = default;
   // inline constexpr Bar(Bar &&) = default;
   public: inline Bar(double amount) noexcept(false)
@@ -45,7 +45,7 @@ class Bla : public Foo
   private: 
   int mX;
   public: 
-  // inline Bla() = default;
+  // inline Bla() = delete;
   // inline constexpr Bla(const Bla &) = default;
   // inline constexpr Bla(Bla &&) = default;
   public: inline Bla(int x, int y) noexcept(false)


### PR DESCRIPTION
The order in which C++ Insights evaluated whether a special member was
defaulted or deleted was wrong. The deleted check should be before the
defaulted.