### PR TITLE
Fixed a missing `const` for `auto&` deduction.

### DIFF
--- a/CodeGenerator.cpp
+++ b/CodeGenerator.cpp
@@ -2872,7 +2872,7 @@ void CodeGenerator::HandleLocalStaticNonTrivialClass(const VarDecl* stmt)
 
     const std::string internalVarName{BuildInternalVarName(GetName(*stmt))};
     const std::string compilerBoolVarName{StrCat(internalVarName, "Guard")};
-    const std::string typeName{GetName(*cxxRecordDecl)};
+    const std::string typeName{GetName(stmt->getType())};
 
     // insert compiler bool to track init state
     const std::string stateTrackingVarName{threadSafe ? "uint64_t" : "bool"};

--- a/InsightsHelpers.cpp
+++ b/InsightsHelpers.cpp
@@ -784,7 +784,7 @@ public:
     bool GetTypeString()
     {
         if(const SplitQualType splitted{mType.split()}; splitted.Quals.empty()) {
-            AddCVQualifiers(mType->getPointeeType().getLocalQualifiers());
+            AddCVQualifiers(mType.getCanonicalType()->getPointeeType().getLocalQualifiers());
         } else {
             AddCVQualifiers(splitted.Quals);
         }
@@ -1103,7 +1103,7 @@ std::string GetName(const DeclRefExpr& declRefExpr)
             if(const VarDecl* vd = GetVarDeclFromDeclRefExpr(declRefExpr)) {
                 if(const auto* cxxRecordDecl = vd->getType()->getAsCXXRecordDecl()) {
                     plainName = StrCat(
-                        "*reinterpret_cast<", GetName(*cxxRecordDecl), "*>(", BuildInternalVarName(plainName), ")");
+                        "*reinterpret_cast<", GetName(vd->getType()), "*>(", BuildInternalVarName(plainName), ")");
                 }
             }
         }

--- a/tests/autoRefAndConst2Test.cpp
+++ b/tests/autoRefAndConst2Test.cpp
@@ -1,0 +1,9 @@
+const int& getTheData() {
+  static int theData;
+  return theData;
+}
+
+int main()
+{
+  auto& x = getTheData();
+}

--- a/tests/autoRefAndConst2Test.expect
+++ b/tests/autoRefAndConst2Test.expect
@@ -1,0 +1,12 @@
+const int & getTheData()
+{
+  static int theData;
+  return theData;
+}
+
+
+int main()
+{
+  const int & x = getTheData();
+}
+

--- a/tests/autoRefAndConstTest.cpp
+++ b/tests/autoRefAndConstTest.cpp
@@ -1,0 +1,11 @@
+#include <vector>
+
+const std::vector<int>& getTheData() {
+  static std::vector<int> theData;
+  return theData;
+}
+
+int main()
+{
+  auto& x = getTheData();
+}

--- a/tests/autoRefAndConstTest.expect
+++ b/tests/autoRefAndConstTest.expect
@@ -1,0 +1,26 @@
+#include <new> // for thread-safe static's placement new
+#include <vector>
+
+const std::vector<int, std::allocator<int> > & getTheData()
+{
+  static uint64_t __theDataGuard;
+  alignas(std::vector<int, std::allocator<int> >) static char __theData[sizeof(std::vector<int, std::allocator<int> >)];
+  
+  if( ! __theDataGuard )
+  {
+    if( __cxa_guard_acquire(&__theDataGuard) )
+    {
+      new (&__theData) std::vector<int, std::allocator<int> >();
+      __theDataGuard = true;
+      __cxa_guard_release(&__theDataGuard);
+    }
+  }
+  return *reinterpret_cast<std::vector<int, std::allocator<int> >*>(__theData);
+}
+
+
+int main()
+{
+  const std::vector<int, std::allocator<int> > & x = getTheData();
+}
+


### PR DESCRIPTION
In the following example:

```C++

static std::vector<int> gV;

const std::vector<int>& get() {
  return gV;
}

auto& aV = get();
```

the resulting type of `aV` should be `const std::vector<>` and not just
`std::vector`.