### PR TITLE
Fixed #254: Show `MemberExpr` template parameters as comment.

### DIFF
--- a/CodeGenerator.cpp
+++ b/CodeGenerator.cpp
@@ -521,7 +521,7 @@ void CodeGenerator::InsertArg(const MemberExpr* stmt)
 
     if(!skipTemplateArgs) {
         if(const auto cxxMethod = dyn_cast_or_null<CXXMethodDecl>(meDecl)) {
-            if(const auto* tmplArgs = cxxMethod->getAsFunction()->getTemplateSpecializationArgs()) {
+            if(const auto* tmplArgs = cxxMethod->getTemplateSpecializationArgs()) {
                 OutputFormatHelper ofm{};
 
                 ofm.Append('<');
@@ -543,6 +543,9 @@ void CodeGenerator::InsertArg(const MemberExpr* stmt)
 
                 if(haveArg) {
                     mOutputFormatHelper.Append(ofm.GetString(), ">");
+
+                } else if(cxxMethod->getAsFunction()->isFunctionTemplateSpecialization()) {
+                    InsertTemplateArgs(tmplArgs->asArray());
                 }
             }
         }

--- a/tests/CXXFoldExprTest.expect
+++ b/tests/CXXFoldExprTest.expect
@@ -66,10 +66,10 @@ class CXXFoldExprTest
 int main()
 {
   CXXFoldExprTest cxxFoldExprTest = {};
-  cxxFoldExprTest.UnaryRightFold(2, 3, 4, 5);
-  cxxFoldExprTest.UnaryLeftFold(2, 3, 4, 5);
-  cxxFoldExprTest.BinaryRightFold(2, 3, 4, 5);
-  cxxFoldExprTest.BinaryLeftFold(2, 3, 4, 5);
+  cxxFoldExprTest.UnaryRightFold<int, int, int, int>(2, 3, 4, 5);
+  cxxFoldExprTest.UnaryLeftFold<int, int, int, int>(2, 3, 4, 5);
+  cxxFoldExprTest.BinaryRightFold<int, int, int, int>(2, 3, 4, 5);
+  cxxFoldExprTest.BinaryLeftFold<int, int, int, int>(2, 3, 4, 5);
 }
 
 

--- a/tests/Issue184.expect
+++ b/tests/Issue184.expect
@@ -85,9 +85,9 @@ int main()
   std::unordered_set<Customer, CustomerHash, CustomerEq> set1 = std::unordered_set<Customer, CustomerHash, CustomerEq, std::allocator<Customer> >();
   std::unordered_set<Customer, ManyParentsWithOperator<CustomerHash, CustomerEq>, ManyParentsWithOperator<CustomerHash, CustomerEq> > set2 = std::unordered_set<Customer, ManyParentsWithOperator<CustomerHash, CustomerEq>, ManyParentsWithOperator<CustomerHash, CustomerEq>, std::allocator<Customer> >();
   std::unordered_set<Customer, ManyParentsWithOperator<CustomerEq, CustomerHash>, ManyParentsWithOperator<CustomerEq, CustomerHash> > set3 = std::unordered_set<Customer, ManyParentsWithOperator<CustomerEq, CustomerHash>, ManyParentsWithOperator<CustomerEq, CustomerHash>, std::allocator<Customer> >();
-  set1.emplace("Test");
-  set2.emplace("Test");
-  set3.emplace("Test");
+  set1.emplace<char const (&)[5]>("Test");
+  set2.emplace<char const (&)[5]>("Test");
+  set3.emplace<char const (&)[5]>("Test");
   return 0;
 }
 

--- a/tests/Issue254.cpp
+++ b/tests/Issue254.cpp
@@ -1,0 +1,15 @@
+struct demonstrator{
+  template <typename return_type = double>
+  return_type templated_function() {
+    return return_type{};
+  }
+};
+
+int demonstrate() {
+  demonstrator D;
+  D.template templated_function<bool>();
+  D.template templated_function<float>();
+  D.template templated_function();
+  return 42;
+}
+  

--- a/tests/Issue254.expect
+++ b/tests/Issue254.expect
@@ -1,0 +1,52 @@
+struct demonstrator
+{
+  template<typename return_type = double>
+  inline return_type templated_function()
+  {
+    return return_type{{}};
+  }
+  
+  /* First instantiated from: Issue254.cpp:10 */
+  #ifdef INSIGHTS_USE_TEMPLATE
+  template<>
+  inline bool templated_function<bool>()
+  {
+    return bool{};
+  }
+  #endif
+  
+  
+  /* First instantiated from: Issue254.cpp:11 */
+  #ifdef INSIGHTS_USE_TEMPLATE
+  template<>
+  inline float templated_function<float>()
+  {
+    return float{};
+  }
+  #endif
+  
+  
+  /* First instantiated from: Issue254.cpp:12 */
+  #ifdef INSIGHTS_USE_TEMPLATE
+  template<>
+  inline double templated_function<double>()
+  {
+    return double{};
+  }
+  #endif
+  
+  // inline constexpr demonstrator() noexcept = default;
+};
+
+
+
+int demonstrate()
+{
+  demonstrator D = demonstrator();
+  D.templated_function<bool>();
+  D.templated_function<float>();
+  D.templated_function<double>();
+  return 42;
+}
+
+  

--- a/tests/LambdaInMemberCallExprTest.cerr
+++ b/tests/LambdaInMemberCallExprTest.cerr
@@ -1,0 +1,7 @@
+.tmp.cpp:37:5: error: no matching member function for call to 'foo'
+  t.foo<__lambda_13_12>(__lambda_13_12);
+  ~~^~~~~~~~~~~~~~~~~~~
+.tmp.cpp:6:15: note: candidate template ignored: invalid explicitly-specified argument for template parameter 'T'
+  inline void foo(T &&)
+              ^
+1 error generated.

--- a/tests/LambdaInMemberCallExprTest.expect
+++ b/tests/LambdaInMemberCallExprTest.expect
@@ -34,6 +34,6 @@ int main()
     
   } __lambda_13_12{};
   
-  t.foo(__lambda_13_12);
+  t.foo<__lambda_13_12>(__lambda_13_12);
 }
 

--- a/tests/MemberExprTemplateTest.expect
+++ b/tests/MemberExprTemplateTest.expect
@@ -33,8 +33,8 @@
       public: 
       inline /*constexpr */ void operator()() const
       {
-        x.f(17);
-        x.ff(17, 2, 55.5);
+        x.f<int>(17);
+        x.ff<int, int, double>(17, 2, 55.5);
       }
       
       private: 

--- a/tests/NonTypeTemplateParameterPackTest.expect
+++ b/tests/NonTypeTemplateParameterPackTest.expect
@@ -69,7 +69,7 @@ class Test
   inline int summ<int, int, int>(int && i, int && __rest1, int && __rest2)
   {
     if constexpr(2 > 0) {
-      return i + this->summ(__rest1, __rest2);
+      return i + this->summ<int &, int &>(__rest1, __rest2);
     }
     
   }
@@ -82,7 +82,7 @@ class Test
   inline int summ<int &, int &>(int & i, int & rest)
   {
     if constexpr(1 > 0) {
-      return i + this->summ(rest);
+      return i + this->summ<int &>(rest);
     }
     
   }
@@ -145,7 +145,7 @@ class Test
 int main()
 {
   Test t = Test();
-  t.summ(1, 2, 3);
+  t.summ<int, int, int>(1, 2, 3);
   Test::Map<int, int> a = Map<int, int, my_array>();
   return t.sum<1>();
 }

--- a/tests/TemplateMemberFunctionTest.cerr
+++ b/tests/TemplateMemberFunctionTest.cerr
@@ -1,0 +1,7 @@
+.tmp.cpp:84:5: error: no matching member function for call to 'Do'
+  f.Do<__lambda_33_10>(__lambda_33_10);
+  ~~^~~~~~~~~~~~~~~~~~
+.tmp.cpp:9:15: note: candidate template ignored: invalid explicitly-specified argument for template parameter 'T'
+  inline void Do(T && t)
+              ^
+1 error generated.

--- a/tests/TemplateMemberFunctionTest.expect
+++ b/tests/TemplateMemberFunctionTest.expect
@@ -81,7 +81,7 @@ int main()
     
   } __lambda_33_10{};
   
-  f.Do(__lambda_33_10);
+  f.Do<__lambda_33_10>(__lambda_33_10);
     
   class __lambda_35_18
   {

--- a/tests/TupeInRangeBasedForTest.expect
+++ b/tests/TupeInRangeBasedForTest.expect
@@ -13,7 +13,7 @@ void fillTuples(std::vector<Tuple_t> tuples) {
 template<>
 void fillTuples<std::tuple<std::basic_string<char>, int> >(std::vector<std::tuple<std::basic_string<char>, int>, std::allocator<std::tuple<std::basic_string<char>, int> > > tuples)
 {
-  tuples.emplace_back("hello", 1);
+  tuples.emplace_back<char const (&)[6], int>("hello", 1);
 }
 #endif
 


### PR DESCRIPTION
Due to another issue (#255) the result of this issue does not compile.
This will be fixed with #255.