### PR TITLE
Better formatting of lambdas.

### DIFF
--- a/tests/ForStmtWithLambdaInInitTest.expect
+++ b/tests/ForStmtWithLambdaInInitTest.expect
@@ -14,7 +14,9 @@ int main()
     
     private: 
     int & x;
-    public: __lambda_7_17(int & _x)
+    
+    public:
+    __lambda_7_17(int & _x)
     : x{_x}
     {}
     
@@ -36,7 +38,9 @@ int main()
     
     private: 
     int & x;
-    public: __lambda_11_17(int & _x)
+    
+    public:
+    __lambda_11_17(int & _x)
     : x{_x}
     {}
     
@@ -53,7 +57,9 @@ int main()
     
     private: 
     int & x;
-    public: __lambda_11_43(int & _x)
+    
+    public:
+    __lambda_11_43(int & _x)
     : x{_x}
     {}
     
@@ -99,7 +105,9 @@ int main()
     
     private: 
     int & x;
-    public: __lambda_15_37(int & _x)
+    
+    public:
+    __lambda_15_37(int & _x)
     : x{_x}
     {}
     
@@ -192,7 +200,9 @@ int main()
     
     private: 
     int & x;
-    public: __lambda_20_37(int & _x)
+    
+    public:
+    __lambda_20_37(int & _x)
     : x{_x}
     {}
     

--- a/tests/Issue176.expect
+++ b/tests/Issue176.expect
@@ -28,6 +28,9 @@ class __lambda_6_12
     return 1;
   }
   
+  public:
+  // /*constexpr */ __lambda_6_12() = default;
+  
 };
 
 __lambda_6_12 foo = __lambda_6_12{};

--- a/tests/Issue2.expect
+++ b/tests/Issue2.expect
@@ -40,9 +40,9 @@ int main()
     public: 
     // inline __lambda_20_16(const __lambda_20_16 &) = delete;
     // inline __lambda_20_16(__lambda_20_16 &&) = default;
-    public: __lambda_20_16(Movable _x, int _c)
+    __lambda_20_16(Movable _x, int _c)
     : x{_x}
-, c{_c}
+    , c{_c}
     {}
     
   };
@@ -59,7 +59,9 @@ int main()
     
     private: 
     int c;
-    public: __lambda_24_16(int _c)
+    
+    public:
+    __lambda_24_16(int _c)
     : c{_c}
     {}
     

--- a/tests/Issue205.expect
+++ b/tests/Issue205.expect
@@ -28,9 +28,8 @@ class EventContainer
     // inline /*constexpr */ __lambda_6_43 & operator=(const __lambda_6_43 &) = delete;
     // inline /*constexpr */ __lambda_6_43(const __lambda_6_43 &) noexcept = default;
     // inline /*constexpr */ __lambda_6_43(__lambda_6_43 &&) noexcept = default;
-    public: __lambda_6_43(EventContainer * _this)
+    __lambda_6_43(EventContainer * _this)
     : __this{_this}
-
     {}
     
   } __lambda_6_43{this};

--- a/tests/Issue205_2.expect
+++ b/tests/Issue205_2.expect
@@ -23,9 +23,8 @@ class EventContainer
     // inline /*constexpr */ __lambda_6_43 & operator=(const __lambda_6_43 &) = delete;
     // inline /*constexpr */ __lambda_6_43(const __lambda_6_43 &) noexcept = default;
     // inline /*constexpr */ __lambda_6_43(__lambda_6_43 &&) noexcept = default;
-    public: __lambda_6_43(EventContainer * _this)
+    __lambda_6_43(EventContainer * _this)
     : __this{_this}
-
     {}
     
   } __lambda_6_43{this};

--- a/tests/Issue238_3.expect
+++ b/tests/Issue238_3.expect
@@ -33,6 +33,9 @@ void f()
       }
     }
     
+    public:
+    // /*constexpr */ __lambda_2_26() = default;
+    
   };
   
   __lambda_2_26 lambda = __lambda_2_26{};

--- a/tests/Issue4.expect
+++ b/tests/Issue4.expect
@@ -17,7 +17,9 @@ int main()
     
     private: 
     char uuu;
-    public: __lambda_9_11(char _uuu)
+    
+    public:
+    __lambda_9_11(char _uuu)
     : uuu{_uuu}
     {}
     

--- a/tests/Issue46.expect
+++ b/tests/Issue46.expect
@@ -36,7 +36,9 @@ class __lambda_5_11
   
   private: 
   int a;
-  public: __lambda_5_11(int _a)
+  
+  public:
+  __lambda_5_11(int _a)
   : a{_a}
   {}
   

--- a/tests/Issue64.expect
+++ b/tests/Issue64.expect
@@ -16,7 +16,7 @@ void func(const std::basic_string<char> & arg)
     public: 
     // inline __lambda_5_11(const __lambda_5_11 &) = default;
     // inline __lambda_5_11(__lambda_5_11 &&) = default;
-    public: __lambda_5_11(const std::basic_string<char> _arg)
+    __lambda_5_11(const std::basic_string<char> _arg)
     : arg{_arg}
     {}
     

--- a/tests/LambdaAndInClassInitializerTest.expect
+++ b/tests/LambdaAndInClassInitializerTest.expect
@@ -73,9 +73,10 @@ class EventContainer
     
     private: 
     EventContainer * __this;
-    public: __lambda_17_38(EventContainer * _this)
+    
+    public:
+    __lambda_17_38(EventContainer * _this)
     : __this{_this}
-
     {}
     
   } __lambda_17_38{this};

--- a/tests/LambdaAsTemplateArgTest.expect
+++ b/tests/LambdaAsTemplateArgTest.expect
@@ -37,7 +37,9 @@ int main()
     
     private: 
     int & y;
-    public: __lambda_12_14(int & _y)
+    
+    public:
+    __lambda_12_14(int & _y)
     : y{_y}
     {}
     

--- a/tests/LambdaCapturingFunctionTest.expect
+++ b/tests/LambdaCapturingFunctionTest.expect
@@ -23,7 +23,9 @@ int main()
     
     private: 
     D & d;
-    public: __lambda_15_14(D & _d)
+    
+    public:
+    __lambda_15_14(D & _d)
     : d{_d}
     {}
     

--- a/tests/LambdaConstexprTest.expect
+++ b/tests/LambdaConstexprTest.expect
@@ -12,7 +12,9 @@ void Test()
     
     private: 
     const int Size;
-    public: __lambda_4_18(const int _Size)
+    
+    public:
+    __lambda_4_18(const int _Size)
     : Size{_Size}
     {}
     

--- a/tests/LambdaHandler3Test.expect
+++ b/tests/LambdaHandler3Test.expect
@@ -28,7 +28,9 @@ int main()
     
     private: 
     int & y;
-    public: __lambda_10_13(int & _y)
+    
+    public:
+    __lambda_10_13(int & _y)
     : y{_y}
     {}
     

--- a/tests/LambdaHandler4Test.expect
+++ b/tests/LambdaHandler4Test.expect
@@ -14,9 +14,10 @@ class Foo
       
       private: 
       Foo * __this;
-      public: __lambda_6_18(Foo * _this)
+      
+      public:
+      __lambda_6_18(Foo * _this)
       : __this{_this}
-
       {}
       
     };
@@ -33,9 +34,10 @@ class Foo
       
       private: 
       Foo * __this;
-      public: __lambda_10_18(Foo * _this)
+      
+      public:
+      __lambda_10_18(Foo * _this)
       : __this{_this}
-
       {}
       
     };
@@ -52,9 +54,10 @@ class Foo
       
       private: 
       Foo __this;
-      public: __lambda_14_18(Foo _this)
+      
+      public:
+      __lambda_14_18(Foo _this)
       : __this{_this}
-
       {}
       
     };
@@ -99,9 +102,10 @@ struct X
       
       private: 
       X * __this;
-      public: __lambda_35_9(X * _this)
+      
+      public:
+      __lambda_35_9(X * _this)
       : __this{_this}
-
       {}
       
     } __lambda_35_9{this};

--- a/tests/LambdaHandler6Test.expect
+++ b/tests/LambdaHandler6Test.expect
@@ -14,9 +14,11 @@ int main()
     private: 
     int & l1;
     int & l2;
-    public: __lambda_5_5(int & _l1, int & _l2)
+    
+    public:
+    __lambda_5_5(int & _l1, int & _l2)
     : l1{_l1}
-, l2{_l2}
+    , l2{_l2}
     {}
     
   } __lambda_5_5{l1, l2};

--- a/tests/LambdaHandler8Test.expect
+++ b/tests/LambdaHandler8Test.expect
@@ -27,7 +27,9 @@ int get(int & v)
     
     private: 
     int & v;
-    public: __lambda_9_18(int & _v)
+    
+    public:
+    __lambda_9_18(int & _v)
     : v{_v}
     {}
     

--- a/tests/LambdaHandlerTest.cerr
+++ b/tests/LambdaHandlerTest.cerr
@@ -1,16 +1,16 @@
-.tmp.cpp:164:5: error: templates cannot be declared inside of a local class
+.tmp.cpp:175:5: error: templates cannot be declared inside of a local class
     template<class type_parameter_0_0>
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-.tmp.cpp:189:11: error: no matching member function for call to 'operator()'
+.tmp.cpp:202:11: error: no matching member function for call to 'operator()'
   lambda7.operator()(foo, 2);
   ~~~~~~~~^~~~~~~~~~
-.tmp.cpp:194:5: error: templates cannot be declared inside of a local class
+.tmp.cpp:207:5: error: templates cannot be declared inside of a local class
     template<class type_parameter_0_0>
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-.tmp.cpp:213:5: error: templates cannot be declared inside of a local class
+.tmp.cpp:228:5: error: templates cannot be declared inside of a local class
     template<class type_parameter_0_0, class type_parameter_0_1>
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-.tmp.cpp:238:12: error: no matching member function for call to 'operator()'
+.tmp.cpp:255:12: error: no matching member function for call to 'operator()'
   lambda73.operator()(foo, b, 44);
   ~~~~~~~~~^~~~~~~~~~
 5 errors generated.

--- a/tests/LambdaHandlerTest.expect
+++ b/tests/LambdaHandlerTest.expect
@@ -16,9 +16,10 @@ class Bar
       
       private: 
       Bar * __this;
-      public: __lambda_8_18(Bar * _this)
+      
+      public:
+      __lambda_8_18(Bar * _this)
       : __this{_this}
-
       {}
       
     };
@@ -46,7 +47,9 @@ int main()
     
     private: 
     int & foo;
-    public: __lambda_20_19(int & _foo)
+    
+    public:
+    __lambda_20_19(int & _foo)
     : foo{_foo}
     {}
     
@@ -92,7 +95,9 @@ int main()
     
     private: 
     int & foo;
-    public: __lambda_28_20(int & _foo)
+    
+    public:
+    __lambda_28_20(int & _foo)
     : foo{_foo}
     {}
     
@@ -112,7 +117,9 @@ int main()
     
     private: 
     int & foo;
-    public: __lambda_32_20(int & _foo)
+    
+    public:
+    __lambda_32_20(int & _foo)
     : foo{_foo}
     {}
     
@@ -131,7 +138,9 @@ int main()
     
     private: 
     int & foo;
-    public: __lambda_34_20(int & _foo)
+    
+    public:
+    __lambda_34_20(int & _foo)
     : foo{_foo}
     {}
     
@@ -150,7 +159,9 @@ int main()
     
     private: 
     int & foo;
-    public: __lambda_36_20(int & _foo)
+    
+    public:
+    __lambda_36_20(int & _foo)
     : foo{_foo}
     {}
     
@@ -179,7 +190,9 @@ int main()
     
     private: 
     int & foo;
-    public: __lambda_38_20(int & _foo)
+    
+    public:
+    __lambda_38_20(int & _foo)
     : foo{_foo}
     {}
     
@@ -199,7 +212,9 @@ int main()
     }
     private: 
     int & foo;
-    public: __lambda_41_21(int & _foo)
+    
+    public:
+    __lambda_41_21(int & _foo)
     : foo{_foo}
     {}
     
@@ -228,7 +243,9 @@ int main()
     
     private: 
     int & foo;
-    public: __lambda_43_21(int & _foo)
+    
+    public:
+    __lambda_43_21(int & _foo)
     : foo{_foo}
     {}
     
@@ -249,9 +266,11 @@ int main()
     private: 
     int foo;
     int b;
-    public: __lambda_46_20(int _foo, int _b)
+    
+    public:
+    __lambda_46_20(int _foo, int _b)
     : foo{_foo}
-, b{_b}
+    , b{_b}
     {}
     
   };
@@ -270,9 +289,11 @@ int main()
     private: 
     int foo;
     int b;
-    public: __lambda_48_20(int _foo, int _b)
+    
+    public:
+    __lambda_48_20(int _foo, int _b)
     : foo{_foo}
-, b{_b}
+    , b{_b}
     {}
     
   };

--- a/tests/LambdaHandlerVLA2Test.cerr
+++ b/tests/LambdaHandlerVLA2Test.cerr
@@ -10,13 +10,13 @@ void Test(int n)
 .tmp.cpp:15:12: error: fields must have a constant size: 'variable length array in structure' extension will never be supported
     char (&buffer)[n];
            ^
-.tmp.cpp:16:42: error: reference to local variable 'n' declared in enclosing function 'Test'
-    public: __lambda_6_5(char (&_buffer)[n])
-                                         ^
+.tmp.cpp:18:34: error: reference to local variable 'n' declared in enclosing function 'Test'
+    __lambda_6_5(char (&_buffer)[n])
+                                 ^
 .tmp.cpp:1:15: note: 'n' declared here
 void Test(int n)
               ^
-.tmp.cpp:20:5: error: no matching constructor for initialization of 'class __lambda_6_5'
+.tmp.cpp:22:5: error: no matching constructor for initialization of 'class __lambda_6_5'
   } __lambda_6_5{buffer};
     ^           ~~~~~~~~
 .tmp.cpp:5:9: note: candidate constructor (the implicit copy constructor) not viable: no known conversion from 'char [n]' to 'const __lambda_6_5' for 1st argument
@@ -25,10 +25,10 @@ void Test(int n)
 .tmp.cpp:5:9: note: candidate constructor (the implicit move constructor) not viable: no known conversion from 'char [n]' to '__lambda_6_5' for 1st argument
   class __lambda_6_5
         ^
-.tmp.cpp:16:13: note: candidate constructor not viable: no known conversion from 'char [n]' to 'char (&)[n]' for 1st argument
-    public: __lambda_6_5(char (&_buffer)[n])
-            ^
-.tmp.cpp:22:15: error: cannot use dot operator on a type
+.tmp.cpp:18:5: note: candidate constructor not viable: no known conversion from 'char [n]' to 'char (&)[n]' for 1st argument
+    __lambda_6_5(char (&_buffer)[n])
+    ^
+.tmp.cpp:24:15: error: cannot use dot operator on a type
   __lambda_6_5.operator()(1, 2);
               ^
 1 warning and 5 errors generated.

--- a/tests/LambdaHandlerVLA2Test.expect
+++ b/tests/LambdaHandlerVLA2Test.expect
@@ -13,7 +13,9 @@ void Test(int n)
     private: 
     unsigned long;
     char (&buffer)[n];
-    public: __lambda_6_5(char (&_buffer)[n])
+    
+    public:
+    __lambda_6_5(char (&_buffer)[n])
     : buffer{_buffer}
     {}
     

--- a/tests/LambdaHandlerVLATest.expect
+++ b/tests/LambdaHandlerVLATest.expect
@@ -47,7 +47,9 @@ struct SA<2>
       private: 
       unsigned long;
       float (&e)[this->nt];
-      public: __lambda_40_8(float (&_e)[this->nt])
+      
+      public:
+      __lambda_40_8(float (&_e)[this->nt])
       : e{_e}
       {}
       

--- a/tests/LambdaImplicitCaptureTest.expect
+++ b/tests/LambdaImplicitCaptureTest.expect
@@ -15,7 +15,9 @@ int main()
     
     private: 
     int x;
-    public: __lambda_7_14(int _x)
+    
+    public:
+    __lambda_7_14(int _x)
     : x{_x}
     {}
     

--- a/tests/LambdaInLamdaTest.expect
+++ b/tests/LambdaInLamdaTest.expect
@@ -18,7 +18,9 @@ int main()
         
         private: 
         char & buffer;
-        public: __lambda_6_9(char & _buffer)
+        
+        public:
+        __lambda_6_9(char & _buffer)
         : buffer{_buffer}
         {}
         
@@ -29,7 +31,9 @@ int main()
     
     private: 
     char & buffer;
-    public: __lambda_4_5(char & _buffer)
+    
+    public:
+    __lambda_4_5(char & _buffer)
     : buffer{_buffer}
     {}
     

--- a/tests/LambdaInVarDeclTest.expect
+++ b/tests/LambdaInVarDeclTest.expect
@@ -19,7 +19,9 @@ int main()
         
         private: 
         char & c;
-        public: __lambda_6_17(char & _c)
+        
+        public:
+        __lambda_6_17(char & _c)
         : c{_c}
         {}
         

--- a/tests/LambdaPackExpansionTest.expect
+++ b/tests/LambdaPackExpansionTest.expect
@@ -50,12 +50,14 @@ void f2<int, int, int, int, int>(int __args0, int __args1, int __args2, int __ar
     int __args2;
     int __args3;
     int __args4;
-    public: __lambda_19_15(int ___args0, int ___args1, int ___args2, int ___args3, int ___args4)
+    
+    public:
+    __lambda_19_15(int ___args0, int ___args1, int ___args2, int ___args3, int ___args4)
     : __args0{___args0}
-, __args1{___args1}
-, __args2{___args2}
-, __args3{___args3}
-, __args4{___args4}
+    , __args1{___args1}
+    , __args2{___args2}
+    , __args3{___args3}
+    , __args4{___args4}
     {}
     
   };

--- a/tests/MemberExprTemplateTest.expect
+++ b/tests/MemberExprTemplateTest.expect
@@ -39,7 +39,9 @@
       
       private: 
       X & x;
-      public: __lambda_10_5(X & _x)
+      
+      public:
+      __lambda_10_5(X & _x)
       : x{_x}
       {}
       

--- a/tests/RangeForStmtHandlerTest.expect
+++ b/tests/RangeForStmtHandlerTest.expect
@@ -18,7 +18,9 @@ struct A
       
       private: 
       int & i;
-      public: __lambda_10_38(int & _i)
+      
+      public:
+      __lambda_10_38(int & _i)
       : i{_i}
       {}
       
@@ -51,7 +53,9 @@ struct B
       
       private: 
       int & i;
-      public: __lambda_22_38(int & _i)
+      
+      public:
+      __lambda_22_38(int & _i)
       : i{_i}
       {}
       

--- a/tests/StructuredBindingsHandler7Test.expect
+++ b/tests/StructuredBindingsHandler7Test.expect
@@ -14,7 +14,9 @@ int main()
     
     private: 
     char (&buffer)[2];
-    public: __lambda_4_5(char (&_buffer)[2])
+    
+    public:
+    __lambda_4_5(char (&_buffer)[2])
     : buffer{_buffer}
     {}
     

--- a/tests/p0428Test.expect
+++ b/tests/p0428Test.expect
@@ -25,6 +25,9 @@ class __lambda_3_10
     return i;
   }
   
+  public:
+  // /*constexpr */ __lambda_3_10() = default;
+  
 };
 
 __lambda_3_10 l = __lambda_3_10{};


### PR DESCRIPTION
- Correct the indent of the lambdas constructor initializer list.
- Skip inserting `public:`, if we are already in a public scope.
- Insert a newline before and after `public:` to make it look like the
  rest.