### PR TITLE
Added support for using libc++ under Linux.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -363,6 +363,10 @@ else()
   set(GIT_COMMIT_HASH "")
 endif()
 
+# Get the include dir
+llvm_config(LLVM_INCLUDE_DIR "--includedir")
+
+
 message(STATUS "Generating version.h")
 
 configure_file(
@@ -602,6 +606,7 @@ message(STATUS "Compiler path         : ${CMAKE_CXX_COMPILER}")
 message(STATUS "llvm-config           : ${LLVM_CONFIG_PATH}")
 message(STATUS "Min LLVM major version: ${INSIGHTS_MIN_LLVM_MAJOR_VERSION}")
 message(STATUS "Install path          : ${CMAKE_INSTALL_PREFIX}")
+message(STATUS "Clang resource dir    : ${INSIGHTS_CLANG_RESOURCE_DIR}")
 message(STATUS "CMAKE_SOURCE_DIR      : ${CMAKE_SOURCE_DIR}")
 message(STATUS "CMAKE_BINARY_DIR      : ${CMAKE_BINARY_DIR}")
 message(STATUS "Git repo url          : ${GIT_REPO_URL}")

--- a/tests/runTest.py
+++ b/tests/runTest.py
@@ -76,24 +76,6 @@ def testCompile(tmpFileName, f, args, fileName, cppStd):
     return False, stderr
 #------------------------------------------------------------------------------
 
-def getDefaultIncludeDirs(cxx):
-    cmd = [cxx, '-E', '-x', 'c++', '-v', '/dev/null']
-    p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    stdout, stderr = p.communicate()
-
-    m = re.findall('\n (/.*)', stderr)
-
-    includes = []
-
-    for x in m:
-        if -1 != x.find('(framework directory)'):
-            continue
-
-        includes.append('-isystem%s' %(x))
-
-    return includes
-#------------------------------------------------------------------------------
-
 
 def main():
     parser = argparse.ArgumentParser(description='Description of your program')
@@ -120,8 +102,6 @@ def main():
     missingExpected = 0
     ret             = 0
 
-    defaultIncludeDirs = getDefaultIncludeDirs(args['cxx'])
-
     regEx         = re.compile('.*cmdline:(.*)')
     regExInsights = re.compile('.*cmdlineinsights:(.*)')
 
@@ -145,11 +125,10 @@ def main():
             missingExpected += 1
             continue
 
-#             cmd   = [insightsPath, f, '-for2while', '--', cppStd, '-m64'] + defaultIncludeDirs
         if '' == insightsOpts:
-            cmd   = [insightsPath, f, '--', cppStd, '-m64'] + defaultIncludeDirs
+            cmd   = [insightsPath, f, '--', cppStd, '-m64']
         else:
-            cmd   = [insightsPath, f, insightsOpts, '--', cppStd, '-m64'] + defaultIncludeDirs
+            cmd   = [insightsPath, f, insightsOpts, '--', cppStd, '-m64']
 
         begin = datetime.datetime.now()
         p   = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/version.h.in
+++ b/version.h.in
@@ -7,4 +7,10 @@
 
 #define INSIGHTS_MIN_LLVM_MAJOR_VERSION @INSIGHTS_MIN_LLVM_MAJOR_VERSION@
 
+// Build Clang's resource dir and include dir by hand. This is necessary, as we do not always have Clang installed. 
+// See: https://github.com/MaskRay/ccls/wiki/Install#clang-resource-directory
+#define INSIGHTS_CLANG_RESOURCE_DIR "-resource-dir=@LLVM_LIBDIR@/clang/@LLVM_PACKAGE_VERSION@"
+#define INSIGHTS_CLANG_RESOURCE_INCLUDE_DIR "-I @LLVM_LIBDIR@/clang/@LLVM_PACKAGE_VERSION@/include"
+#define INSIGHTS_LLVM_INCLUDE_DIR "-isystem@LLVM_INCLUDE_DIR@/c++/v1"
+
 #endif /* INSIGHTS_VERSION_H */


### PR DESCRIPTION
During adding libc++ support for Linux also addressed a Clang
`resource-dir` issue. This patch adds support to figure out the Clang
resource dir and add it to the command line as first arguments. Those a
user should be able to override them. In general, this hopefully solves
a couple of missing include errors.