### PR TITLE
Prepare providing own macOS binary.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -142,7 +142,7 @@ install:
 
     mkdir ${TRAVIS_BUILD_DIR}/clang
     cd ${TRAVIS_BUILD_DIR}/clang
-    wget -q --continue --directory-prefix=$HOME/Library/Caches/Homebrew https://releases.llvm.org/${LLVM_VERSION}/clang+llvm-${LLVM_VERSION}-x86_64-apple-darwin.tar.xz
+    wget -q --continue --directory-prefix=$HOME/Library/Caches/Homebrew https://github.com/andreasfertig/cppinsights-compiler-binaries/releases/download/${LLVM_VERSION}/clang+llvm-${LLVM_VERSION}-x86_64-apple-darwin.tar.xz
 
     mkdir current
     tar -xJf $HOME/Library/Caches/Homebrew/clang+llvm-${LLVM_VERSION}-x86_64-apple-darwin.tar.xz -C current --strip-components 1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ install:
   - cmd: if not exist C:\llvm-bin\downloaded ( 
             mkdir C:\llvm-bin &&
             cd C:\llvm-bin &&
-            (powershell Start-FileDownload "https://ziglang.org/deps/llvm+clang-8.0.0-win64-msvc-release.tar.xz" -FileName llvm.tar.xz) &&
+            (powershell Start-FileDownload "https://github.com/andreasfertig/cppinsights-compiler-binaries/releases/download/8.0.0/llvm+clang-8.0.0-win64-msvc-release.tar.xz" -FileName llvm.tar.xz) &&
             7z x C:\llvm-bin\llvm.tar.xz &&
             7z x C:\llvm-bin\llvm.tar &&
             del llvm.tar &&


### PR DESCRIPTION
To have more control about the used LLVM version cache them at GitHub.
This also allows to use a custom build macOS version, as the official
LLVM 9 is still not available.