### PR TITLE
Fixed #264: Wrap BinaryOperators in their according parentheses.

### DIFF
--- a/CodeGenerator.cpp
+++ b/CodeGenerator.cpp
@@ -568,15 +568,13 @@ void CodeGenerator::InsertArg(const BinaryOperator* stmt)
 {
     LAMBDA_SCOPE_HELPER(BinaryOperator);
 
-    InsertArg(stmt->getLHS());
+    const bool needLHSParens{isa<BinaryOperator>(stmt->getLHS()->IgnoreImpCasts())};
+    WrapInParensIfNeeded(needLHSParens, [&] { InsertArg(stmt->getLHS()); });
+
     mOutputFormatHelper.Append(" ", stmt->getOpcodeStr(), " ");
 
-    // For + and - add the parentheses, if not already supplied. It looks like fold-expression to not carry them.
-    const bool needParens{
-        isa<BinaryOperator>(stmt->getRHS()->IgnoreImpCasts()) &&
-        ((BinaryOperatorKind::BO_Add == stmt->getOpcode()) || (BinaryOperatorKind::BO_Sub == stmt->getOpcode()))};
-
-    WrapInParensIfNeeded(needParens, [&] { InsertArg(stmt->getRHS()); });
+    const bool needRHSParens{isa<BinaryOperator>(stmt->getRHS()->IgnoreImpCasts())};
+    WrapInParensIfNeeded(needRHSParens, [&] { InsertArg(stmt->getRHS()); });
 }
 //-----------------------------------------------------------------------------
 

--- a/InsightsHelpers.cpp
+++ b/InsightsHelpers.cpp
@@ -506,6 +506,20 @@ private:
         return ret;
     }
 
+    bool HandleType(const PackExpansionType* type)
+    {
+        type->dump();
+        const auto qt = type->getPattern();
+
+        const bool ret = HandleType(qt.getTypePtrOrNull());
+
+        if(ret) {
+            mData.Append("...");
+        }
+
+        return ret;
+    }
+
     bool HandleType(const Type* type)
     {
 #define HANDLE_TYPE(t)                                                                                                 \
@@ -533,6 +547,7 @@ private:
         HANDLE_TYPE(ConstantArrayType);
         HANDLE_TYPE(InjectedClassNameType);
         HANDLE_TYPE(DependentTemplateSpecializationType);
+        HANDLE_TYPE(PackExpansionType);
 
 #undef HANDLE_TYPE
         return false;

--- a/tests/CXXFoldExprTest.expect
+++ b/tests/CXXFoldExprTest.expect
@@ -13,7 +13,7 @@ class CXXFoldExprTest
   template<>
   inline int UnaryRightFold<int, int, int, int>(const int & __ts0, const int & __ts1, const int & __ts2, const int & __ts3)
   {
-    return __ts0 / __ts1 / __ts2 / __ts3;
+    return __ts0 / (__ts1 / (__ts2 / __ts3));
   }
   #endif
   
@@ -27,7 +27,7 @@ class CXXFoldExprTest
   template<>
   inline int UnaryLeftFold<int, int, int, int>(const int & __ts0, const int & __ts1, const int & __ts2, const int & __ts3)
   {
-    return __ts0 / __ts1 / __ts2 / __ts3;
+    return ((__ts0 / __ts1) / __ts2) / __ts3;
   }
   #endif
   
@@ -41,7 +41,7 @@ class CXXFoldExprTest
   template<>
   inline int BinaryRightFold<int, int, int, int>(const int & __ts0, const int & __ts1, const int & __ts2, const int & __ts3)
   {
-    return __ts0 / __ts1 / __ts2 / __ts3 / 2;
+    return __ts0 / (__ts1 / (__ts2 / (__ts3 / 2)));
   }
   #endif
   
@@ -55,7 +55,7 @@ class CXXFoldExprTest
   template<>
   inline int BinaryLeftFold<int, int, int, int>(const int & __ts0, const int & __ts1, const int & __ts2, const int & __ts3)
   {
-    return 2 / __ts0 / __ts1 / __ts2 / __ts3;
+    return (((2 / __ts0) / __ts1) / __ts2) / __ts3;
   }
   #endif
   

--- a/tests/ClassOperatorHandler5Test.expect
+++ b/tests/ClassOperatorHandler5Test.expect
@@ -8,7 +8,7 @@ std::basic_string<char> trim(const std::basic_string<char> & input)
   
   std::string final = std::basic_string<char>(input);
   int i = 0;
-  while(i < static_cast<int>(input.length()) && static_cast<int>(input.operator[](i)) <= static_cast<int>(' ')) {
+  while((i < static_cast<int>(input.length())) && (static_cast<int>(input.operator[](i)) <= static_cast<int>(' '))) {
     i++;
   }
   
@@ -20,8 +20,8 @@ std::basic_string<char> trim(const std::basic_string<char> & input)
     final.operator=(input.substr(static_cast<unsigned long>(i), input.length() - static_cast<unsigned long>(i)));
   }
   
-  i = static_cast<int>(final.length()) - 1;
-  while(i >= 0 && static_cast<int>(final.operator[](i)) <= static_cast<int>(' ')) {
+  i = (static_cast<int>(final.length()) - 1);
+  while((i >= 0) && (static_cast<int>(final.operator[](i)) <= static_cast<int>(' '))) {
     i--;
   }
   

--- a/tests/ClassOperatorHandler9Test.expect
+++ b/tests/ClassOperatorHandler9Test.expect
@@ -78,7 +78,7 @@ MyVector<int> operator+(const MyVector<int> & a, const MyVector<int> & b)
   vec_t result = MyVector<int>(a.size()) /* NRVO variable */;
   for(std::size_t s = 0; s <= a.size(); ++s) 
   {
-    result.operator[](s) = a.operator[](s) + b.operator[](s);
+    result.operator[](s) = (a.operator[](s) + b.operator[](s));
   }
   
   return MyVector<int>(result);
@@ -103,7 +103,7 @@ MyVector<int> operator*<int>(const MyVector<int> & a, const MyVector<int> & b)
   MyVector<int> result = MyVector<int>(a.size()) /* NRVO variable */;
   for(std::size_t s = 0; s <= a.size(); ++s) 
   {
-    result.operator[](s) = a.operator[](s) + b.operator[](s);
+    result.operator[](s) = (a.operator[](s) + b.operator[](s));
   }
   
   return MyVector<int>(result);
@@ -116,7 +116,7 @@ MyVector<int> Foo(const MyVector<int> & a, const MyVector<int> & b)
   vec_t result = MyVector<int>{a.size()} /* NRVO variable */;
   for(std::size_t s = 0; s <= a.size(); ++s) 
   {
-    result.operator[](s) = a.operator[](s) + b.operator[](s);
+    result.operator[](s) = (a.operator[](s) + b.operator[](s));
   }
   
   return MyVector<int>(result);

--- a/tests/ConstexprFunctionHandlerTest.expect
+++ b/tests/ConstexprFunctionHandlerTest.expect
@@ -34,6 +34,6 @@ int main()
   int fact4 = factorial(fact);
   float f = Get();
   const float f2 = Get();
-  return static_cast<int>(static_cast<float>(fact + d) + factFloat + static_cast<float>(fact2) + static_cast<float>(fact3) + static_cast<float>(fact4));
+  return static_cast<int>(((((static_cast<float>(fact + d)) + factFloat) + static_cast<float>(fact2)) + static_cast<float>(fact3)) + static_cast<float>(fact4));
 }
 

--- a/tests/FoldExpressionTest.cpp
+++ b/tests/FoldExpressionTest.cpp
@@ -1,0 +1,74 @@
+// + - * / % ^ & | = < > << >> += -= *= /= %= ^= &= |= <<= >>= == != <= >= && || , .* ->*
+
+// Tests for some of the 32 operators
+
+template<typename... Args>
+constexpr auto plus(Args... args) { return (... + args); }
+
+template<typename... Args>
+constexpr auto minus(Args... args) { return (... - args); }
+
+template<typename... Args>
+constexpr auto times(Args... args) { return (... * args); }
+
+template<typename... Args>
+constexpr auto div(Args... args) { return (... / args); }
+
+template<typename... Args>
+constexpr auto mod(Args... args) { return (... % args); }
+
+template<typename... Args>
+constexpr auto bitwiseXOr(Args... args) { return (... ^ args); }
+
+template<typename... Args>
+constexpr auto bitwiseAnd(Args... args) { return (... & args); }
+
+template<typename... Args>
+constexpr auto bitwiseOr(Args... args) { return (... | args); }
+
+
+// = 
+
+template<typename... Args>
+constexpr auto lt(Args... args) { return (... < args); }
+
+template<typename... Args>
+constexpr auto gt(Args... args) { return (... > args); }
+
+
+template<typename... Args>
+constexpr auto logicalAnd(Args... args) { return (... && args); }
+
+template<typename... Args>
+constexpr auto logicalOr(Args... args) { return (... ||args); }
+
+template<typename... Args>
+constexpr auto comma(Args... args) { return (... , args); }
+
+int main()
+{
+    static_assert(6 == plus(1,2,3));
+    static_assert(1 == minus(6,2,3));
+    static_assert(18 == times(3,2,3));
+    static_assert(3 == div(18,2,3));
+    static_assert(0 == mod(18,4,2));
+    static_assert(0b00'011 == bitwiseXOr(0b11'101, 0b11'010, 0b00'100));
+    static_assert(0b00'010 == bitwiseAnd(0b11'010, 0b11'010, 0b00'010));
+    static_assert(0b11'111 == bitwiseOr(0b11'001, 0b11'010, 0b00'100));
+
+// = 
+
+    static_assert(false == lt(1,2,0));
+    static_assert(false == gt(1,2,1));
+
+
+    static_assert(false == logicalAnd(true, true, true, false));
+    static_assert(true == logicalOr(true, true, true, false));
+
+    static_assert(4 == comma(1,2,3,4));
+
+    // Verify that we do not introduce parens here.
+    int x = 4;
+    x /= 2;
+}
+

--- a/tests/FoldExpressionTest.expect
+++ b/tests/FoldExpressionTest.expect
@@ -1,0 +1,184 @@
+// + - * / % ^ & | = < > << >> += -= *= /= %= ^= &= |= <<= >>= == != <= >= && || , .* ->*
+
+// Tests for some of the 32 operators
+
+template<typename... Args>
+constexpr auto plus(Args... args) { return (... + args); }
+
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+inline constexpr int plus<int, int, int>(int __args0, int __args1, int __args2)
+{
+  return (__args0 + __args1) + __args2;
+}
+#endif
+
+
+template<typename... Args>
+constexpr auto minus(Args... args) { return (... - args); }
+
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+inline constexpr int minus<int, int, int>(int __args0, int __args1, int __args2)
+{
+  return (__args0 - __args1) - __args2;
+}
+#endif
+
+
+template<typename... Args>
+constexpr auto times(Args... args) { return (... * args); }
+
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+inline constexpr int times<int, int, int>(int __args0, int __args1, int __args2)
+{
+  return (__args0 * __args1) * __args2;
+}
+#endif
+
+
+template<typename... Args>
+constexpr auto div(Args... args) { return (... / args); }
+
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+inline constexpr int div<int, int, int>(int __args0, int __args1, int __args2)
+{
+  return (__args0 / __args1) / __args2;
+}
+#endif
+
+
+template<typename... Args>
+constexpr auto mod(Args... args) { return (... % args); }
+
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+inline constexpr int mod<int, int, int>(int __args0, int __args1, int __args2)
+{
+  return (__args0 % __args1) % __args2;
+}
+#endif
+
+
+template<typename... Args>
+constexpr auto bitwiseXOr(Args... args) { return (... ^ args); }
+
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+inline constexpr int bitwiseXOr<int, int, int>(int __args0, int __args1, int __args2)
+{
+  return (__args0 ^ __args1) ^ __args2;
+}
+#endif
+
+
+template<typename... Args>
+constexpr auto bitwiseAnd(Args... args) { return (... & args); }
+
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+inline constexpr int bitwiseAnd<int, int, int>(int __args0, int __args1, int __args2)
+{
+  return (__args0 & __args1) & __args2;
+}
+#endif
+
+
+template<typename... Args>
+constexpr auto bitwiseOr(Args... args) { return (... | args); }
+
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+inline constexpr int bitwiseOr<int, int, int>(int __args0, int __args1, int __args2)
+{
+  return (__args0 | __args1) | __args2;
+}
+#endif
+
+
+
+// = 
+
+template<typename... Args>
+constexpr auto lt(Args... args) { return (... < args); }
+
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+inline constexpr bool lt<int, int, int>(int __args0, int __args1, int __args2)
+{
+  return (static_cast<int>(__args0 < __args1)) < __args2;
+}
+#endif
+
+
+template<typename... Args>
+constexpr auto gt(Args... args) { return (... > args); }
+
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+inline constexpr bool gt<int, int, int>(int __args0, int __args1, int __args2)
+{
+  return (static_cast<int>(__args0 > __args1)) > __args2;
+}
+#endif
+
+
+
+template<typename... Args>
+constexpr auto logicalAnd(Args... args) { return (... && args); }
+
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+inline constexpr bool logicalAnd<bool, bool, bool, bool>(bool __args0, bool __args1, bool __args2, bool __args3)
+{
+  return ((__args0 && __args1) && __args2) && __args3;
+}
+#endif
+
+
+template<typename... Args>
+constexpr auto logicalOr(Args... args) { return (... ||args); }
+
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+inline constexpr bool logicalOr<bool, bool, bool, bool>(bool __args0, bool __args1, bool __args2, bool __args3)
+{
+  return ((__args0 || __args1) || __args2) || __args3;
+}
+#endif
+
+
+template<typename... Args>
+constexpr auto comma(Args... args) { return (... , args); }
+
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+inline constexpr int comma<int, int, int, int>(int __args0, int __args1, int __args2, int __args3)
+{
+  return ((__args0 , __args1) , __args2) , __args3;
+}
+#endif
+
+
+int main()
+{
+  /* PASSED: static_assert(6 == plus(1, 2, 3)); */
+  /* PASSED: static_assert(1 == minus(6, 2, 3)); */
+  /* PASSED: static_assert(18 == times(3, 2, 3)); */
+  /* PASSED: static_assert(3 == div(18, 2, 3)); */
+  /* PASSED: static_assert(0 == mod(18, 4, 2)); */
+  /* PASSED: static_assert(3 == bitwiseXOr(29, 26, 4)); */
+  /* PASSED: static_assert(2 == bitwiseAnd(26, 26, 2)); */
+  /* PASSED: static_assert(31 == bitwiseOr(25, 26, 4)); */
+  /* PASSED: static_assert(static_cast<int>(false) == static_cast<int>(lt(1, 2, 0))); */
+  /* PASSED: static_assert(static_cast<int>(false) == static_cast<int>(gt(1, 2, 1))); */
+  /* PASSED: static_assert(static_cast<int>(false) == static_cast<int>(logicalAnd(true, true, true, false))); */
+  /* PASSED: static_assert(static_cast<int>(true) == static_cast<int>(logicalOr(true, true, true, false))); */
+  /* PASSED: static_assert(4 == comma(1, 2, 3, 4)); */
+  int x = 4;
+  x /= 2;
+}
+
+

--- a/tests/FunctionalCast2Test.expect
+++ b/tests/FunctionalCast2Test.expect
@@ -16,7 +16,7 @@ namespace details::array_single_compare {
   template<>
   inline constexpr bool Compare<unsigned char, 6, int, 0, 1, 2, 3, 4, 5>(const unsigned char (&ar)[6], const int & to, std::integer_sequence<unsigned long, 0, 1, 2, 3, 4, 5>)
   {
-    return (to == static_cast<int>(ar[0UL])) && (to == static_cast<int>(ar[1UL])) && (to == static_cast<int>(ar[2UL])) && (to == static_cast<int>(ar[3UL])) && (to == static_cast<int>(ar[4UL])) && (to == static_cast<int>(ar[5UL]));
+    return (to == static_cast<int>(ar[0UL])) && ((to == static_cast<int>(ar[1UL])) && ((to == static_cast<int>(ar[2UL])) && ((to == static_cast<int>(ar[3UL])) && ((to == static_cast<int>(ar[4UL])) && (to == static_cast<int>(ar[5UL]))))));
   }
   #endif
   
@@ -50,7 +50,7 @@ namespace details::array_compare {
   template<>
   inline constexpr bool Compare<unsigned char, 6, 0, 1, 2, 3, 4, 5>(const unsigned char (&ar)[6], const unsigned char (&to)[6], std::integer_sequence<unsigned long, 0, 1, 2, 3, 4, 5>)
   {
-    return (static_cast<int>(to[0UL]) == static_cast<int>(ar[0UL])) && (static_cast<int>(to[1UL]) == static_cast<int>(ar[1UL])) && (static_cast<int>(to[2UL]) == static_cast<int>(ar[2UL])) && (static_cast<int>(to[3UL]) == static_cast<int>(ar[3UL])) && (static_cast<int>(to[4UL]) == static_cast<int>(ar[4UL])) && (static_cast<int>(to[5UL]) == static_cast<int>(ar[5UL]));
+    return (static_cast<int>(to[0UL]) == static_cast<int>(ar[0UL])) && ((static_cast<int>(to[1UL]) == static_cast<int>(ar[1UL])) && ((static_cast<int>(to[2UL]) == static_cast<int>(ar[2UL])) && ((static_cast<int>(to[3UL]) == static_cast<int>(ar[3UL])) && ((static_cast<int>(to[4UL]) == static_cast<int>(ar[4UL])) && (static_cast<int>(to[5UL]) == static_cast<int>(ar[5UL]))))));
   }
   #endif
   

--- a/tests/Issue264.cpp
+++ b/tests/Issue264.cpp
@@ -1,0 +1,9 @@
+// Move it outside of main to get compiling code. As user is not allowed to declare a template inside a local class.
+auto f = [](auto... i) { return (.../i); };
+auto g = [](auto... i) { return (i/...); };
+
+int main()
+{
+  f(1,2,3);
+  g(1,2,3);
+}

--- a/tests/Issue264.expect
+++ b/tests/Issue264.expect
@@ -1,0 +1,66 @@
+// Move it outside of main to get compiling code. As user is not allowed to declare a template inside a local class.
+
+class __lambda_2_10
+{
+  public: 
+  template<class ... type_parameter_0_0>
+  inline /*constexpr */ auto operator()(type_parameter_0_0... i) const
+  {
+    return (... / i);
+  }
+  
+  #ifdef INSIGHTS_USE_TEMPLATE
+  template<>
+  inline /*constexpr */ int operator()(int __i0, int __i1, int __i2) const
+  {
+    return (__i0 / __i1) / __i2;
+  }
+  #endif
+  
+  private: 
+  template<class ... type_parameter_0_0>
+  static inline auto __invoke(type_parameter_0_0... i)
+  {
+    return (... / i);
+  }
+  
+};
+
+__lambda_2_10 f = __lambda_2_10{};
+
+
+class __lambda_3_10
+{
+  public: 
+  template<class ... type_parameter_0_0>
+  inline /*constexpr */ auto operator()(type_parameter_0_0... i) const
+  {
+    return (i / ...);
+  }
+  
+  #ifdef INSIGHTS_USE_TEMPLATE
+  template<>
+  inline /*constexpr */ int operator()(int __i0, int __i1, int __i2) const
+  {
+    return __i0 / (__i1 / __i2);
+  }
+  #endif
+  
+  private: 
+  template<class ... type_parameter_0_0>
+  static inline auto __invoke(type_parameter_0_0... i)
+  {
+    return (i / ...);
+  }
+  
+};
+
+__lambda_3_10 g = __lambda_3_10{};
+
+
+int main()
+{
+  f.operator()(1, 2, 3);
+  g.operator()(1, 2, 3);
+}
+

--- a/tests/Issue91.expect
+++ b/tests/Issue91.expect
@@ -58,7 +58,7 @@ int i = fold_minus<0>();
 
 /* PASSED: static_assert(fold_minus<0>() == 5); */
 
-/* PASSED: static_assert(0 - 0 - 5 == -5); */
+/* PASSED: static_assert(((0 - 0) - 5) == -5); */
 
 
 //print_int<fold_minus<0>()> p;

--- a/tests/LambdaAsTemplateArgTest.expect
+++ b/tests/LambdaAsTemplateArgTest.expect
@@ -32,7 +32,7 @@ int main()
     public: 
     inline /*constexpr */ int operator()(int x, int b) const
     {
-      return x + y + b;
+      return (x + y) + b;
     }
     
     private: 

--- a/tests/LambdaHandler5Test.expect
+++ b/tests/LambdaHandler5Test.expect
@@ -56,7 +56,7 @@ int main()
     public: 
     inline /*constexpr */ void operator()(int & x, int & y) const
     {
-      x = x + y;
+      x = (x + y);
     }
     
     using retType_13_5 = void (*)(int &, int &);
@@ -68,7 +68,7 @@ int main()
     private: 
     static inline void __invoke(int & x, int & y)
     {
-      x = x + y;
+      x = (x + y);
     }
     
     

--- a/tests/LambdaHandler6Test.expect
+++ b/tests/LambdaHandler6Test.expect
@@ -8,7 +8,7 @@ int main()
     public: 
     inline /*constexpr */ void operator()() const
     {
-      l1 = 2 * l2;
+      l1 = (2 * l2);
     }
     
     private: 

--- a/tests/LambdaHandlerTest.expect
+++ b/tests/LambdaHandlerTest.expect
@@ -154,7 +154,7 @@ int main()
     inline /*constexpr */ int operator()(int & x, int b) const
     {
       printf("%d\n", foo + x);
-      return foo + x + b;
+      return (foo + x) + b;
     }
     
     private: 
@@ -176,7 +176,7 @@ int main()
     inline /*constexpr */ auto operator()(int & x, type_parameter_0_0 b) const
     {
       printf("%d\n", foo + x);
-      return foo + x + b;
+      return (foo + x) + b;
     }
     
     #ifdef INSIGHTS_USE_TEMPLATE
@@ -184,7 +184,7 @@ int main()
     inline /*constexpr */ int operator()(int & x, int b) const
     {
       printf("%d\n", foo + x);
-      return foo + x + b;
+      return (foo + x) + b;
     }
     #endif
     
@@ -208,7 +208,7 @@ int main()
     inline /*constexpr */ auto operator()(int & x, const type_parameter_0_0 & b) const
     {
       printf("%d\n", foo + x);
-      return foo + x + b;
+      return (foo + x) + b;
     }
     private: 
     int & foo;
@@ -229,7 +229,7 @@ int main()
     inline /*constexpr */ auto operator()(int & x, const type_parameter_0_0 & b, const type_parameter_0_1 c) const
     {
       printf("%d\n", foo + x);
-      return foo + x + b + c;
+      return ((foo + x) + b) + c;
     }
     
     #ifdef INSIGHTS_USE_TEMPLATE
@@ -237,7 +237,7 @@ int main()
     inline /*constexpr */ int operator()(int & x, const int & b, const int c) const
     {
       printf("%d\n", foo + x);
-      return foo + x + b + c;
+      return ((foo + x) + b) + c;
     }
     #endif
     
@@ -260,7 +260,7 @@ int main()
     inline /*constexpr */ int operator()(int & x, int bb) const
     {
       printf("%d\n", foo + x);
-      return foo + x + bb;
+      return (foo + x) + bb;
     }
     
     private: 
@@ -283,7 +283,7 @@ int main()
     inline /*constexpr */ int operator()(int & x, int bb) const noexcept
     {
       printf("%d\n", foo + x);
-      return foo + x + bb;
+      return (foo + x) + bb;
     }
     
     private: 

--- a/tests/StructuredBindingsHandler3Test.expect
+++ b/tests/StructuredBindingsHandler3Test.expect
@@ -111,7 +111,7 @@ q17);
     std::tuple_element<0, constant::Q>::type a = constant::get<0UL>(__q19);
     std::tuple_element<1, constant::Q>::type b = constant::get<1UL>(__q19);
     std::tuple_element<2, constant::Q>::type c = constant::get<2UL>(__q19);
-    return a == 0 && b == 1 && c == 4;
+    return ((a == 0) && (b == 1)) && (c == 4);
   }
   
 

--- a/tests/TemporaryHandler2Test.expect
+++ b/tests/TemporaryHandler2Test.expect
@@ -50,7 +50,7 @@ void f7(X & x)
 
 X f8(bool x, int y)
 {
-  if(x || y == 2) {
+  if(x || (y == 2)) {
     return X(y);
   }
   

--- a/tests/VarTemplateDecl3Test.expect
+++ b/tests/VarTemplateDecl3Test.expect
@@ -19,7 +19,7 @@ T circular_area(T r)
 template<>
 int circular_area<int>(int r)
 {
-  return pi<int> * r * r;
+  return (pi<int> * r) * r;
 }
 #endif
 

--- a/tests/VariadicTemplateRightFoldPlusTest.expect
+++ b/tests/VariadicTemplateRightFoldPlusTest.expect
@@ -20,7 +20,7 @@ inline constexpr int fold_minus_impl_rf<0>()
 template<>
 inline constexpr int fold_minus_impl_rf<0, 1>()
 {
-  return 5 - 0 - 1;
+  return (5 - 0) - 1;
 }
 #endif
 
@@ -50,7 +50,7 @@ inline constexpr int fold_negative_minus_impl_rf<0>()
 template<>
 inline constexpr int fold_negative_minus_impl_rf<0, 1>()
 {
-  return -5 - 0 - 1;
+  return (-5 - 0) - 1;
 }
 #endif
 


### PR DESCRIPTION
This goes not only for `BinaryOperators`in fold expressions. All
expressions with a `BinaryOperator` are now wrapped.

While processing #264 there was another error with the `TypePrinter`
regarding the lambdas `auto` parameter which is fixed by this patch
as well.