### PR TITLE
Fixed #251: Suppress unused compiler generated special members.

### DIFF
--- a/CodeGenerator.cpp
+++ b/CodeGenerator.cpp
@@ -2002,6 +2002,14 @@ void CodeGenerator::InsertCXXMethodDecl(const CXXMethodDecl* stmt, SkipBody skip
 
 void CodeGenerator::InsertArg(const CXXMethodDecl* stmt)
 {
+    // As per [special]/1: "Programs shall not define implicitly-declared special member functions." hide special
+    // members which are not used and with that not fully evaluated. This also hopefully removes confusion about the
+    // noexcept, which is not evaluated, if the special member is not used.
+    if(not stmt->hasBody() && not stmt->isUserProvided() && not stmt->isExplicitlyDefaulted() &&
+       not stmt->isDeleted()) {
+        return;
+    }
+
     InsertCXXMethodDecl(stmt, SkipBody::No);
 }
 //-----------------------------------------------------------------------------

--- a/tests/AutoHandler3Test.expect
+++ b/tests/AutoHandler3Test.expect
@@ -2,13 +2,11 @@ struct S
 {
   void f();
   
-  // inline ~S() noexcept = default;
 };
 
 
 struct T
 {
-  // inline ~T() noexcept = default;
 };
 
 

--- a/tests/BaseToDerivedMemberPointerTest.expect
+++ b/tests/BaseToDerivedMemberPointerTest.expect
@@ -2,9 +2,6 @@ class Base
 {
   public: 
   // inline constexpr Base() noexcept = default;
-  // inline ~Base() = default;
-  // inline constexpr Base(const Base &) = default;
-  // inline constexpr Base(Base &&) = default;
 };
 
 
@@ -13,8 +10,6 @@ class Derived : public Base
 {
   public: 
   // inline constexpr Derived() noexcept = default;
-  // inline constexpr Derived(const Derived &) = default;
-  // inline constexpr Derived(Derived &&) = default;
 };
 
 

--- a/tests/CXXConstructorDeclDefaultedTest.expect
+++ b/tests/CXXConstructorDeclDefaultedTest.expect
@@ -1,8 +1,6 @@
 struct DefaultedCtorAndConstexpr
 {
   inline constexpr DefaultedCtorAndConstexpr() noexcept = default;
-  // inline constexpr DefaultedCtorAndConstexpr(const DefaultedCtorAndConstexpr &) = default;
-  // inline constexpr DefaultedCtorAndConstexpr(DefaultedCtorAndConstexpr &&) = default;
 };
 
 

--- a/tests/CXXDefaultInitExpr2Test.expect
+++ b/tests/CXXDefaultInitExpr2Test.expect
@@ -12,8 +12,6 @@ struct Foo
   {
   }
   
-  // inline constexpr Foo(const Foo &) = default;
-  // inline constexpr Foo(Foo &&) = default;
 };
 
 

--- a/tests/CXXDefaultInitExprTest.expect
+++ b/tests/CXXDefaultInitExprTest.expect
@@ -30,8 +30,6 @@ class Alloc<int, 0>
   {
   }
   
-  // inline constexpr Alloc(const Alloc<int, 0> &) = default;
-  // inline constexpr Alloc(Alloc<int, 0> &&) = default;
 };
 
 #endif
@@ -54,8 +52,6 @@ class Alloc<char, 1>
   {
   }
   
-  // inline constexpr Alloc(const Alloc<char, 1> &) = default;
-  // inline constexpr Alloc(Alloc<char, 1> &&) = default;
 };
 
 #endif

--- a/tests/CXXDestructorTest.expect
+++ b/tests/CXXDestructorTest.expect
@@ -57,7 +57,6 @@ class Alloc<int, 0>
     
   }
   
-  // inline constexpr Alloc(const Alloc<int, 0> &) = default;
 };
 
 #endif
@@ -94,7 +93,6 @@ class Alloc<char, 1>
     
   }
   
-  // inline constexpr Alloc(const Alloc<char, 1> &) = default;
 };
 
 #endif

--- a/tests/CXXMethodTemplateExplicitSpecializationTest.expect
+++ b/tests/CXXMethodTemplateExplicitSpecializationTest.expect
@@ -15,8 +15,6 @@ class Foo<int>
   void Func();
   
   // inline constexpr Foo() noexcept = default;
-  // inline constexpr Foo(const Foo<int> &) = default;
-  // inline constexpr Foo(Foo<int> &&) = default;
 };
 
 #endif
@@ -32,8 +30,6 @@ class Foo<char>
   void Func();
   
   // inline constexpr Foo() noexcept = default;
-  // inline constexpr Foo(const Foo<char> &) = default;
-  // inline constexpr Foo(Foo<char> &&) = default;
 };
 
 #endif

--- a/tests/CharLiteralTest.expect
+++ b/tests/CharLiteralTest.expect
@@ -41,7 +41,6 @@ struct Foo<int>
   
   inline void operator=(int v) volatile;
   
-  // inline ~Foo() noexcept = default;
 };
 
 #endif
@@ -69,7 +68,6 @@ struct Foo<char>
   
   inline void operator=(char v) volatile;
   
-  // inline ~Foo() noexcept = default;
 };
 
 #endif
@@ -116,9 +114,6 @@ class Test
   Foo<char> mData[1024];
   Foo<int> mLength;
   public: 
-  // inline constexpr Test(const Test &) = default;
-  // inline constexpr Test(Test &&) = default;
-  // inline constexpr Test & operator=(Test &&) = default;
   // inline Test() noexcept = default;
 };
 

--- a/tests/Class2Test.expect
+++ b/tests/Class2Test.expect
@@ -52,7 +52,6 @@ class Test
   private: 
   int mV;
   public: 
-  // inline ~Test() noexcept = default;
 };
 
 
@@ -61,9 +60,7 @@ class Test
 struct S
 {
   Test count;
-  // inline S(S &) = default;
   // inline constexpr S(S &&) = delete;
-  // inline S & operator=(S &&) = default;
   // inline S() noexcept(false) = default;
 };
 

--- a/tests/ClassCallTest.expect
+++ b/tests/ClassCallTest.expect
@@ -25,9 +25,6 @@ class Foo
   private: 
   int mFoo;
   public: 
-  // inline constexpr Foo(const Foo &) = default;
-  // inline constexpr Foo(Foo &&) = default;
-  // inline ~Foo() = default;
 };
 
 
@@ -51,8 +48,6 @@ class Bar : public Foo
   private: 
   int mBar;
   public: 
-  // inline constexpr Bar(const Bar &) = default;
-  // inline constexpr Bar(Bar &&) = default;
 };
 
 

--- a/tests/ClassInlineInit2Test.expect
+++ b/tests/ClassInlineInit2Test.expect
@@ -15,10 +15,6 @@ class StdVector
   
   public: 
   std::vector<int, std::allocator<int> > v = std::vector<int, std::allocator<int> >{std::initializer_list<int>{1, 2, 3, 4, 5}};
-  // inline StdVector(const StdVector &) = default;
-  // inline StdVector(StdVector &&) = default;
-  // inline StdVector & operator=(StdVector &&) = default;
-  // inline ~StdVector() = default;
 };
 
 

--- a/tests/ClassInlineInitTest.expect
+++ b/tests/ClassInlineInitTest.expect
@@ -4,10 +4,6 @@ struct Test
 {
   std::basic_string<char> s = std::basic_string<char>{"333"};
   int x{2};
-  // inline Test(const Test &) = default;
-  // inline Test(Test &&) = default;
-  // inline Test & operator=(Test &&) = default;
-  // inline ~Test() = default;
 };
 
 

--- a/tests/ClassMethodOutsideClassTest.expect
+++ b/tests/ClassMethodOutsideClassTest.expect
@@ -7,8 +7,6 @@ class X
   
   void modify();
   
-  // inline constexpr X(const X &) = default;
-  // inline constexpr X(X &&) = default;
 };
 
 

--- a/tests/ClassOpInTemplateFunctionTest.expect
+++ b/tests/ClassOpInTemplateFunctionTest.expect
@@ -50,11 +50,7 @@ class Foo
   #endif
   
   int mX;
-  // inline Foo & operator=(const Foo &) = default;
   // inline Foo & operator=(Foo &&) noexcept = default;
-  // inline constexpr Foo(const Foo &) = default;
-  // inline constexpr Foo(Foo &&) = default;
-  // inline ~Foo() noexcept = default;
 };
 
 

--- a/tests/ClassOperatorHandler2Test.expect
+++ b/tests/ClassOperatorHandler2Test.expect
@@ -67,7 +67,6 @@ class Foo
   public: 
   // inline constexpr Foo(const Foo &) noexcept = default;
   // inline constexpr Foo(Foo &&) noexcept = default;
-  // inline ~Foo() noexcept = default;
 };
 
 

--- a/tests/ClassOperatorHandler4Test.expect
+++ b/tests/ClassOperatorHandler4Test.expect
@@ -9,8 +9,6 @@ class Foo
   }
   
   int mX;
-  // inline constexpr Foo(const Foo &) = default;
-  // inline constexpr Foo(Foo &&) = default;
 };
 
 

--- a/tests/ClassOperatorHandler6Test.expect
+++ b/tests/ClassOperatorHandler6Test.expect
@@ -9,11 +9,6 @@ class Bar
 {
   public: 
   // inline constexpr Bar() noexcept = default;
-  // inline constexpr Bar(const Bar &) = default;
-  // inline constexpr Bar(Bar &&) = default;
-  // inline constexpr Bar & operator=(const Bar &) = default;
-  // inline constexpr Bar & operator=(Bar &&) = default;
-  // inline ~Bar() = default;
 };
 
 
@@ -28,9 +23,6 @@ class Woo
   }
   
   int mX;
-  // inline constexpr Woo(const Woo &) = default;
-  // inline constexpr Woo(Woo &&) = default;
-  // inline ~Woo() noexcept = default;
 };
 
 
@@ -101,10 +93,6 @@ class Foo : public Bar
   }
   
   int mX;
-  // inline Foo & operator=(const Foo &) = default;
-  // inline Foo & operator=(Foo &&) = default;
-  // inline constexpr Foo(const Foo &) = default;
-  // inline constexpr Foo(Foo &&) = default;
 };
 
 

--- a/tests/ClassOperatorHandler7Test.cerr
+++ b/tests/ClassOperatorHandler7Test.cerr
@@ -1,26 +1,26 @@
-.tmp.cpp:60:5: error: use of undeclared identifier 'type_parameter_0_0'
+.tmp.cpp:53:5: error: use of undeclared identifier 'type_parameter_0_0'
   A<type_parameter_0_0 *>::B foo;
     ^
-.tmp.cpp:60:25: error: expected expression
+.tmp.cpp:53:25: error: expected expression
   A<type_parameter_0_0 *>::B foo;
                         ^
-.tmp.cpp:60:28: error: non-friend class member 'B' cannot have a qualified name
+.tmp.cpp:53:28: error: non-friend class member 'B' cannot have a qualified name
   A<type_parameter_0_0 *>::B foo;
                          ~~^
-.tmp.cpp:60:29: error: expected ';' at end of declaration list
+.tmp.cpp:53:29: error: expected ';' at end of declaration list
   A<type_parameter_0_0 *>::B foo;
                             ^
                             ;
-.tmp.cpp:94:15: warning: explicit instantiation of 'foo<int>' that occurs after an explicit specialization has no effect [-Winstantiation-after-specialization]
+.tmp.cpp:87:15: warning: explicit instantiation of 'foo<int>' that occurs after an explicit specialization has no effect [-Winstantiation-after-specialization]
 template void foo<int>(); // first case
               ^
-.tmp.cpp:75:6: note: previous template specialization is here
+.tmp.cpp:68:6: note: previous template specialization is here
 void foo<int>()
      ^
-.tmp.cpp:95:15: warning: explicit instantiation of 'foo<int *>' that occurs after an explicit specialization has no effect [-Winstantiation-after-specialization]
+.tmp.cpp:88:15: warning: explicit instantiation of 'foo<int *>' that occurs after an explicit specialization has no effect [-Winstantiation-after-specialization]
 template void foo<int*>(); // second case
               ^
-.tmp.cpp:86:6: note: previous template specialization is here
+.tmp.cpp:79:6: note: previous template specialization is here
 void foo<int *>()
      ^
 2 warnings and 4 errors generated.

--- a/tests/ClassOperatorHandler7Test.expect
+++ b/tests/ClassOperatorHandler7Test.expect
@@ -17,8 +17,6 @@ struct A<int>
   void foo(int);
   
   // inline constexpr A() noexcept = default;
-  // inline constexpr A(const A<int> &) = default;
-  // inline constexpr A(A<int> &&) = default;
 };
 
 #endif
@@ -34,15 +32,10 @@ struct A<int *>
     void operator()(int);
     
     // inline constexpr B() noexcept = default;
-    // inline ~B() = default;
-    // inline constexpr B(const A<int *>::B &) = default;
-    // inline constexpr B(A<int *>::B &&) = default;
   };
   
   A<int *>::B foo;
   // inline constexpr A() noexcept = default;
-  // inline constexpr A(const A<int *> &) = default;
-  // inline constexpr A(A<int *> &&) = default;
 };
 
 #endif

--- a/tests/ClassOperatorHandler9Test.expect
+++ b/tests/ClassOperatorHandler9Test.expect
@@ -62,9 +62,7 @@ class MyVector<int>
     return this->v.operator[](i);
   }
   
-  // inline MyVector(const MyVector<int> &) = default;
   // inline MyVector(MyVector<int> &&) noexcept = default;
-  // inline MyVector<int> & operator=(MyVector<int> &&) = default;
   // inline ~MyVector() noexcept = default;
 };
 

--- a/tests/ClassOperatorHandlerTest.cerr
+++ b/tests/ClassOperatorHandlerTest.cerr
@@ -1,60 +1,60 @@
-.tmp.cpp:106:21: error: no class named 'Fest' in namespace 'Hello::Bello'
+.tmp.cpp:103:21: error: no class named 'Fest' in namespace 'Hello::Bello'
 class Hello::Bello::Fest
       ~~~~~~~~~~~~~~^
-.tmp.cpp:106:21: warning: extra qualification on member 'Fest' [-Wextra-qualification]
-.tmp.cpp:141:29: error: no type named 'Fest' in namespace 'Hello::Bello'; did you mean simply 'Fest'?
+.tmp.cpp:103:21: warning: extra qualification on member 'Fest' [-Wextra-qualification]
+.tmp.cpp:136:29: error: no type named 'Fest' in namespace 'Hello::Bello'; did you mean simply 'Fest'?
 inline bool operator<(const Hello::Bello::Fest & LHS, const Hello::Bello::Fest & RHS)
                             ^~~~~~~~~~~~~~~~~~
                             Fest
-.tmp.cpp:74:7: note: 'Fest' declared here
+.tmp.cpp:73:7: note: 'Fest' declared here
 class Fest
       ^
-.tmp.cpp:141:61: error: no type named 'Fest' in namespace 'Hello::Bello'; did you mean simply 'Fest'?
+.tmp.cpp:136:61: error: no type named 'Fest' in namespace 'Hello::Bello'; did you mean simply 'Fest'?
 inline bool operator<(const Hello::Bello::Fest & LHS, const Hello::Bello::Fest & RHS)
                                                             ^~~~~~~~~~~~~~~~~~
                                                             Fest
-.tmp.cpp:74:7: note: 'Fest' declared here
+.tmp.cpp:73:7: note: 'Fest' declared here
 class Fest
       ^
-.tmp.cpp:147:8: error: no type named 'Fest' in namespace 'Hello::Bello'; did you mean simply 'Fest'?
+.tmp.cpp:142:8: error: no type named 'Fest' in namespace 'Hello::Bello'; did you mean simply 'Fest'?
 static Hello::Bello::Fest sF = Hello::Bello::Fest{3};
        ^~~~~~~~~~~~~~~~~~
        Fest
-.tmp.cpp:74:7: note: 'Fest' declared here
+.tmp.cpp:73:7: note: 'Fest' declared here
 class Fest
       ^
-.tmp.cpp:147:46: error: no member named 'Fest' in namespace 'Hello::Bello'
+.tmp.cpp:142:46: error: no member named 'Fest' in namespace 'Hello::Bello'
 static Hello::Bello::Fest sF = Hello::Bello::Fest{3};
                                ~~~~~~~~~~~~~~^
-.tmp.cpp:147:50: error: expected ';' after top level declarator
+.tmp.cpp:142:50: error: expected ';' after top level declarator
 static Hello::Bello::Fest sF = Hello::Bello::Fest{3};
                                                  ^
                                                  ;
-.tmp.cpp:190:3: error: no type named 'Fest' in namespace 'Hello::Bello'; did you mean simply 'Fest'?
+.tmp.cpp:185:3: error: no type named 'Fest' in namespace 'Hello::Bello'; did you mean simply 'Fest'?
   Hello::Bello::Fest f3 = Hello::Bello::Fest{3};
   ^~~~~~~~~~~~~~~~~~
   Fest
-.tmp.cpp:74:7: note: 'Fest' declared here
+.tmp.cpp:73:7: note: 'Fest' declared here
 class Fest
       ^
-.tmp.cpp:190:41: error: no member named 'Fest' in namespace 'Hello::Bello'
+.tmp.cpp:185:41: error: no member named 'Fest' in namespace 'Hello::Bello'
   Hello::Bello::Fest f3 = Hello::Bello::Fest{3};
                           ~~~~~~~~~~~~~~^
-.tmp.cpp:190:45: error: expected ';' at end of declaration
+.tmp.cpp:185:45: error: expected ';' at end of declaration
   Hello::Bello::Fest f3 = Hello::Bello::Fest{3};
                                             ^
                                             ;
-.tmp.cpp:191:3: error: no type named 'Fest' in namespace 'Hello::Bello'; did you mean simply 'Fest'?
+.tmp.cpp:186:3: error: no type named 'Fest' in namespace 'Hello::Bello'; did you mean simply 'Fest'?
   Hello::Bello::Fest f4 = Hello::Bello::Fest{3};
   ^~~~~~~~~~~~~~~~~~
   Fest
-.tmp.cpp:74:7: note: 'Fest' declared here
+.tmp.cpp:73:7: note: 'Fest' declared here
 class Fest
       ^
-.tmp.cpp:191:41: error: no member named 'Fest' in namespace 'Hello::Bello'
+.tmp.cpp:186:41: error: no member named 'Fest' in namespace 'Hello::Bello'
   Hello::Bello::Fest f4 = Hello::Bello::Fest{3};
                           ~~~~~~~~~~~~~~^
-.tmp.cpp:191:45: error: expected ';' at end of declaration
+.tmp.cpp:186:45: error: expected ';' at end of declaration
   Hello::Bello::Fest f4 = Hello::Bello::Fest{3};
                                             ^
                                             ;

--- a/tests/ClassOperatorHandlerTest.expect
+++ b/tests/ClassOperatorHandlerTest.expect
@@ -66,7 +66,6 @@ class Test
   public: 
   // inline constexpr Test(const Test &) noexcept = default;
   // inline constexpr Test(Test &&) noexcept = default;
-  // inline ~Test() noexcept = default;
 };
 
 
@@ -94,8 +93,6 @@ class Fest
   private: 
   int mX;
   public: 
-  // inline constexpr Fest(const Fest &) = default;
-  // inline constexpr Fest(Fest &&) = default;
 };
 
 
@@ -132,8 +129,6 @@ class Hello::Bello::Fest
   private: 
   int mX;
   public: 
-  // inline constexpr Hello::Bello::Fest(const Hello::Bello::Fest &) = default;
-  // inline constexpr Hello::Bello::Fest(Hello::Bello::Fest &&) = default;
 };
 
 

--- a/tests/ClassTemplateDeclTest.cerr
+++ b/tests/ClassTemplateDeclTest.cerr
@@ -1,4 +1,4 @@
-.tmp.cpp:33:23: error: use of undeclared identifier 'Tmpl'; did you mean 'Test::Tmpl'?
+.tmp.cpp:31:23: error: use of undeclared identifier 'Tmpl'; did you mean 'Test::Tmpl'?
   Test::Tmpl<int> x = Tmpl<int>();
                       ^
 .tmp.cpp:9:9: note: 'Test::Tmpl' declared here

--- a/tests/ClassTemplateDeclTest.expect
+++ b/tests/ClassTemplateDeclTest.expect
@@ -19,8 +19,6 @@ class Test
     int m;
     public: 
     // inline Tmpl() noexcept = default;
-    // inline constexpr Tmpl(const Tmpl<int> &) = default;
-    // inline constexpr Tmpl(Tmpl<int> &&) = default;
   };
   
   #endif

--- a/tests/ClassTemplateTest.expect
+++ b/tests/ClassTemplateTest.expect
@@ -25,9 +25,6 @@ class Foo<int>
   }
   
   public: 
-  // inline ~Foo() = default;
-  // inline constexpr Foo(const Foo<int> &) = default;
-  // inline constexpr Foo(Foo<int> &&) = default;
 };
 
 #endif
@@ -43,8 +40,6 @@ class Bar : public Foo<int>
   }
   
   // inline constexpr Bar() noexcept = default;
-  // inline constexpr Bar(const Bar &) = default;
-  // inline constexpr Bar(Bar &&) = default;
 };
 
 

--- a/tests/ClassTemplateWithMethodDeclTest.expect
+++ b/tests/ClassTemplateWithMethodDeclTest.expect
@@ -16,8 +16,6 @@ struct Foo<int>
   }
   
   // inline constexpr Foo() noexcept = default;
-  // inline constexpr Foo(const Foo<int> &) = default;
-  // inline constexpr Foo(Foo<int> &&) = default;
 };
 
 #endif

--- a/tests/ClassTemplateWithoutDefinitionTest.expect
+++ b/tests/ClassTemplateWithoutDefinitionTest.expect
@@ -8,8 +8,6 @@ class Foo<double>
 {
   public: 
   // inline constexpr Foo() noexcept = default;
-  // inline constexpr Foo(const Foo<double> &) = default;
-  // inline constexpr Foo(Foo<double> &&) = default;
 };
 
 #endif

--- a/tests/ClassTest.expect
+++ b/tests/ClassTest.expect
@@ -47,7 +47,6 @@ class Test
   private: 
   int mV;
   public: 
-  // inline ~Test() noexcept = default;
 };
 
 

--- a/tests/ClassWithDeletedSpecialFunctionTest.expect
+++ b/tests/ClassWithDeletedSpecialFunctionTest.expect
@@ -19,8 +19,6 @@ class Foo<int>
   {
   }
   
-  // inline constexpr Foo(const Foo<int> &) = default;
-  // inline constexpr Foo(Foo<int> &&) = default;
 };
 
 #endif

--- a/tests/ClassWithMutableMemberTest.expect
+++ b/tests/ClassWithMutableMemberTest.expect
@@ -12,9 +12,6 @@ class C
   private: 
   mutable int mX;
   public: 
-  // inline constexpr C(const C &) = default;
-  // inline C & operator=(const C &) = default;
-  // inline constexpr C(C &&) = default;
 };
 
 

--- a/tests/ClassWithoutDefinitionTest.expect
+++ b/tests/ClassWithoutDefinitionTest.expect
@@ -14,8 +14,6 @@ class Foo<int>
   struct Far;
   public: 
   // inline constexpr Foo() noexcept = default;
-  // inline constexpr Foo(const Foo<int> &) = default;
-  // inline constexpr Foo(Foo<int> &&) = default;
 };
 
 #endif

--- a/tests/CompilerGeneratedHandler2Test.expect
+++ b/tests/CompilerGeneratedHandler2Test.expect
@@ -7,7 +7,6 @@ class C
   public: 
   int i;
   inline virtual ~C() noexcept = default;
-  // inline C & operator=(const C &) = default;
   // inline constexpr C(const C &) noexcept = default;
   // inline C() noexcept = default;
 };
@@ -30,11 +29,6 @@ class D : public C
   
   public: 
   int x;
-  // inline constexpr D(const D &) = default;
-  // inline constexpr D(D &&) = default;
-  // inline D & operator=(const D &) = default;
-  // inline D & operator=(D &&) = default;
-  // inline virtual ~D() noexcept = default;
 };
 
 

--- a/tests/CompilerGeneratedHandlerTest.expect
+++ b/tests/CompilerGeneratedHandlerTest.expect
@@ -3,7 +3,6 @@
 struct S
 {
   int i;
-  // inline S() = default;
   // inline constexpr S(const S &) noexcept = default;
   // inline constexpr S(S &&) noexcept = default;
 };
@@ -17,7 +16,6 @@ struct SS
   // inline constexpr SS(const SS &) noexcept = default;
   // inline constexpr SS(SS &&) noexcept = default;
   // inline constexpr SS & operator=(const SS &) noexcept = default;
-  // inline constexpr SS & operator=(SS &&) = default;
 };
 
 
@@ -28,7 +26,6 @@ class C
   
   public: 
   int i;
-  // inline C() = default;
   // inline constexpr C(const C &) noexcept = default;
   // inline constexpr C(C &&) noexcept = default;
 };
@@ -44,8 +41,6 @@ class D
   // inline constexpr D(const D &) noexcept = default;
   // inline constexpr D(D &&) noexcept = default;
   // inline constexpr D & operator=(const D &) noexcept = default;
-  // inline constexpr D & operator=(D &&) = default;
-  // inline ~D() = default;
 };
 
 
@@ -63,8 +58,6 @@ class E
   private: 
   int i;
   public: 
-  // inline constexpr E(const E &) = default;
-  // inline constexpr E(E &&) = default;
 };
 
 

--- a/tests/DefaultArgInNamespaceTest.expect
+++ b/tests/DefaultArgInNamespaceTest.expect
@@ -22,8 +22,6 @@ class West
     return 2;
   }
   
-  // inline constexpr West(const Test::West &) = default;
-  // inline constexpr West(Test::West &&) = default;
 };
 
 

--- a/tests/DelegatingCtorTest.expect
+++ b/tests/DelegatingCtorTest.expect
@@ -27,9 +27,6 @@ struct Foo<int>
   
   char _x;
   int _y;
-  // inline constexpr Foo(const Foo<int> &) = default;
-  // inline constexpr Foo(Foo<int> &&) = default;
-  // inline ~Foo() noexcept = default;
 };
 
 #endif
@@ -50,9 +47,6 @@ struct Foo<char>
   
   char _x;
   int _y;
-  // inline constexpr Foo(const Foo<char> &) = default;
-  // inline constexpr Foo(Foo<char> &&) = default;
-  // inline ~Foo() = default;
 };
 
 #endif
@@ -75,8 +69,6 @@ struct Bar<char> : public Foo<char>
   {
   }
   
-  // inline constexpr Bar(const Bar<char> &) = default;
-  // inline constexpr Bar(Bar<char> &&) = default;
 };
 
 #endif

--- a/tests/FieldDeclArrayRefTest.expect
+++ b/tests/FieldDeclArrayRefTest.expect
@@ -33,8 +33,6 @@ class array<int, 2>
   {
   }
   
-  // inline constexpr array(const array<int, 2> &) = default;
-  // inline constexpr array(array<int, 2> &&) = default;
 };
 
 #endif

--- a/tests/FriendDeclTest.expect
+++ b/tests/FriendDeclTest.expect
@@ -26,8 +26,6 @@ class Foo
   int mI;
   public: 
   friend void ChangePrivate(Foo &);
-  // inline constexpr Foo(const Foo &) = default;
-  // inline constexpr Foo(Foo &&) = default;
 };
 
 

--- a/tests/FunctionRefQualifierTest.expect
+++ b/tests/FunctionRefQualifierTest.expect
@@ -14,9 +14,6 @@ struct Foo
   }
   
   // inline constexpr Foo() noexcept = default;
-  // inline constexpr Foo(const Foo &) = default;
-  // inline constexpr Foo(Foo &&) = default;
-  // inline ~Foo() noexcept = default;
 };
 
 

--- a/tests/FunctionTemplateDecl2Test.expect
+++ b/tests/FunctionTemplateDecl2Test.expect
@@ -28,10 +28,6 @@ class Test
   }
   #endif
   
-  // inline constexpr Test(const Test &) = default;
-  // inline constexpr Test(Test &&) = default;
-  // inline constexpr Test & operator=(const Test &) = default;
-  // inline constexpr Test & operator=(Test &&) = default;
 };
 
 

--- a/tests/FunctionTemplateDecl3Test.expect
+++ b/tests/FunctionTemplateDecl3Test.expect
@@ -42,10 +42,6 @@ class Test<int>
   }
   #endif
   
-  // inline constexpr Test(const Test<int> &) = default;
-  // inline constexpr Test(Test<int> &&) = default;
-  // inline constexpr Test<int> & operator=(const Test<int> &) = default;
-  // inline constexpr Test<int> & operator=(Test<int> &&) = default;
 };
 
 #endif
@@ -71,10 +67,6 @@ class Test<char>
   }
   #endif
   
-  // inline constexpr Test(const Test<char> &) = default;
-  // inline constexpr Test(Test<char> &&) = default;
-  // inline constexpr Test<char> & operator=(const Test<char> &) = default;
-  // inline constexpr Test<char> & operator=(Test<char> &&) = default;
 };
 
 #endif
@@ -90,8 +82,6 @@ class Test<float>
   inline constexpr Test() noexcept = default;
   template<typename T2>
   inline Test<float> & operator=(const Test<T2> & other);
-  // inline constexpr Test(const Test<float> &) = default;
-  // inline constexpr Test(Test<float> &&) = default;
 };
 
 #endif

--- a/tests/FunctionTemplateDeclTest.expect
+++ b/tests/FunctionTemplateDeclTest.expect
@@ -32,10 +32,6 @@ class Test<int>
   }
   #endif
   
-  // inline constexpr Test(const Test<int> &) = default;
-  // inline constexpr Test(Test<int> &&) = default;
-  // inline constexpr Test<int> & operator=(const Test<int> &) = default;
-  // inline constexpr Test<int> & operator=(Test<int> &&) = default;
 };
 
 #endif
@@ -61,10 +57,6 @@ class Test<char>
   }
   #endif
   
-  // inline constexpr Test(const Test<char> &) = default;
-  // inline constexpr Test(Test<char> &&) = default;
-  // inline constexpr Test<char> & operator=(const Test<char> &) = default;
-  // inline constexpr Test<char> & operator=(Test<char> &&) = default;
 };
 
 #endif

--- a/tests/ImplicitCast2Test.expect
+++ b/tests/ImplicitCast2Test.expect
@@ -16,10 +16,6 @@ struct A
     return 2;
   }
   
-  // inline constexpr A() noexcept = default;
-  // inline constexpr A(const A &) = default;
-  // inline constexpr A(A &&) = default;
-  // inline ~A() noexcept = default;
 };
 
  

--- a/tests/ImplicitCastTest.expect
+++ b/tests/ImplicitCastTest.expect
@@ -2,9 +2,6 @@ class Base
 {
   public: 
   // inline constexpr Base() noexcept = default;
-  // inline ~Base() = default;
-  // inline constexpr Base(const Base &) = default;
-  // inline constexpr Base(Base &&) = default;
 };
 
 
@@ -13,8 +10,6 @@ class Derived : public Base
 {
   public: 
   // inline constexpr Derived() noexcept = default;
-  // inline constexpr Derived(const Derived &) = default;
-  // inline constexpr Derived(Derived &&) = default;
 };
 
 

--- a/tests/ImplicitValueInitExprTest.expect
+++ b/tests/ImplicitValueInitExprTest.expect
@@ -4,7 +4,6 @@ struct Point
 {
   double x;
   double y;
-  // inline ~Point() noexcept = default;
 };
 
 
@@ -53,7 +52,6 @@ struct Complex
 {
   _Complex float fc;
   _Complex int ic;
-  // inline ~Complex() noexcept = default;
 };
 
 

--- a/tests/InClassInitializer2Test.expect
+++ b/tests/InClassInitializer2Test.expect
@@ -8,8 +8,6 @@ int main()
     }
     
     int x;
-    // inline constexpr S(const S &) = default;
-    // inline constexpr S(S &&) = default;
   };
   
   S s = S();

--- a/tests/InitializerList2Test.expect
+++ b/tests/InitializerList2Test.expect
@@ -8,8 +8,6 @@ class Foo
   {
   }
   
-  // inline constexpr Foo(const Foo &) = default;
-  // inline constexpr Foo(Foo &&) = default;
 };
 
 

--- a/tests/InitializerListTest.expect
+++ b/tests/InitializerListTest.expect
@@ -31,7 +31,6 @@ class X
     return *this;
   }
   
-  // inline constexpr X(const X &) = default;
 };
 
 
@@ -46,8 +45,6 @@ struct V
   {
   }
   
-  // inline constexpr V(const V &) = default;
-  // inline constexpr V(V &&) = default;
 };
 
 
@@ -56,7 +53,6 @@ struct Y
 {
   int x;
   int y;
-  // inline ~Y() noexcept = default;
 };
 
 

--- a/tests/Issue123.expect
+++ b/tests/Issue123.expect
@@ -34,8 +34,6 @@ struct Person<int>
   }
   
   // inline Person() noexcept = default;
-  // inline constexpr Person(const Person<int> &) = default;
-  // inline constexpr Person(Person<int> &&) = default;
 };
 
 

--- a/tests/Issue184.expect
+++ b/tests/Issue184.expect
@@ -16,9 +16,6 @@ class Customer
     return std::basic_string<char>(this->name);
   }
   
-  // inline Customer(const Customer &) = default;
-  // inline Customer(Customer &&) = default;
-  // inline Customer & operator=(Customer &&) = default;
   // inline ~Customer() noexcept = default;
 };
 
@@ -31,10 +28,6 @@ struct CustomerEq
     return std::operator==(c0.getName(), c1.getName());
   }
   
-  // inline constexpr CustomerEq() noexcept = default;
-  // inline ~CustomerEq() noexcept = default;
-  // inline constexpr CustomerEq(const CustomerEq &) noexcept = default;
-  // inline constexpr CustomerEq(CustomerEq &&) noexcept = default;
 };
 
 
@@ -46,10 +39,6 @@ struct CustomerHash
     return std::hash<std::basic_string<char> >().operator()(c.getName());
   }
   
-  // inline constexpr CustomerHash() noexcept = default;
-  // inline ~CustomerHash() noexcept = default;
-  // inline constexpr CustomerHash(const CustomerHash &) noexcept = default;
-  // inline constexpr CustomerHash(CustomerHash &&) noexcept = default;
 };
 
 
@@ -70,10 +59,6 @@ struct ManyParentsWithOperator<CustomerHash, CustomerEq> : public CustomerHash, 
   using CustomerEq::operator();
   // inline bool CustomerEq::operator()(const Customer & c0, const Customer & c1) const;
   
-  // inline constexpr ManyParentsWithOperator() noexcept = default;
-  // inline ~ManyParentsWithOperator() noexcept = default;
-  // inline constexpr ManyParentsWithOperator(const ManyParentsWithOperator<CustomerHash, CustomerEq> &) noexcept = default;
-  // inline constexpr ManyParentsWithOperator(ManyParentsWithOperator<CustomerHash, CustomerEq> &&) noexcept = default;
 };
 
 #endif
@@ -90,10 +75,6 @@ struct ManyParentsWithOperator<CustomerEq, CustomerHash> : public CustomerEq, pu
   using CustomerHash::operator();
   // inline std::size_t CustomerHash::operator()(const Customer & c) const;
   
-  // inline constexpr ManyParentsWithOperator() noexcept = default;
-  // inline ~ManyParentsWithOperator() noexcept = default;
-  // inline constexpr ManyParentsWithOperator(const ManyParentsWithOperator<CustomerEq, CustomerHash> &) noexcept = default;
-  // inline constexpr ManyParentsWithOperator(ManyParentsWithOperator<CustomerEq, CustomerHash> &&) noexcept = default;
 };
 
 #endif

--- a/tests/Issue188_2.expect
+++ b/tests/Issue188_2.expect
@@ -23,8 +23,6 @@ struct _Head_base<2, long, 0>
   
   inline constexpr _Head_base(const mstd::_Head_base<2, long, 0> &) = default;
   long _M_head_impl;
-  // inline ~_Head_base() = default;
-  // inline constexpr mstd::_Head_base<2, long, 0> & operator=(const mstd::_Head_base<2, long, 0> &) = default;
 };
 
 #endif
@@ -44,8 +42,6 @@ struct _Head_base<1, short, 0>
   
   inline constexpr _Head_base(const mstd::_Head_base<1, short, 0> &) = default;
   short _M_head_impl;
-  // inline ~_Head_base() = default;
-  // inline constexpr mstd::_Head_base<1, short, 0> & operator=(const mstd::_Head_base<1, short, 0> &) = default;
 };
 
 #endif
@@ -109,9 +105,6 @@ struct _Tuple_impl<1, short, long> : public mstd::_Tuple_impl<2, long>, private 
   template<typename ... _UElements>
   inline constexpr _Tuple_impl(const _Tuple_impl<1UL, _UElements...> & __in);
   
-  // inline constexpr _Tuple_impl(const mstd::_Tuple_impl<1, short, long> &) = default;
-  // inline constexpr _Tuple_impl(mstd::_Tuple_impl<1, short, long> &&) = default;
-  // inline constexpr mstd::_Tuple_impl<1, short, long> & operator=(mstd::_Tuple_impl<1, short, long> &&) = default;
 };
 
 #endif
@@ -142,11 +135,6 @@ struct _Tuple_impl<2, long> : public mstd::_Tuple_impl<3>, private mstd::_Head_b
   #endif
   
   
-  // inline constexpr _Tuple_impl(const mstd::_Tuple_impl<2, long> &) = default;
-  // inline constexpr _Tuple_impl(mstd::_Tuple_impl<2, long> &&) = default;
-  // inline constexpr mstd::_Tuple_impl<2, long> & operator=(mstd::_Tuple_impl<2, long> &&) = default;
-  // inline ~_Tuple_impl() = default;
-  // inline constexpr mstd::_Tuple_impl<2, long> & operator=(const mstd::_Tuple_impl<2, long> &) = default;
 };
 
 #endif
@@ -160,11 +148,6 @@ struct _Tuple_impl<3>
   template<std::size_t , typename ... type_parameter_0_1>
   friend class _Tuple_impl;
   inline constexpr _Tuple_impl() noexcept = default;
-  // inline constexpr _Tuple_impl(const mstd::_Tuple_impl<3> &) = default;
-  // inline constexpr _Tuple_impl(mstd::_Tuple_impl<3> &&) = default;
-  // inline ~_Tuple_impl() = default;
-  // inline constexpr mstd::_Tuple_impl<3> & operator=(const mstd::_Tuple_impl<3> &) = default;
-  // inline constexpr mstd::_Tuple_impl<3> & operator=(mstd::_Tuple_impl<3> &&) = default;
 };
 
 #endif

--- a/tests/Issue193.expect
+++ b/tests/Issue193.expect
@@ -12,10 +12,6 @@ template<>
 class rule_t<int, cppcmb_rule_tag16>
 {
   public: 
-  // inline constexpr rule_t() noexcept = default;
-  // inline constexpr rule_t(const rule_t<int, cppcmb_rule_tag16> &) = default;
-  // inline constexpr rule_t(rule_t<int, cppcmb_rule_tag16> &&) = default;
-  // inline ~rule_t() noexcept = default;
 };
 
 #endif

--- a/tests/Issue2.expect
+++ b/tests/Issue2.expect
@@ -17,7 +17,6 @@ struct Movable
   
   // inline Movable(const Movable &) = delete;
   // inline Movable & operator=(const Movable &) = delete;
-  // inline ~Movable() noexcept = default;
 };
 
 
@@ -39,7 +38,6 @@ int main()
     int c;
     public: 
     // inline __lambda_20_16(const __lambda_20_16 &) = delete;
-    // inline __lambda_20_16(__lambda_20_16 &&) = default;
     __lambda_20_16(Movable && _x, int _c)
     : x{std::move(_x)}
     , c{_c}

--- a/tests/Issue205.expect
+++ b/tests/Issue205.expect
@@ -7,9 +7,6 @@ class EventContainer
   int val;
   std::function<void ()> something;
   public: 
-  // inline EventContainer(const EventContainer &) = default;
-  // inline EventContainer(EventContainer &&) = default;
-  // inline EventContainer & operator=(EventContainer &&) = default;
   // inline ~EventContainer() noexcept = default;
   
   public: 

--- a/tests/Issue205_2.expect
+++ b/tests/Issue205_2.expect
@@ -35,9 +35,6 @@ class EventContainer
   {
   }
   
-  // inline EventContainer(const EventContainer &) = default;
-  // inline EventContainer(EventContainer &&) = default;
-  // inline EventContainer & operator=(EventContainer &&) = default;
   // inline ~EventContainer() noexcept = default;
   
 };

--- a/tests/Issue236.expect
+++ b/tests/Issue236.expect
@@ -1,17 +1,11 @@
 struct S
 {
-  // inline constexpr S & operator=(const S &) = default;
-  // inline constexpr S & operator=(S &&) = default;
-  // inline ~S() = default;
 };
 
 
 class T : private virtual S
 {
   public: 
-  // inline T & operator=(const T &) = default;
-  // inline T & operator=(T &&) = default;
-  // inline ~T() = default;
 };
 
 

--- a/tests/Issue238_2.cerr
+++ b/tests/Issue238_2.cerr
@@ -1,16 +1,16 @@
-.tmp.cpp:48:5: error: templates cannot be declared inside of a local class
+.tmp.cpp:45:5: error: templates cannot be declared inside of a local class
     template<class type_parameter_0_0>
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-.tmp.cpp:79:5: error: templates cannot be declared inside of a local class
+.tmp.cpp:76:5: error: templates cannot be declared inside of a local class
     template<class type_parameter_0_0>
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-.tmp.cpp:55:16: error: declaration of variable 'test' with deduced type 'auto' requires an initializer
+.tmp.cpp:52:16: error: declaration of variable 'test' with deduced type 'auto' requires an initializer
           auto test;
                ^
-.tmp.cpp:86:16: error: declaration of variable 'test' with deduced type 'auto' requires an initializer
+.tmp.cpp:83:16: error: declaration of variable 'test' with deduced type 'auto' requires an initializer
           auto test;
                ^
-.tmp.cpp:96:10: error: no matching member function for call to 'operator()'
+.tmp.cpp:93:10: error: no matching member function for call to 'operator()'
   lambda.operator()(MyArrayWrapper<int>(vec));
   ~~~~~~~^~~~~~~~~~
 5 errors generated.

--- a/tests/Issue238_2.expect
+++ b/tests/Issue238_2.expect
@@ -28,10 +28,7 @@ class MyArrayWrapper<int>
     return this->size > 0 ? &this->data[this->size - 1] : nullptr;
   }
   
-  // inline MyArrayWrapper() noexcept = default;
   // inline constexpr MyArrayWrapper(const MyArrayWrapper<int> &) noexcept = default;
-  // inline constexpr MyArrayWrapper(MyArrayWrapper<int> &&) = default;
-  // inline ~MyArrayWrapper() noexcept = default;
 };
 
 #endif

--- a/tests/Issue251.cpp
+++ b/tests/Issue251.cpp
@@ -1,0 +1,14 @@
+#include <utility>
+
+class Foo
+{
+};
+static_assert(noexcept(Foo( Foo() )), "");
+static_assert(not noexcept( new Foo() ), "");
+
+int main()
+{
+  Foo f;
+// Foo ff = f;
+//  Foo fff = std::move(f);
+}

--- a/tests/Issue251.expect
+++ b/tests/Issue251.expect
@@ -1,0 +1,19 @@
+#include <utility>
+
+class Foo
+{
+  public: 
+  // inline constexpr Foo() noexcept = default;
+};
+
+
+/* PASSED: static_assert(noexcept(true) , ""); */
+
+/* PASSED: static_assert(!noexcept(false) , ""); */
+
+
+int main()
+{
+  Foo f = Foo();
+}
+

--- a/tests/Issue258.expect
+++ b/tests/Issue258.expect
@@ -17,7 +17,6 @@ int main()
     std::unique_ptr<int, std::default_delete<int> > x;
     public: 
     // inline /*constexpr */ __lambda_7_19(const __lambda_7_19 &) = delete;
-    // inline __lambda_7_19(__lambda_7_19 &&) = default;
     __lambda_7_19(std::unique_ptr<int, std::default_delete<int> > && _x)
     : x{std::move(_x)}
     {}

--- a/tests/Issue258_2.expect
+++ b/tests/Issue258_2.expect
@@ -19,7 +19,6 @@ class NonMoveable
     return this->mX;
   }
   
-  // inline ~NonMoveable() noexcept = default;
 };
 
 
@@ -40,7 +39,6 @@ int main()
     NonMoveable x;
     public: 
     // inline __lambda_22_19(const __lambda_22_19 &) = delete;
-    // inline /*constexpr */ __lambda_22_19(__lambda_22_19 &&) = default;
     __lambda_22_19(NonMoveable && _x)
     : x{static_cast<NonMoveable &&>(_x)}
     {}

--- a/tests/Issue50.expect
+++ b/tests/Issue50.expect
@@ -14,8 +14,6 @@ void foo<Test &>(Test & t)
 struct Test
 {
   // inline constexpr Test() noexcept = default;
-  // inline constexpr Test(const Test &) = default;
-  // inline constexpr Test(Test &&) = default;
 };
 
 

--- a/tests/Issue50_2.expect
+++ b/tests/Issue50_2.expect
@@ -4,8 +4,6 @@
 struct Test
 {
   // inline constexpr Test() noexcept = default;
-  // inline constexpr Test(const Test &) = default;
-  // inline constexpr Test(Test &&) = default;
 };
 
 

--- a/tests/Issue60.expect
+++ b/tests/Issue60.expect
@@ -46,9 +46,6 @@ struct Index<&Person::age>
   std::map<int, int, std::less<int>, std::allocator<std::pair<const int, int> > > data;
   static inline Index<&Person::age>::Key extractKey(const Index<&Person::age>::POD & pod);
   
-  // inline Index(const Index<&Person::age> &) = default;
-  // inline Index(Index<&Person::age> &&) = default;
-  // inline Index<&Person::age> & operator=(Index<&Person::age> &&) = default;
   // inline ~Index() noexcept = default;
   // inline Index() noexcept = default;
 };

--- a/tests/Issue64.expect
+++ b/tests/Issue64.expect
@@ -14,8 +14,6 @@ void func(const std::basic_string<char> & arg)
     private: 
     const std::basic_string<char> arg;
     public: 
-    // inline __lambda_5_11(const __lambda_5_11 &) = default;
-    // inline __lambda_5_11(__lambda_5_11 &&) = default;
     __lambda_5_11(const std::basic_string<char> _arg)
     : arg{_arg}
     {}

--- a/tests/LambdaAndInClassInitializerTest.expect
+++ b/tests/LambdaAndInClassInitializerTest.expect
@@ -45,9 +45,6 @@ class function<void ()>
   #endif
   
   
-  // inline constexpr function(const function<void ()> &) = default;
-  // inline constexpr function(function<void ()> &&) = default;
-  // inline ~function() noexcept = default;
 };
 
 #endif
@@ -82,8 +79,6 @@ class EventContainer
   } __lambda_17_38{this};
   
   // inline constexpr EventContainer() noexcept(false) = default;
-  // inline constexpr EventContainer(const EventContainer &) = default;
-  // inline constexpr EventContainer(EventContainer &&) = default;
 };
 
 

--- a/tests/LambdaAsTemplateArgTest.expect
+++ b/tests/LambdaAsTemplateArgTest.expect
@@ -7,8 +7,6 @@ template<>
 struct FunctionArgs<int (__lambda_12_14::*)(int, int) const>
 {
   // inline constexpr FunctionArgs() noexcept = default;
-  // inline constexpr FunctionArgs(const FunctionArgs<int (__lambda_12_14::*)(int, int) const> &) = default;
-  // inline constexpr FunctionArgs(FunctionArgs<int (__lambda_12_14::*)(int, int) const> &&) = default;
 };
 
 #endif

--- a/tests/LambdaHandler4Test.expect
+++ b/tests/LambdaHandler4Test.expect
@@ -75,8 +75,6 @@ class Foo
   int mX;
   public: 
   // inline constexpr Foo(const Foo &) noexcept = default;
-  // inline constexpr Foo(Foo &&) = default;
-  // inline ~Foo() noexcept = default;
 };
 
 

--- a/tests/LambdaHandlerVLATest.expect
+++ b/tests/LambdaHandlerVLATest.expect
@@ -65,7 +65,6 @@ struct SA<2>
   bool Test();
   
   int nt;
-  // inline constexpr SA(const SA<2> &) = default;
 };
 
 #endif

--- a/tests/LambdaInLamda2Test.cerr
+++ b/tests/LambdaInLamda2Test.cerr
@@ -4,29 +4,29 @@
 .tmp.cpp:14:5: error: unknown type name 'S'
     S s;
     ^
-.tmp.cpp:19:11: error: '__lambda_5_7' cannot be defined in a parameter type
+.tmp.cpp:18:11: error: '__lambda_5_7' cannot be defined in a parameter type
     class __lambda_5_7
           ^
-.tmp.cpp:58:7: error: redefinition of parameter '__lambda_5_7'
+.tmp.cpp:51:7: error: redefinition of parameter '__lambda_5_7'
     } __lambda_5_7{};
       ^
-.tmp.cpp:19:11: note: previous declaration is here
+.tmp.cpp:18:11: note: previous declaration is here
     class __lambda_5_7
           ^
-.tmp.cpp:58:19: error: expected ')'
+.tmp.cpp:51:19: error: expected ')'
     } __lambda_5_7{};
                   ^
-.tmp.cpp:18:17: note: to match this '('
+.tmp.cpp:17:17: note: to match this '('
     __lambda_4_5(    
                 ^
-.tmp.cpp:60:5: error: unknown type name 'S'
+.tmp.cpp:53:5: error: unknown type name 'S'
     S _s)
     ^
-.tmp.cpp:60:9: error: expected ';' at end of declaration list
+.tmp.cpp:53:9: error: expected ';' at end of declaration list
     S _s)
         ^
         ;
-.tmp.cpp:66:33: error: use of undeclared identifier '__lambda_5_7'
+.tmp.cpp:59:33: error: use of undeclared identifier '__lambda_5_7'
   __lambda_4_5 l = __lambda_4_5{__lambda_5_7.operator()()};
                                 ^
 8 errors generated.

--- a/tests/LambdaInLamda2Test.expect
+++ b/tests/LambdaInLamda2Test.expect
@@ -14,7 +14,6 @@ int main()
     S s;
     public: 
     // inline /*constexpr */ __lambda_4_5(const __lambda_4_5 &) noexcept = default;
-    // inline /*constexpr */ __lambda_4_5(__lambda_4_5 &&) = default;
     __lambda_4_5(    
     class __lambda_5_7
     {
@@ -24,10 +23,7 @@ int main()
         struct S
         {
           int v{676};
-          // inline ~S() noexcept = default;
-          // inline constexpr S() = default;
           // inline constexpr S(const S &) noexcept = default;
-          // inline constexpr S(S &&) = default;
         };
         
         return S{{676}};
@@ -45,10 +41,7 @@ int main()
         struct S
         {
           int v{676};
-          // inline ~S() noexcept = default;
-          // inline constexpr S() = default;
           // inline constexpr S(const S &) noexcept = default;
-          // inline constexpr S(S &&) = default;
         };
         
         return S{{676}};

--- a/tests/LambdaInMemberCallExprTest.expect
+++ b/tests/LambdaInMemberCallExprTest.expect
@@ -16,8 +16,6 @@ class Test
   #endif
   
   // inline constexpr Test() noexcept = default;
-  // inline constexpr Test(const Test &) = default;
-  // inline constexpr Test(Test &&) = default;
 };
 
 

--- a/tests/MutableFieldDeclTest.expect
+++ b/tests/MutableFieldDeclTest.expect
@@ -5,8 +5,6 @@ int main()
   {
     mutable int x;
     public: 
-    // inline constexpr Test(const Test &) = default;
-    // inline constexpr Test & operator=(const Test &) = default;
   };
   
 }

--- a/tests/NRVOHandlerTest.expect
+++ b/tests/NRVOHandlerTest.expect
@@ -8,7 +8,6 @@ struct C
     printf("Copy\n");
   }
   
-  // inline ~C() noexcept = default;
 };
 
 

--- a/tests/NonTypeTemplateArgTest.expect
+++ b/tests/NonTypeTemplateArgTest.expect
@@ -21,8 +21,6 @@ struct SC<&c>
   }
   
   // inline constexpr SC() noexcept = default;
-  // inline constexpr SC(const SC<&c> &) = default;
-  // inline constexpr SC(SC<&c> &&) = default;
 };
 
 #endif

--- a/tests/NonTypeTemplateParameterPackTest.cerr
+++ b/tests/NonTypeTemplateParameterPackTest.cerr
@@ -1,11 +1,11 @@
-.tmp.cpp:156:41: error: use of undeclared identifier 'my_array'; did you mean 'Test::my_array'?
+.tmp.cpp:149:41: error: use of undeclared identifier 'my_array'; did you mean 'Test::my_array'?
   Test::Map<int, int> a = Map<int, int, my_array>();
                                         ^~~~~~~~
                                         Test::my_array
 .tmp.cpp:106:9: note: 'Test::my_array' declared here
   class my_array
         ^
-.tmp.cpp:156:41: error: use of undeclared identifier 'my_array'
+.tmp.cpp:149:41: error: use of undeclared identifier 'my_array'
   Test::Map<int, int> a = Map<int, int, my_array>();
                                         ^
 2 errors generated.

--- a/tests/NonTypeTemplateParameterPackTest.expect
+++ b/tests/NonTypeTemplateParameterPackTest.expect
@@ -114,9 +114,6 @@ class Test
   {
     public: 
     // inline constexpr my_array() noexcept = default;
-    // inline ~my_array() = default;
-    // inline constexpr my_array(const my_array<int> &) = default;
-    // inline constexpr my_array(my_array<int> &&) = default;
   };
   
   #endif
@@ -136,14 +133,10 @@ class Test
     my_array<int> value;
     public: 
     // inline constexpr Map() noexcept = default;
-    // inline constexpr Map(const Map<int, int, my_array> &) = default;
-    // inline constexpr Map(Map<int, int, my_array> &&) = default;
   };
   
   #endif
   // inline constexpr Test() noexcept = default;
-  // inline constexpr Test(const Test &) = default;
-  // inline constexpr Test(Test &&) = default;
 };
 
 

--- a/tests/PureVirtualFunctionTest.expect
+++ b/tests/PureVirtualFunctionTest.expect
@@ -4,12 +4,7 @@ class Test
   public: 
   virtual void Pure() = 0;
   
-  // inline constexpr Test & operator=(const Test &) = default;
-  // inline constexpr Test & operator=(Test &&) = default;
-  // inline ~Test() = default;
   // inline constexpr Test() noexcept = default;
-  // inline constexpr Test(const Test &) = default;
-  // inline constexpr Test(Test &&) = default;
 };
 
 
@@ -22,12 +17,7 @@ class West : public Test
   {
   }
   
-  // inline constexpr West & operator=(const West &) = default;
-  // inline constexpr West & operator=(West &&) = default;
-  // inline ~West() = default;
   // inline constexpr West() noexcept = default;
-  // inline constexpr West(const West &) = default;
-  // inline constexpr West(West &&) = default;
 };
 
 

--- a/tests/RangeForStmtHandler3Test.expect
+++ b/tests/RangeForStmtHandler3Test.expect
@@ -55,10 +55,7 @@
   {
     return false;
   }
-  // inline ~null_sentinal_t() noexcept = default;
-  // inline constexpr null_sentinal_t() = default;
   // inline constexpr null_sentinal_t(const null_sentinal_t &) noexcept = default;
-  // inline constexpr null_sentinal_t(null_sentinal_t &&) = default;
 };
 
 
@@ -86,7 +83,6 @@ struct str_view<char>
     return {};
   }
   
-  // inline ~str_view() noexcept = default;
 };
 
 #endif

--- a/tests/RangeForStmtHandler4Test.expect
+++ b/tests/RangeForStmtHandler4Test.expect
@@ -31,8 +31,6 @@ class MyArrayWrapper<int>
   }
   
   // inline MyArrayWrapper() noexcept = default;
-  // inline constexpr MyArrayWrapper(const MyArrayWrapper<int> &) = default;
-  // inline constexpr MyArrayWrapper(MyArrayWrapper<int> &&) = default;
 };
 
 #endif

--- a/tests/RangeForStmtHandler5Test.expect
+++ b/tests/RangeForStmtHandler5Test.expect
@@ -16,8 +16,6 @@ class MyArrayWrapper
   }
   
   // inline MyArrayWrapper() noexcept = default;
-  // inline constexpr MyArrayWrapper(const MyArrayWrapper &) = default;
-  // inline constexpr MyArrayWrapper(MyArrayWrapper &&) = default;
 };
 
 

--- a/tests/RangeForStmtHandler8Test.expect
+++ b/tests/RangeForStmtHandler8Test.expect
@@ -25,7 +25,6 @@ struct A
   
   int v[10]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
   // inline constexpr A(const A &) noexcept = default;
-  // inline constexpr A(A &&) = default;
 };
 
 

--- a/tests/RangeForStmtHandlerTest.expect
+++ b/tests/RangeForStmtHandlerTest.expect
@@ -30,8 +30,6 @@ struct A
   }
   
   int v[10];
-  // inline constexpr A(const A &) = default;
-  // inline constexpr A(A &&) = default;
 };
 
 
@@ -80,8 +78,6 @@ struct B
   }
   
   int v[10];
-  // inline constexpr B(const B &) = default;
-  // inline constexpr B(B &&) = default;
 };
 
 

--- a/tests/SpecialMemberTest.expect
+++ b/tests/SpecialMemberTest.expect
@@ -23,9 +23,6 @@ class D
   std::unique_ptr<int, std::default_delete<int> > p;
   public: 
   // inline constexpr D(const D &) = delete;
-  // inline D(D &&) = default;
-  // inline D & operator=(D &&) = default;
-  // inline ~D() = default;
 };
 
 

--- a/tests/StaticHandler2Test.expect
+++ b/tests/StaticHandler2Test.expect
@@ -22,8 +22,6 @@ class Singleton
   inline Singleton() noexcept = default;
   int mX;
   public: 
-  // inline constexpr Singleton(const Singleton &) = default;
-  // inline constexpr Singleton(Singleton &&) = default;
 };
 
 

--- a/tests/StaticHandler3Test.expect
+++ b/tests/StaticHandler3Test.expect
@@ -23,7 +23,6 @@ class Singleton
   inline ~Singleton() noexcept = default;
   int mX;
   public: 
-  // inline constexpr Singleton(const Singleton &) = default;
 };
 
 

--- a/tests/StaticHandler4Test.expect
+++ b/tests/StaticHandler4Test.expect
@@ -14,8 +14,6 @@ class Sing
     X();
   }
   
-  // inline constexpr Sing(const Sing &) = default;
-  // inline constexpr Sing(Sing &&) = default;
 };
 
 

--- a/tests/StaticHandler5Test.expect
+++ b/tests/StaticHandler5Test.expect
@@ -15,7 +15,6 @@ class Sing
     X();
   }
   
-  // inline Sing(const Sing &) = default;
 };
 
 

--- a/tests/StaticHandler6Test.expect
+++ b/tests/StaticHandler6Test.expect
@@ -11,8 +11,6 @@ class Sing
     X();
   }
   
-  // inline constexpr Sing(const Sing &) = default;
-  // inline constexpr Sing(Sing &&) = default;
 };
 
 

--- a/tests/StaticHandlerTest.expect
+++ b/tests/StaticHandlerTest.expect
@@ -28,7 +28,6 @@ class Singleton
   
   int mX;
   public: 
-  // inline constexpr Singleton(const Singleton &) = default;
 };
 
 
@@ -70,7 +69,6 @@ class Bingleton
   private: 
   int mX;
   public: 
-  // inline constexpr Bingleton(const Bingleton &) = default;
 };
 
 

--- a/tests/StaticInLambdaTest.expect
+++ b/tests/StaticInLambdaTest.expect
@@ -28,7 +28,6 @@ class Singleton
   
   int mX;
   public: 
-  // inline constexpr Singleton(const Singleton &) = default;
 };
 
 

--- a/tests/StructuredBindingsHandler2Test.expect
+++ b/tests/StructuredBindingsHandler2Test.expect
@@ -6,9 +6,7 @@ int main()
   {
     int x;
     int y;
-    // inline SP() = default;
     // inline constexpr SP(const SP &) noexcept = default;
-    // inline constexpr SP(SP &&) = default;
   };
   
   SP sp = {1, 2};
@@ -21,9 +19,7 @@ int main()
     public: 
     int x;
     int y;
-    // inline CP() = default;
     // inline constexpr CP(const CP &) noexcept = default;
-    // inline constexpr CP(CP &&) = default;
   };
   
   CP cp = {1, 2};

--- a/tests/StructuredBindingsHandler3Test.cerr
+++ b/tests/StructuredBindingsHandler3Test.cerr
@@ -1,90 +1,90 @@
-.tmp.cpp:83:8: error: no template named 'tuple_size'; did you mean 'std::tuple_size'?
+.tmp.cpp:82:8: error: no template named 'tuple_size'; did you mean 'std::tuple_size'?
 struct tuple_size<constant::Q>
        ^~~~~~~~~~
        std::tuple_size
 .tmp.cpp:4:45: note: 'std::tuple_size' declared here
 namespace std { template<typename T> struct tuple_size; }
                                             ^
-.tmp.cpp:90:8: error: no template named 'tuple_element'; did you mean 'std::tuple_element'?
+.tmp.cpp:89:8: error: no template named 'tuple_element'; did you mean 'std::tuple_element'?
 struct tuple_element<N, constant::Q>
        ^~~~~~~~~~~~~
        std::tuple_element
 .tmp.cpp:5:51: note: 'std::tuple_element' declared here
 namespace std { template<size_t, typename> struct tuple_element;
                                                   ^
-.tmp.cpp:101:46: error: no matching function for call to 'get'
+.tmp.cpp:100:46: error: no matching function for call to 'get'
 std::tuple_element<0, constant::Q>::type a = constant::get<0UL>(constant::__q17);
                                              ^~~~~~~~~~~~~~~~~~
-.tmp.cpp:50:33: note: candidate function template not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
+.tmp.cpp:49:33: note: candidate function template not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
   template<int N> constexpr int get(Q &&) { return N * N; }
                                 ^
-.tmp.cpp:102:46: error: no matching function for call to 'get'
+.tmp.cpp:101:46: error: no matching function for call to 'get'
 std::tuple_element<1, constant::Q>::type b = constant::get<1UL>(constant::__q17);
                                              ^~~~~~~~~~~~~~~~~~
-.tmp.cpp:50:33: note: candidate function template not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
+.tmp.cpp:49:33: note: candidate function template not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
   template<int N> constexpr int get(Q &&) { return N * N; }
                                 ^
-.tmp.cpp:103:65: error: use of undeclared identifier 'conststd'
+.tmp.cpp:102:65: error: use of undeclared identifier 'conststd'
 std::tuple_element<2, constant::Q>::type c = constant::get<2UL>(conststd::tuple_element<0, constant::Q>::type && a = constant::get<0UL>(constant::);
                                                                 ^
-.tmp.cpp:103:147: error: expected unqualified-id
+.tmp.cpp:102:147: error: expected unqualified-id
 std::tuple_element<2, constant::Q>::type c = constant::get<2UL>(conststd::tuple_element<0, constant::Q>::type && a = constant::get<0UL>(constant::);
                                                                                                                                                   ^
-.tmp.cpp:104:36: error: expected '(' for function-style cast or type construction
+.tmp.cpp:103:36: error: expected '(' for function-style cast or type construction
 ntstd::tuple_element<1, constant::Q>::type && b = constant::get<1UL>(constant::);
+                        ~~~~~~~~~~~^
+.tmp.cpp:103:39: error: no member named 'type' in the global namespace
+ntstd::tuple_element<1, constant::Q>::type && b = constant::get<1UL>(constant::);
+                                    ~~^
+.tmp.cpp:103:80: error: expected unqualified-id
+ntstd::tuple_element<1, constant::Q>::type && b = constant::get<1UL>(constant::);
+                                                                               ^
+.tmp.cpp:104:36: error: expected '(' for function-style cast or type construction
+:_std::tuple_element<2, constant::Q>::type && c = constant::get<2UL>(constant::);
                         ~~~~~~~~~~~^
 .tmp.cpp:104:39: error: no member named 'type' in the global namespace
-ntstd::tuple_element<1, constant::Q>::type && b = constant::get<1UL>(constant::);
+:_std::tuple_element<2, constant::Q>::type && c = constant::get<2UL>(constant::);
                                     ~~^
 .tmp.cpp:104:80: error: expected unqualified-id
-ntstd::tuple_element<1, constant::Q>::type && b = constant::get<1UL>(constant::);
-                                                                               ^
-.tmp.cpp:105:36: error: expected '(' for function-style cast or type construction
-:_std::tuple_element<2, constant::Q>::type && c = constant::get<2UL>(constant::);
-                        ~~~~~~~~~~~^
-.tmp.cpp:105:39: error: no member named 'type' in the global namespace
-:_std::tuple_element<2, constant::Q>::type && c = constant::get<2UL>(constant::);
-                                    ~~^
-.tmp.cpp:105:80: error: expected unqualified-id
 :_std::tuple_element<2, constant::Q>::type && c = constant::get<2UL>(constant::);
                                                                                ^
-.tmp.cpp:111:50: error: no matching function for call to 'get'
+.tmp.cpp:110:50: error: no matching function for call to 'get'
     std::tuple_element<0, constant::Q>::type a = constant::get<0UL>(__q19);
                                                  ^~~~~~~~~~~~~~~~~~
-.tmp.cpp:50:33: note: candidate function template not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
+.tmp.cpp:49:33: note: candidate function template not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
+  template<int N> constexpr int get(Q &&) { return N * N; }
+                                ^
+.tmp.cpp:111:50: error: no matching function for call to 'get'
+    std::tuple_element<1, constant::Q>::type b = constant::get<1UL>(__q19);
+                                                 ^~~~~~~~~~~~~~~~~~
+.tmp.cpp:49:33: note: candidate function template not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
   template<int N> constexpr int get(Q &&) { return N * N; }
                                 ^
 .tmp.cpp:112:50: error: no matching function for call to 'get'
-    std::tuple_element<1, constant::Q>::type b = constant::get<1UL>(__q19);
-                                                 ^~~~~~~~~~~~~~~~~~
-.tmp.cpp:50:33: note: candidate function template not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
-  template<int N> constexpr int get(Q &&) { return N * N; }
-                                ^
-.tmp.cpp:113:50: error: no matching function for call to 'get'
     std::tuple_element<2, constant::Q>::type c = constant::get<2UL>(__q19);
                                                  ^~~~~~~~~~~~~~~~~~
-.tmp.cpp:50:33: note: candidate function template not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
+.tmp.cpp:49:33: note: candidate function template not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
   template<int N> constexpr int get(Q &&) { return N * N; }
                                 ^
-.tmp.cpp:111:46: error: variables defined in a constexpr function must be initialized
+.tmp.cpp:110:46: error: variables defined in a constexpr function must be initialized
     std::tuple_element<0, constant::Q>::type a = constant::get<0UL>(__q19);
                                              ^
-.tmp.cpp:123:52: error: no matching function for call to 'get'
+.tmp.cpp:122:52: error: no matching function for call to 'get'
       std::tuple_element<0, constant::Q>::type a = constant::get<0UL>(__q26);
                                                    ^~~~~~~~~~~~~~~~~~
-.tmp.cpp:50:33: note: candidate function template not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
+.tmp.cpp:49:33: note: candidate function template not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
+  template<int N> constexpr int get(Q &&) { return N * N; }
+                                ^
+.tmp.cpp:123:52: error: no matching function for call to 'get'
+      std::tuple_element<1, constant::Q>::type b = constant::get<1UL>(__q26);
+                                                   ^~~~~~~~~~~~~~~~~~
+.tmp.cpp:49:33: note: candidate function template not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
   template<int N> constexpr int get(Q &&) { return N * N; }
                                 ^
 .tmp.cpp:124:52: error: no matching function for call to 'get'
-      std::tuple_element<1, constant::Q>::type b = constant::get<1UL>(__q26);
-                                                   ^~~~~~~~~~~~~~~~~~
-.tmp.cpp:50:33: note: candidate function template not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
-  template<int N> constexpr int get(Q &&) { return N * N; }
-                                ^
-.tmp.cpp:125:52: error: no matching function for call to 'get'
       std::tuple_element<2, constant::Q>::type c = constant::get<2UL>(__q26);
                                                    ^~~~~~~~~~~~~~~~~~
-.tmp.cpp:50:33: note: candidate function template not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
+.tmp.cpp:49:33: note: candidate function template not viable: no known conversion from 'constant::Q' to 'constant::Q &&' for 1st argument
   template<int N> constexpr int get(Q &&) { return N * N; }
                                 ^
 fatal error: too many errors emitted, stopping now [-ferror-limit=]

--- a/tests/StructuredBindingsHandler3Test.expect
+++ b/tests/StructuredBindingsHandler3Test.expect
@@ -43,7 +43,6 @@ namespace constant {
 {
   // inline constexpr Q() noexcept = default;
   // inline constexpr Q(const constant::Q &) noexcept = default;
-  // inline constexpr Q(constant::Q &&) = default;
 };
 
 

--- a/tests/StructuredBindingsHandler5Test.expect
+++ b/tests/StructuredBindingsHandler5Test.expect
@@ -147,9 +147,6 @@ class Point
   double mX;
   double mY;
   public: 
-  // inline constexpr Point(const Point &) = default;
-  // inline constexpr Point(Point &&) = default;
-  // inline ~Point() noexcept = default;
 };
 
 

--- a/tests/StructuredBindingsHandler6Test.expect
+++ b/tests/StructuredBindingsHandler6Test.expect
@@ -109,8 +109,6 @@ class Point
   #endif
   
   // inline constexpr Point(const Point &) noexcept = default;
-  // inline constexpr Point(Point &&) = default;
-  // inline ~Point() noexcept = default;
 };
 
 

--- a/tests/TemplateAsTemplateArgumentTest.expect
+++ b/tests/TemplateAsTemplateArgumentTest.expect
@@ -7,9 +7,6 @@ class my_array<int>
 {
   public: 
   // inline constexpr my_array() noexcept = default;
-  // inline ~my_array() = default;
-  // inline constexpr my_array(const my_array<int> &) = default;
-  // inline constexpr my_array(my_array<int> &&) = default;
 };
 
 #endif
@@ -32,8 +29,6 @@ class Map<int, int, my_array>
   my_array<int> value;
   public: 
   // inline constexpr Map() noexcept = default;
-  // inline constexpr Map(const Map<int, int, my_array> &) = default;
-  // inline constexpr Map(Map<int, int, my_array> &&) = default;
 };
 
 #endif

--- a/tests/TemplateExpansion2Test.expect
+++ b/tests/TemplateExpansion2Test.expect
@@ -71,9 +71,6 @@ class B
 {
   public: 
   // inline constexpr B() noexcept = default;
-  // inline ~B() = default;
-  // inline constexpr B(const B &) = default;
-  // inline constexpr B(B &&) = default;
 };
 
 
@@ -82,9 +79,6 @@ class E
 {
   public: 
   // inline constexpr E() noexcept = default;
-  // inline ~E() = default;
-  // inline constexpr E(const E &) = default;
-  // inline constexpr E(E &&) = default;
 };
 
 
@@ -101,8 +95,6 @@ class S<int> : public B
 {
   public: 
   // inline constexpr S() noexcept = default;
-  // inline constexpr S(const S<int> &) = default;
-  // inline constexpr S(S<int> &&) = default;
 };
 
 #endif
@@ -115,9 +107,6 @@ class S<double> : public B
 {
   public: 
   // inline constexpr S() noexcept = default;
-  // inline ~S() = default;
-  // inline constexpr S(const S<double> &) = default;
-  // inline constexpr S(S<double> &&) = default;
 };
 
 #endif
@@ -135,8 +124,6 @@ class Y<double> : public S<double>, public E
 {
   public: 
   // inline constexpr Y() noexcept = default;
-  // inline constexpr Y(const Y<double> &) = default;
-  // inline constexpr Y(Y<double> &&) = default;
 };
 
 #endif

--- a/tests/TemplateExpansionTest.expect
+++ b/tests/TemplateExpansionTest.expect
@@ -6,7 +6,6 @@ struct template_tuple {};
 template<>
 struct template_tuple<identity>
 {
-  // inline ~template_tuple() noexcept = default;
 };
 
 #endif
@@ -42,9 +41,6 @@ void foo2()
   {
     public: 
     // inline constexpr B() noexcept = default;
-    // inline ~B() = default;
-    // inline constexpr B(const B<Test, Test> &) = default;
-    // inline constexpr B(B<Test, Test> &&) = default;
   };
   
   #endif
@@ -61,8 +57,6 @@ void foo2()
   {
     public: 
     // inline constexpr testType() noexcept = default;
-    // inline constexpr testType(const testType<int> &) = default;
-    // inline constexpr testType(testType<int> &&) = default;
   };
   
   #endif
@@ -99,8 +93,6 @@ void foo2()
   {
     public: 
     // inline constexpr testIntegral() noexcept = default;
-    // inline constexpr testIntegral(const testIntegral<2> &) = default;
-    // inline constexpr testIntegral(testIntegral<2> &&) = default;
   };
   
   #endif
@@ -129,8 +121,6 @@ class testTemplate<A>
     B<Test, Test> testTemplateExpansion;
     public: 
     // inline constexpr C() noexcept = default;
-    // inline constexpr C(const C<Test, Test> &) = default;
-    // inline constexpr C(C<Test, Test> &&) = default;
   };
   
   #endif
@@ -145,8 +135,6 @@ class testTemplate<A>
   {
     public: 
     // inline constexpr testExpr() noexcept = default;
-    // inline constexpr testExpr(const testExpr<4, 1> &) = default;
-    // inline constexpr testExpr(testExpr<4, 1> &&) = default;
   };
   
   #endif
@@ -161,8 +149,6 @@ class testTemplate<A>
   {
     public: 
     // inline constexpr testPack() noexcept = default;
-    // inline constexpr testPack(const testPack<0, 1, 2, 4> &) = default;
-    // inline constexpr testPack(testPack<0, 1, 2, 4> &&) = default;
   };
   
   #endif

--- a/tests/TemplateHandlerTest.expect
+++ b/tests/TemplateHandlerTest.expect
@@ -86,8 +86,6 @@ class Template<int>
   private: 
   const int mX;
   public: 
-  // inline constexpr Template(const Template<int> &) = default;
-  // inline constexpr Template(Template<int> &&) = default;
 };
 
 #endif
@@ -111,8 +109,6 @@ class Template<double>
   private: 
   const double mX;
   public: 
-  // inline constexpr Template(const Template<double> &) = default;
-  // inline constexpr Template(Template<double> &&) = default;
 };
 
 #endif

--- a/tests/TemplateKeywordTest.cerr
+++ b/tests/TemplateKeywordTest.cerr
@@ -1,4 +1,4 @@
-.tmp.cpp:65:42: error: use of undeclared identifier 'result'
+.tmp.cpp:63:42: error: use of undeclared identifier 'result'
   compose<>::to<>::result<int, char> a = result<int, char>();
                                          ^
 1 error generated.

--- a/tests/TemplateKeywordTest.expect
+++ b/tests/TemplateKeywordTest.expect
@@ -19,8 +19,6 @@ namespace detail
     struct detail::to<int>::result<int, char>
     {
       // inline constexpr detail::to<int>::result() noexcept = default;
-      // inline constexpr detail::to<int>::result(const result<int, char> &) = default;
-      // inline constexpr detail::to<int>::result(result<int, char> &&) = default;
     };
     
     #endif

--- a/tests/TemplateMemberFunctionTest.expect
+++ b/tests/TemplateMemberFunctionTest.expect
@@ -50,8 +50,6 @@ class Foo
   }
   #endif
   
-  // inline constexpr Foo(const Foo &) = default;
-  // inline constexpr Foo(Foo &&) = default;
 };
 
 

--- a/tests/TemplateWithNullptrTest.cerr
+++ b/tests/TemplateWithNullptrTest.cerr
@@ -1,10 +1,10 @@
-.tmp.cpp:34:16: error: template argument for non-type template parameter must be an expression
+.tmp.cpp:32:16: error: template argument for non-type template parameter must be an expression
 B<A> b1 = B<A, void (A::*)()>();
                ^~~~~~~~~~~~~
 .tmp.cpp:14:28: note: template parameter is declared here
 template<class T, void(T::*SomeMethod)() = nullptr>
                            ^
-.tmp.cpp:37:25: error: template argument for non-type template parameter must be an expression
+.tmp.cpp:35:25: error: template argument for non-type template parameter must be an expression
 B<A, nullptr> b3 = B<A, void (A::*)()>();
                         ^~~~~~~~~~~~~
 .tmp.cpp:14:28: note: template parameter is declared here

--- a/tests/TemplateWithNullptrTest.expect
+++ b/tests/TemplateWithNullptrTest.expect
@@ -24,8 +24,6 @@ class B<A, void (A::*)()>
 {
   public: 
   // inline constexpr B() noexcept = default;
-  // inline constexpr B(const B<A, void (A::*)()> &) = default;
-  // inline constexpr B(B<A, void (A::*)()> &&) = default;
 };
 
 #endif

--- a/tests/TemporaryHandler2Test.expect
+++ b/tests/TemporaryHandler2Test.expect
@@ -10,10 +10,6 @@ class X
   
   void modify();
   
-  // inline constexpr X(const X &) = default;
-  // inline constexpr X(X &&) = default;
-  // inline ~X() noexcept = default;
-  // inline X & operator=(const X &) = default;
   // inline X & operator=(X &&) noexcept = default;
 };
 
@@ -78,7 +74,6 @@ class Base
     std::operator<<(std::cout, "Base dtor").operator<<(std::endl);
   }
   
-  // inline constexpr Base(const Base &) = default;
 };
 
 
@@ -92,7 +87,6 @@ class Foo : public Base
     std::operator<<(std::cout, "Foo dtor").operator<<(std::endl);
   }
   
-  // inline constexpr Foo(const Foo &) = default;
 };
 
 
@@ -125,7 +119,6 @@ struct S
   {
   }
   
-  // inline constexpr S(const S &) = default;
 };
 
 

--- a/tests/TemporaryHandlerTest.expect
+++ b/tests/TemporaryHandlerTest.expect
@@ -4,10 +4,6 @@ using namespace std;
 class A
 {
   public: 
-  // inline constexpr A() noexcept = default;
-  // inline constexpr A(const A &) = default;
-  // inline constexpr A(A &&) = default;
-  // inline ~A() noexcept = default;
 };
 
 
@@ -22,10 +18,6 @@ class B
     return A();
   }
   
-  // inline constexpr B() noexcept = default;
-  // inline ~B() noexcept = default;
-  // inline constexpr B(const B &) = default;
-  // inline constexpr B(B &&) = default;
 };
 
 
@@ -33,10 +25,6 @@ class B
 class C : public B
 {
   public: 
-  // inline constexpr C() noexcept = default;
-  // inline constexpr C(const C &) = default;
-  // inline constexpr C(C &&) = default;
-  // inline ~C() noexcept = default;
 };
 
 

--- a/tests/TypeAliasTemplateTest.expect
+++ b/tests/TypeAliasTemplateTest.expect
@@ -34,8 +34,6 @@ struct F<int>
   #endif
   
   
-  // inline constexpr F(const F<int> &) = default;
-  // inline constexpr F(F<int> &&) = default;
 };
 
 #endif

--- a/tests/TypeIdInTemplateTest.expect
+++ b/tests/TypeIdInTemplateTest.expect
@@ -26,8 +26,6 @@ class Foo<int>
   }
   
   // inline constexpr Foo() noexcept = default;
-  // inline constexpr Foo(const Foo<int> &) = default;
-  // inline constexpr Foo(Foo<int> &&) = default;
 };
 
 #endif

--- a/tests/UnnamedStructuredBindingTest.expect
+++ b/tests/UnnamedStructuredBindingTest.expect
@@ -4,7 +4,6 @@ struct RET
 {
   X x;
   int r;
-  // inline ~RET() noexcept = default;
 };
 
 

--- a/tests/UnresolvedPredefinedExprTest.expect
+++ b/tests/UnresolvedPredefinedExprTest.expect
@@ -22,8 +22,6 @@ class Test<int>
     const char * f = "Test";
   }
   
-  // inline constexpr Test(const Test<int> &) = default;
-  // inline constexpr Test(Test<int> &&) = default;
 };
 
 #endif

--- a/tests/UsingDecl2Test.cerr
+++ b/tests/UsingDecl2Test.cerr
@@ -1,7 +1,7 @@
-.tmp.cpp:85:63: error: 'protectedMember' is a protected member of 'ProtectedMember'
+.tmp.cpp:70:63: error: 'protectedMember' is a protected member of 'ProtectedMember'
   static_cast<ProtectedMember&>(usingProtectedToPublicMember).protectedMember = 1;
                                                               ^
-.tmp.cpp:58:7: note: declared protected here
+.tmp.cpp:48:7: note: declared protected here
   int protectedMember;
       ^
 1 error generated.

--- a/tests/UsingDecl2Test.expect
+++ b/tests/UsingDecl2Test.expect
@@ -12,12 +12,7 @@ struct B
   {
   }
   
-  // inline constexpr B & operator=(const B &) = default;
-  // inline constexpr B & operator=(B &&) = default;
-  // inline ~B() = default;
   // inline constexpr B() noexcept = default;
-  // inline constexpr B(const B &) = default;
-  // inline constexpr B(B &&) = default;
 };
 
 
@@ -41,12 +36,7 @@ struct D : public B
   {
   }
   
-  // inline constexpr D & operator=(const D &) = default;
-  // inline constexpr D & operator=(D &&) = default;
-  // inline ~D() = default;
   // inline constexpr D() noexcept = default;
-  // inline constexpr D(const D &) = default;
-  // inline constexpr D(D &&) = default;
 };
 
 
@@ -59,9 +49,6 @@ struct ProtectedMember
   using value_type = int;
   public: 
   // inline ProtectedMember() noexcept = default;
-  // inline ~ProtectedMember() = default;
-  // inline constexpr ProtectedMember(const ProtectedMember &) = default;
-  // inline constexpr ProtectedMember(ProtectedMember &&) = default;
 };
 
 
@@ -73,8 +60,6 @@ struct UsingProtectedToPublicMember : public ProtectedMember
   
   using ProtectedMember::value_type;
   // inline UsingProtectedToPublicMember() noexcept = default;
-  // inline constexpr UsingProtectedToPublicMember(const UsingProtectedToPublicMember &) = default;
-  // inline constexpr UsingProtectedToPublicMember(UsingProtectedToPublicMember &&) = default;
 };
 
 

--- a/tests/UsingDeclTest.expect
+++ b/tests/UsingDeclTest.expect
@@ -23,12 +23,7 @@ struct B
   int m;
   using value_type = int;
   public: 
-  // inline B & operator=(const B &) = default;
-  // inline B & operator=(B &&) = default;
-  // inline ~B() = default;
   // inline B() noexcept = default;
-  // inline constexpr B(const B &) = default;
-  // inline constexpr B(B &&) = default;
 };
 
 
@@ -70,12 +65,7 @@ struct D<int> : public B
   using B::h;
   inline void h(int);
   
-  // inline D<int> & operator=(const D<int> &) = default;
-  // inline D<int> & operator=(D<int> &&) = default;
-  // inline ~D() = default;
   // inline D() noexcept = default;
-  // inline constexpr D(const D<int> &) = default;
-  // inline constexpr D(D<int> &&) = default;
 };
 
 #endif
@@ -88,8 +78,6 @@ namespace Test
     struct Alloc
 {
   // inline constexpr Alloc() noexcept = default;
-  // inline constexpr Alloc(const Test::Alloc &) = default;
-  // inline constexpr Alloc(Test::Alloc &&) = default;
 };
 
 

--- a/tests/VarTemplateDecl3Test.expect
+++ b/tests/VarTemplateDecl3Test.expect
@@ -38,7 +38,6 @@ struct X<int>
 {
   int x;
   int y;
-  // inline ~X() noexcept = default;
 };
 
 #endif

--- a/tests/VisitorTest.expect
+++ b/tests/VisitorTest.expect
@@ -12,7 +12,6 @@ struct visitor<__lambda_8_7, __lambda_9_7> : public __lambda_8_7, public __lambd
   // inline /*constexpr */ void ::operator()(const char * value) const;
   
   // inline constexpr visitor<__lambda_8_7, __lambda_9_7> & operator=(visitor<__lambda_8_7, __lambda_9_7> &&) = delete;
-  // inline ~visitor() noexcept = default;
 };
 
 #endif
@@ -38,7 +37,6 @@ int main()
     }
     
     // inline /*constexpr */ __lambda_8_7 & operator=(const __lambda_8_7 &) = delete;
-    // inline /*constexpr */ __lambda_8_7(const __lambda_8_7 &) = default;
     // inline /*constexpr */ __lambda_8_7(__lambda_8_7 &&) noexcept = default;
     
   };
@@ -52,7 +50,6 @@ int main()
     }
     
     // inline /*constexpr */ __lambda_9_7 & operator=(const __lambda_9_7 &) = delete;
-    // inline /*constexpr */ __lambda_9_7(const __lambda_9_7 &) = default;
     // inline /*constexpr */ __lambda_9_7(__lambda_9_7 &&) noexcept = default;
     
   };

--- a/tests/constexprPoint.expect
+++ b/tests/constexprPoint.expect
@@ -33,8 +33,6 @@
   double mX;
   double mY;
   public: 
-  // inline constexpr Point(const Point &) = default;
-  // inline constexpr Point(Point &&) = default;
 };
 
 

--- a/tests/usingConstructorTest.expect
+++ b/tests/usingConstructorTest.expect
@@ -10,9 +10,6 @@ class Foo
   {
   }
   
-  // inline constexpr Foo(const Foo &) = default;
-  // inline constexpr Foo(Foo &&) = default;
-  // inline ~Foo() = default;
 };
 
 
@@ -23,8 +20,6 @@ class Bar : public Foo
   public: 
   int mX;
   // inline Bar() = delete;
-  // inline constexpr Bar(const Bar &) = default;
-  // inline constexpr Bar(Bar &&) = default;
   public: inline Bar(double amount) noexcept(false)
   : Foo(amount)
   {
@@ -46,8 +41,6 @@ class Bla : public Foo
   int mX;
   public: 
   // inline Bla() = delete;
-  // inline constexpr Bla(const Bla &) = default;
-  // inline constexpr Bla(Bla &&) = default;
   public: inline Bla(int x, int y) noexcept(false)
   : Foo(x, y)
   {


### PR DESCRIPTION
As per [special]/1: "Programs shall not define implicitly-declared
special member functions." hide special members which are not used
and with that not fully evaluated. This also hopefully removes
confusion about `noexcept`, which is not evaluated, if the special
member function is not used.