### PR TITLE
Simplified `InsertTemplateArgs` by making it a template and other things.

### DIFF
--- a/CodeGenerator.h
+++ b/CodeGenerator.h
@@ -279,7 +279,9 @@ protected:
         OutputFormatHelper& GetBuffer(OutputFormatHelper& outputFormatHelper) const;
     };
 
-    void HandleLambdaExpr(const LambdaExpr* stmt, LambdaHelper& lambdaHelper);
+    void               HandleLambdaExpr(const LambdaExpr* stmt, LambdaHelper& lambdaHelper);
+    static std::string FillConstantArray(const ConstantArrayType* ct, const std::string& value, const uint64_t startAt);
+    static std::string GetValueOfValueInit(const QualType& t);
 
     LambdaStackType  mLambdaStackThis;
     LambdaStackType& mLambdaStack;
@@ -290,8 +292,12 @@ protected:
     SkipVarDecl           mSkipVarDecl;
     UseCommaInsteadOfSemi mUseCommaInsteadOfSemi;
     const LambdaExpr*     mLambdaExpr;
-    static inline bool
-        mHaveLocalStatic;  // Track whether there was a thread-safe in the code. This requires adding the <new> header.
+    static inline bool    mHaveLocalStatic;  //!< Track whether there was a thread-safe \c static in the code. This
+                                             //!< requires adding the \c <new> header.
+
+    static constexpr auto MAX_FILL_VALUES_FOR_ARRAYS{
+        uint64_t{100}};  //!< This is the upper limit of elements which will be shown for an array when filled by \c
+                         //!< FillConstantArray.
 };
 //-----------------------------------------------------------------------------
 

--- a/InsightsHelpers.cpp
+++ b/InsightsHelpers.cpp
@@ -756,11 +756,9 @@ private:
         HandleTypeAfter(dyn_cast_or_null<t>(type));                                                                    \
     }
 
-        if(nullptr == type) {
-            return;
+        if(nullptr != type) {
+            HANDLE_TYPE(FunctionProtoType);
         }
-
-        HANDLE_TYPE(FunctionProtoType);
     }
 
     void AddCVQualifiers(const Qualifiers& quals)
@@ -988,8 +986,6 @@ std::string GetTypeNameAsParameter(const QualType& t, const std::string& varName
         } else if(Contains(typeName, "*")) {
             InsertBefore(typeName, "*", "(");
             InsertAfter(typeName, "*", StrCat(varName, ")"));
-        } else {
-            typeName += StrCat(" ", varName);
         }
     } else if(t->isFunctionPointerType()) {
         if(Contains(typeName, "(*")) {

--- a/InsightsHelpers.cpp
+++ b/InsightsHelpers.cpp
@@ -574,7 +574,7 @@ private:
                      type->getIdentifier()->getName().str());
 
         CodeGenerator codeGenerator{mData};
-        codeGenerator.InsertTemplateArgs(type->template_arguments());
+        codeGenerator.InsertTemplateArgs(*type);
 
         return true;
     }

--- a/InsightsOnce.h
+++ b/InsightsOnce.h
@@ -3,7 +3,7 @@
 
 namespace clang::insights {
 
-/// \brief A helper object which returns a boolen value just once and toggles it after the first query.
+/// \brief A helper object which returns a boolean value just once and toggles it after the first query.
 ///
 /// This allows to simplify code like this:
 /// \code

--- a/tests/DeductionGuideTest.cerr
+++ b/tests/DeductionGuideTest.cerr
@@ -1,19 +1,19 @@
-.tmp.cpp:64:13: error: unknown type name 'type_parameter_0_1'
+.tmp.cpp:66:13: error: unknown type name 'type_parameter_0_1'
   container(type_parameter_0_1 beg, type_parameter_0_1 end) -> container<T>;
             ^
-.tmp.cpp:64:37: error: unknown type name 'type_parameter_0_1'
+.tmp.cpp:66:37: error: unknown type name 'type_parameter_0_1'
   container(type_parameter_0_1 beg, type_parameter_0_1 end) -> container<T>;
                                     ^
-.tmp.cpp:66:13: error: unknown type name 'Iter'
+.tmp.cpp:68:13: error: unknown type name 'Iter'
   container(Iter b, Iter e) -> container<typename std::iterator_traits<Iter>::value_type>;
             ^
-.tmp.cpp:66:21: error: unknown type name 'Iter'
+.tmp.cpp:68:21: error: unknown type name 'Iter'
   container(Iter b, Iter e) -> container<typename std::iterator_traits<Iter>::value_type>;
                     ^
-.tmp.cpp:66:72: error: use of undeclared identifier 'Iter'
+.tmp.cpp:68:72: error: use of undeclared identifier 'Iter'
   container(Iter b, Iter e) -> container<typename std::iterator_traits<Iter>::value_type>;
                                                                        ^
-.tmp.cpp:66:77: error: no type named 'value_type' in the global namespace; did you mean 'std::false_type'?
+.tmp.cpp:68:77: error: no type named 'value_type' in the global namespace; did you mean 'std::false_type'?
   container(Iter b, Iter e) -> container<typename std::iterator_traits<Iter>::value_type>;
                                                                             ^~~~~~~~~~~~
                                                                             std::false_type

--- a/tests/DeductionGuideTest.cpp
+++ b/tests/DeductionGuideTest.cpp
@@ -1,0 +1,19 @@
+// Source: https://en.cppreference.com/w/cpp/language/class_template_argument_deduction
+
+#include <iterator>
+#include <vector>
+
+namespace Test {
+// declaration of the template
+template<class T> struct container {
+    container(T t) {}
+    template<class Iter> container(Iter beg, Iter end);
+};
+// additional deduction guide
+template<class Iter>
+container(Iter b, Iter e) -> container<typename std::iterator_traits<Iter>::value_type>;
+// uses
+container c(7); // OK: deduces T=int using an implicitly-generated guide
+std::vector<double> v = { /* ... */};
+auto d = container(v.begin(), v.end()); // OK: deduces T=double
+}

--- a/tests/DeductionGuideTest.expect
+++ b/tests/DeductionGuideTest.expect
@@ -1,0 +1,80 @@
+// Source: https://en.cppreference.com/w/cpp/language/class_template_argument_deduction
+
+#include <iterator>
+#include <vector>
+
+namespace Test
+{
+  template<class T>
+  struct container
+  {
+    inline container(T t)
+    {
+    }
+    
+    template<class Iter>
+    container(Iter beg, Iter end);
+    
+  };
+  
+  /* First instantiated from: DeductionGuideTest.cpp:16 */
+  #ifdef INSIGHTS_USE_TEMPLATE
+  template<>
+  struct container<int>
+  {
+    inline container(int t)
+    {
+    }
+    
+    template<class Iter>
+    container(Iter beg, Iter end);
+    
+  };
+  
+  #endif
+  /* First instantiated from: DeductionGuideTest.cpp:18 */
+  #ifdef INSIGHTS_USE_TEMPLATE
+  template<>
+  struct container<double>
+  {
+    inline container(double t);
+    
+    template<class Iter>
+    container(Iter beg, Iter end);
+    
+    
+    /* First instantiated from: DeductionGuideTest.cpp:18 */
+    #ifdef INSIGHTS_USE_TEMPLATE
+    template<>
+    container<std::__wrap_iter<double *> >(std::__wrap_iter<double *> beg, std::__wrap_iter<double *> end);
+    #endif
+    
+    
+  };
+  
+  #endif
+  template<class T>
+  container(T t) -> container<T>;
+  
+  /* First instantiated from: DeductionGuideTest.cpp:16 */
+  #ifdef INSIGHTS_USE_TEMPLATE
+  template<>
+  container(int t) -> container<int>;
+  #endif
+  
+  template<class T>
+  container(type_parameter_0_1 beg, type_parameter_0_1 end) -> container<T>;
+  template<class T>
+  container(Iter b, Iter e) -> container<typename std::iterator_traits<Iter>::value_type>;
+  
+  /* First instantiated from: DeductionGuideTest.cpp:18 */
+  #ifdef INSIGHTS_USE_TEMPLATE
+  template<>
+  container(std::__wrap_iter<double *> b, std::__wrap_iter<double *> e) -> container<double>;
+  #endif
+  
+  container<int> c = container<int>(7);
+  std::vector<double> v = std::vector<double, std::allocator<double> >{};
+  container<double> d = container<double>(v.begin(), v.end());
+  
+}

--- a/tests/Issue101.expect
+++ b/tests/Issue101.expect
@@ -387,7 +387,7 @@ struct compose<>
   template<>
   struct to<add_pointer::to<identity> >
   {
-    using T = detail::to<add_pointer::to<identity>>;
+    using T = detail::to<add_pointer::to<identity> >;
     template<typename ... Ts>
     using result = detail::to<identity>::result<Ts...>;
   };
@@ -398,7 +398,7 @@ struct compose<>
   template<>
   struct to<add_const::to<add_pointer::to<identity> > >
   {
-    using T = detail::to<add_const::to<add_pointer::to<identity> >>;
+    using T = detail::to<add_const::to<add_pointer::to<identity> > >;
     template<typename ... Ts>
     using result = detail::to<add_pointer::to<identity> >::result<Ts...>;
   };
@@ -409,7 +409,7 @@ struct compose<>
   template<>
   struct to<add_pointer::to<add_const::to<identity> > >
   {
-    using T = detail::to<add_pointer::to<add_const::to<identity> >>;
+    using T = detail::to<add_pointer::to<add_const::to<identity> > >;
     template<typename ... Ts>
     using result = detail::to<add_const::to<identity> >::result<Ts...>;
   };
@@ -420,7 +420,7 @@ struct compose<>
   template<>
   struct to<add_pointer::to<wrap> >
   {
-    using T = detail::to<add_pointer::to<wrap>>;
+    using T = detail::to<add_pointer::to<wrap> >;
     template<typename ... Ts>
     using result = detail::to<wrap>::result<Ts...>;
   };
@@ -431,7 +431,7 @@ struct compose<>
   template<>
   struct to<add_const::to<add_pointer::to<wrap> > >
   {
-    using T = detail::to<add_const::to<add_pointer::to<wrap> >>;
+    using T = detail::to<add_const::to<add_pointer::to<wrap> > >;
     template<typename ... Ts>
     using result = detail::to<add_pointer::to<wrap> >::result<Ts...>;
   };
@@ -662,8 +662,8 @@ using apply_to = typename F::template to<C>::template result<Ts...>;
 
 /* PASSED: static_assert(std::is_same_v<apply<compose<add_const, add_pointer>, int>, int *const>); */
 
-/* PASSED: static_assert(std::is_same_v<wrapped<int *>, wrapped<int *>>); */
+/* PASSED: static_assert(std::is_same_v<wrapped<int *>, wrapped<int *> >); */
 
-/* PASSED: static_assert(std::is_same_v<wrapped<const int *>, wrapped<const int *>>); */
+/* PASSED: static_assert(std::is_same_v<wrapped<const int *>, wrapped<const int *> >); */
 
 

--- a/tests/Issue102.expect
+++ b/tests/Issue102.expect
@@ -127,7 +127,7 @@ struct FunctionArgsBase {
 template<>
 struct FunctionArgsBase<std::basic_string<char>, std::basic_string<char> >
 {
-  using args = std::tuple<std::basic_string<char>>;
+  using args = std::tuple<std::basic_string<char> >;
   using arity = std::integral_constant<unsigned int, static_cast<unsigned int>(1)>;
   using result = std::basic_string<char>;
 };
@@ -247,9 +247,9 @@ template<>
 int match<int &, __lambda_73_4, __lambda_74_4, __lambda_75_4>(int & value, const __lambda_73_4 & _case, const __lambda_74_4 & __cases2, const __lambda_75_4 & __cases3)
 {
   using namespace std;
-  using args = FunctionArgs<__lambda_73_4>::tuple<std::basic_string<char>>;
-  using arg = tuple_element_t<0, std::tuple<std::basic_string<char> >>;
-  using match = is_same<std::basic_string<char>, decay_t<int &>>;
+  using args = FunctionArgs<__lambda_73_4>::tuple<std::basic_string<char> >;
+  using arg = tuple_element_t<0, std::tuple<std::basic_string<char> > >;
+  using match = is_same<std::basic_string<char>, decay_t<int &> >;
   return details::match_call(_case, std::forward<int &>(value), std::integral_constant<bool, false>(static_cast<std::integral_constant<bool, false>&>(std::is_same<std::basic_string<char>, int>{{}})), __cases2, __cases3);
 }
 #endif
@@ -261,8 +261,8 @@ int match<int &, __lambda_74_4, __lambda_75_4>(int & value, const __lambda_74_4 
 {
   using namespace std;
   using args = FunctionArgs<__lambda_74_4>::tuple<int>;
-  using arg = tuple_element_t<0, std::tuple<int>>;
-  using match = is_same<decay_t<arg>, decay_t<int &>>;
+  using arg = tuple_element_t<0, std::tuple<int> >;
+  using match = is_same<decay_t<arg>, decay_t<int &> >;
   return details::match_call(_case, std::forward<int &>(value), std::integral_constant<bool, true>(static_cast<std::integral_constant<bool, true>&>(std::is_same<int, int>{{}})), __cases2);
 }
 #endif
@@ -273,9 +273,9 @@ template<>
 int match<char const (&)[3], __lambda_73_4, __lambda_74_4, __lambda_75_4>(char const (&value)[3], const __lambda_73_4 & _case, const __lambda_74_4 & __cases2, const __lambda_75_4 & __cases3)
 {
   using namespace std;
-  using args = FunctionArgs<__lambda_73_4>::tuple<std::basic_string<char>>;
-  using arg = tuple_element_t<0, std::tuple<std::basic_string<char> >>;
-  using match = is_same<std::basic_string<char>, decay_t<char const (&)[3]>>;
+  using args = FunctionArgs<__lambda_73_4>::tuple<std::basic_string<char> >;
+  using arg = tuple_element_t<0, std::tuple<std::basic_string<char> > >;
+  using match = is_same<std::basic_string<char>, decay_t<char const (&)[3]> >;
   return details::match_call(_case, std::forward<char const (&)[3]>(value), std::integral_constant<bool, false>(static_cast<std::integral_constant<bool, false>&>(std::is_same<std::basic_string<char>, const char *>{{}})), __cases2, __cases3);
 }
 #endif
@@ -287,8 +287,8 @@ int match<char const (&)[3], __lambda_74_4, __lambda_75_4>(char const (&value)[3
 {
   using namespace std;
   using args = FunctionArgs<__lambda_74_4>::tuple<int>;
-  using arg = tuple_element_t<0, std::tuple<int>>;
-  using match = is_same<decay_t<arg>, decay_t<char const (&)[3]>>;
+  using arg = tuple_element_t<0, std::tuple<int> >;
+  using match = is_same<decay_t<arg>, decay_t<char const (&)[3]> >;
   return details::match_call(_case, std::forward<char const (&)[3]>(value), std::integral_constant<bool, false>(static_cast<std::integral_constant<bool, false>&>(std::is_same<int, const char *>{{}})), __cases2);
 }
 #endif
@@ -299,9 +299,9 @@ template<>
 std::basic_string<char> match<std::basic_string<char> &, __lambda_73_4, __lambda_74_4, __lambda_75_4>(std::basic_string<char> & value, const __lambda_73_4 & _case, const __lambda_74_4 & __cases2, const __lambda_75_4 & __cases3)
 {
   using namespace std;
-  using args = FunctionArgs<__lambda_73_4>::tuple<std::basic_string<char>>;
-  using arg = tuple_element_t<0, std::tuple<std::basic_string<char> >>;
-  using match = is_same<std::basic_string<char>, std::basic_string<char>>;
+  using args = FunctionArgs<__lambda_73_4>::tuple<std::basic_string<char> >;
+  using arg = tuple_element_t<0, std::tuple<std::basic_string<char> > >;
+  using match = is_same<std::basic_string<char>, std::basic_string<char> >;
   return details::match_call(_case, std::forward<std::basic_string<char> &>(value), std::integral_constant<bool, true>(static_cast<std::integral_constant<bool, true>&>(std::is_same<std::basic_string<char>, std::basic_string<char> >{{}})), __cases2, __cases3);
 }
 #endif

--- a/tests/Issue15.expect
+++ b/tests/Issue15.expect
@@ -24,7 +24,7 @@ constexpr int operator""_cs()
 /* First instantiated from: Issue15.cpp:38 */
 #ifdef INSIGHTS_USE_TEMPLATE
 template<>
-inline constexpr int operator""_cs<52, 53, 54, 55>()
+inline constexpr int operator""_cs<'4', '5', '6', '7'>()
 {
   return 0;
 }
@@ -40,7 +40,7 @@ constexpr int operator""_x()
 /* First instantiated from: Issue15.cpp:33 */
 #ifdef INSIGHTS_USE_TEMPLATE
 template<>
-inline constexpr int operator""_x<char, 49, 50, 51, 52, 53>()
+inline constexpr int operator""_x<char, '1', '2', '3', '4', '5'>()
 {
   return 0;
 }
@@ -51,7 +51,7 @@ int main()
 {
   using namespace std::literals;
   std::chrono::seconds t = std::operator""s(98291919ULL);
-  int t4 = operator""_x<char, 49, 50, 51, 52, 53>();
+  int t4 = operator""_x<char, '1', '2', '3', '4', '5'>();
   std::basic_string<char> str = operator""_str("abcd", 4UL);
   std::chrono::duration<long long, std::ratio<1, 1> > sec = operator""_s(4ULL);
   int cookedTemplateLiteral = operator""_cs<'4', '5', '6', '7'>();

--- a/tests/TemplateArgumentsTest.expect
+++ b/tests/TemplateArgumentsTest.expect
@@ -14,7 +14,7 @@ static inline decltype(auto) Normalize(const T& arg)
 template<>
 inline char const (&Normalize<char [8]>(char const (&arg)[8]))[8]
 {
-  if constexpr(std::is_same_v<char [8], std::basic_string<char>>) ;
+  if constexpr(std::is_same_v<char [8], std::basic_string<char> >) ;
   else /* constexpr */ {
     return arg;
   }
@@ -27,7 +27,7 @@ inline char const (&Normalize<char [8]>(char const (&arg)[8]))[8]
 template<>
 inline const int & Normalize<int>(const int & arg)
 {
-  if constexpr(std::is_same_v<int, std::basic_string<char>>) ;
+  if constexpr(std::is_same_v<int, std::basic_string<char> >) ;
   else /* constexpr */ {
     return arg;
   }
@@ -40,7 +40,7 @@ inline const int & Normalize<int>(const int & arg)
 template<>
 inline const char * Normalize<std::basic_string<char> >(const std::basic_string<char> & arg)
 {
-  if constexpr(std::is_same_v<std::basic_string<char>, std::basic_string<char>>) {
+  if constexpr(std::is_same_v<std::basic_string<char>, std::basic_string<char> >) {
     return arg.c_str();
   }
   

--- a/tests/TemplateMemberFunctionTest.expect
+++ b/tests/TemplateMemberFunctionTest.expect
@@ -44,7 +44,7 @@ class Foo
   /* First instantiated from: TemplateMemberFunctionTest.cpp:37 */
   #ifdef INSIGHTS_USE_TEMPLATE
   template<>
-  inline void DoBar<1, 116, __lambda_37_21>(__lambda_37_21 && t)
+  inline void DoBar<1, 't', __lambda_37_21>(__lambda_37_21 && t)
   {
     t.operator()();
   }

--- a/tests/TemplatesWithAutoAndLambdaTest.expect
+++ b/tests/TemplatesWithAutoAndLambdaTest.expect
@@ -19,7 +19,7 @@ void print(const T1& arg1, const Types&... args)
 /* First instantiated from: TemplatesWithAutoAndLambdaTest.cpp:22 */
 #ifdef INSIGHTS_USE_TEMPLATE
 template<>
-void print<32, char [3], double, std::basic_string<char> >(char const (&arg1)[3], const double & __args1, const std::basic_string<char> & __args2)
+void print<' ', char [3], double, std::basic_string<char> >(char const (&arg1)[3], const double & __args1, const std::basic_string<char> & __args2)
 {
   std::operator<<(std::cout, arg1);
     


### PR DESCRIPTION
Simplified `InsertTemplateArgs` by making it a template.
Aligned template output of type `char`.
Removed duplicate code in `GetValueOfValueInit` and `InitListExpr`.
Added function to get class or struct tag name.