### PR TITLE
Fixed #176: Switching to LLVM 9 gives us P0428.

### DIFF
--- a/tests/Issue176.cpp
+++ b/tests/Issue176.cpp
@@ -1,0 +1,12 @@
+// cmdline:-std=c++2a
+#include <iostream>
+
+// Moved this out of main to get a version that compiles after transformation. As it is not allowed for a user to
+// declare a method template in a function.
+auto foo = []<typename T>(T i) { return 1; };
+
+int main()
+{
+    foo(3);
+    return 0;
+}

--- a/tests/Issue176.expect
+++ b/tests/Issue176.expect
@@ -1,0 +1,41 @@
+// cmdline:-std=c++2a
+#include <iostream>
+
+// Moved this out of main to get a version that compiles after transformation. As it is not allowed for a user to
+// declare a method template in a function.
+
+class __lambda_6_12
+{
+  public: 
+  template<typename T>
+  inline /*constexpr */ auto operator()(T i) const
+  {
+    return 1;
+  }
+  
+  #ifdef INSIGHTS_USE_TEMPLATE
+  template<>
+  inline /*constexpr */ int operator()(int i) const
+  {
+    return 1;
+  }
+  #endif
+  
+  private: 
+  template<typename T>
+  static inline auto __invoke(T i)
+  {
+    return 1;
+  }
+  
+};
+
+__lambda_6_12 foo = __lambda_6_12{};
+
+
+int main()
+{
+  foo.operator()(3);
+  return 0;
+}
+

--- a/tests/p0428Test.cpp
+++ b/tests/p0428Test.cpp
@@ -1,0 +1,8 @@
+// cmdline:-std=c++2a
+
+auto l = []<class T>(T t, int i) { return i; };
+
+int main()
+{
+    return l(3,4) == 4;
+}

--- a/tests/p0428Test.expect
+++ b/tests/p0428Test.expect
@@ -1,0 +1,37 @@
+// cmdline:-std=c++2a
+
+
+class __lambda_3_10
+{
+  public: 
+  template<class T>
+  inline /*constexpr */ auto operator()(T t, int i) const
+  {
+    return i;
+  }
+  
+  #ifdef INSIGHTS_USE_TEMPLATE
+  template<>
+  inline /*constexpr */ int operator()(int t, int i) const
+  {
+    return i;
+  }
+  #endif
+  
+  private: 
+  template<class T>
+  static inline auto __invoke(T t, int i)
+  {
+    return i;
+  }
+  
+};
+
+__lambda_3_10 l = __lambda_3_10{};
+
+
+int main()
+{
+  return static_cast<int>(l.operator()(3, 4) == 4);
+}
+


### PR DESCRIPTION
The pure switch from LLVM 8 to 9 gives us support for P0428 "templates
lambdas". Hence, only tests are added.