### PR TITLE
Renamed CompilerGeneratedHandler to RecordDeclHandler.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -411,7 +411,6 @@ endif()
 # name the executable and all source files
 add_clang_tool(insights
     CodeGenerator.cpp
-    CompilerGeneratedHandler.cpp
     DPrint.cpp
     FunctionDeclHandler.cpp
     GlobalVariableHandler.cpp
@@ -419,6 +418,7 @@ add_clang_tool(insights
     InsightsBase.cpp
     InsightsHelpers.cpp
     OutputFormatHelper.cpp
+    RecordDeclHandler.cpp
     StaticAssertHandler.cpp
     TemplateHandler.cpp
 )

--- a/Insights.cpp
+++ b/Insights.cpp
@@ -24,11 +24,11 @@
 #include "DPrint.h"
 
 #include "CodeGenerator.h"
-#include "CompilerGeneratedHandler.h"
 #include "DPrint.h"
 #include "FunctionDeclHandler.h"
 #include "GlobalVariableHandler.h"
 #include "Insights.h"
+#include "RecordDeclHandler.h"
 #include "StaticAssertHandler.h"
 #include "TemplateHandler.h"
 #include "version.h"
@@ -88,7 +88,7 @@ public:
     explicit CppInsightASTConsumer(Rewriter& rewriter)
     : ASTConsumer()
     , mMatcher{}
-    , mCompilerGeneratedHandler{rewriter, mMatcher}
+    , mRecordDeclHandler{rewriter, mMatcher}
     , mStaticAssertHandler{rewriter, mMatcher}
     , mTemplateHandler{rewriter, mMatcher}
     , mGlobalVariableHandler{rewriter, mMatcher}
@@ -114,13 +114,13 @@ public:
     }
 
 private:
-    MatchFinder              mMatcher;
-    CompilerGeneratedHandler mCompilerGeneratedHandler;
-    StaticAssertHandler      mStaticAssertHandler;
-    TemplateHandler          mTemplateHandler;
-    GlobalVariableHandler    mGlobalVariableHandler;
-    FunctionDeclHandler      mFunctionDeclHandler;
-    Rewriter&                mRewriter;
+    MatchFinder           mMatcher;
+    RecordDeclHandler     mRecordDeclHandler;
+    StaticAssertHandler   mStaticAssertHandler;
+    TemplateHandler       mTemplateHandler;
+    GlobalVariableHandler mGlobalVariableHandler;
+    FunctionDeclHandler   mFunctionDeclHandler;
+    Rewriter&             mRewriter;
 };
 //-----------------------------------------------------------------------------
 

--- a/RecordDeclHandler.cpp
+++ b/RecordDeclHandler.cpp
@@ -5,7 +5,7 @@
  *
  ****************************************************************************/
 
-#include "CompilerGeneratedHandler.h"
+#include "RecordDeclHandler.h"
 #include "ClangCompat.h"
 #include "CodeGenerator.h"
 #include "InsightsHelpers.h"
@@ -19,7 +19,7 @@ using namespace clang::ast_matchers;
 
 namespace clang::insights {
 
-CompilerGeneratedHandler::CompilerGeneratedHandler(Rewriter& rewrite, MatchFinder& matcher)
+RecordDeclHandler::RecordDeclHandler(Rewriter& rewrite, MatchFinder& matcher)
 : InsightsBase(rewrite)
 {
     matcher.addMatcher(cxxRecordDecl(hasDefinition(),
@@ -34,7 +34,7 @@ CompilerGeneratedHandler::CompilerGeneratedHandler(Rewriter& rewrite, MatchFinde
 }
 //-----------------------------------------------------------------------------
 
-void CompilerGeneratedHandler::run(const MatchFinder::MatchResult& result)
+void RecordDeclHandler::run(const MatchFinder::MatchResult& result)
 {
     if(const auto* cxxRecordDecl = result.Nodes.getNodeAs<CXXRecordDecl>("cxxRecordDecl")) {
         OutputFormatHelper outputFormatHelper{};

--- a/RecordDeclHandler.h
+++ b/RecordDeclHandler.h
@@ -17,14 +17,15 @@ class Rewriter;
 
 namespace clang::insights {
 
-/// \brief Show which special members the compiler generates for a certain class.
+/// \brief Show a struct or class with the special members the compiler generates.
 ///
 /// Conveniently the compiler generates special member for us. Like the default constructor, copy or move operators.
-/// Under certain circumstances it stops generating. This matches makes it visible.
-class CompilerGeneratedHandler final : public ast_matchers::MatchFinder::MatchCallback, public InsightsBase
+/// Under certain circumstances it stops generating. This handler rewrites an entire class and shows all the pieces the
+/// compiler adds for us.
+class RecordDeclHandler final : public ast_matchers::MatchFinder::MatchCallback, public InsightsBase
 {
 public:
-    CompilerGeneratedHandler(Rewriter& rewrite, ast_matchers::MatchFinder& Matcher);
+    RecordDeclHandler(Rewriter& rewrite, ast_matchers::MatchFinder& Matcher);
     void run(const ast_matchers::MatchFinder::MatchResult& result) override;
 };
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
The old name is no longer correct, as the handler does much more than
just inserting special members. To reflect this it is renamed to a
better matching name.