### PR TITLE
Added support for transformation of a std::initializer_list.

### DIFF
--- a/CodeGenerator.h
+++ b/CodeGenerator.h
@@ -12,6 +12,7 @@
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 #include "clang/ASTMatchers/ASTMatchers.h"
 #include "clang/Rewrite/Core/Rewriter.h"
+#include "llvm/ADT/APInt.h"
 
 #include "ClangCompat.h"
 #include "InsightsStaticStrings.h"
@@ -260,6 +261,8 @@ protected:
                               T&&                    lambda,
                               const AddSpaceAtTheEnd addSpaceAtTheEnd = AddSpaceAtTheEnd::No);
 
+    void UpdateCurrentPos() { mCurrentPos = mOutputFormatHelper.CurrentPos(); }
+
     static const char* GetKind(const UnaryExprOrTypeTraitExpr& uk);
     static const char* GetBuiltinTypeSuffix(const BuiltinType::Kind& kind);
 
@@ -294,10 +297,15 @@ protected:
     const LambdaExpr*     mLambdaExpr;
     static inline bool    mHaveLocalStatic;  //!< Track whether there was a thread-safe \c static in the code. This
                                              //!< requires adding the \c <new> header.
-
     static constexpr auto MAX_FILL_VALUES_FOR_ARRAYS{
         uint64_t{100}};  //!< This is the upper limit of elements which will be shown for an array when filled by \c
                          //!< FillConstantArray.
+    llvm::Optional<size_t> mCurrentPos{};       //!< The position in mOutputFormatHelper where a potential
+                                                //!< std::initializer_list expansion must be inserted.
+    llvm::Optional<size_t> mCurrentFieldPos{};  //!< The position in mOutputFormatHelper in a class where where a
+                                                //!< potential std::initializer_list expansion must be inserted.
+    OutputFormatHelper* mOutputFormatHelperOutside{
+        nullptr};  //!< Helper output buffer for std::initializer_list expansion.
 };
 //-----------------------------------------------------------------------------
 

--- a/Insights.cpp
+++ b/Insights.cpp
@@ -53,6 +53,11 @@ const InsightsOptions& GetInsightsOptions()
 static llvm::cl::OptionCategory gInsightCategory("Insights");
 //-----------------------------------------------------------------------------
 
+static llvm::cl::OptionCategory gInsightEduCategory(
+    "Insights- Educational",
+    "This transformations are only for education purposes. The resulting code most likely does not compile.");
+//-----------------------------------------------------------------------------
+
 static llvm::cl::opt<bool> gStdinMode("stdin",
                                       llvm::cl::desc("Override source file's content (in the overlaying\n"
                                                      "virtual file system) with input from <stdin> and run\n"
@@ -67,13 +72,13 @@ static llvm::cl::opt<bool>
     gUseLibCpp("use-libc++", llvm::cl::desc("Use libc++."), llvm::cl::init(false), llvm::cl::cat(gInsightCategory));
 //-----------------------------------------------------------------------------
 
-#define INSIGHTS_OPT(option, name, deflt, description)                                                                 \
+#define INSIGHTS_OPT(option, name, deflt, description, category)                                                       \
     static llvm::cl::opt<bool, true> g##name(option,                                                                   \
                                              llvm::cl::desc(description),                                              \
                                              llvm::cl::NotHidden,                                                      \
                                              llvm::cl::location(gInsightsOptions.name),                                \
                                              llvm::cl::init(deflt),                                                    \
-                                             llvm::cl::cat(gInsightCategory));
+                                             llvm::cl::cat(category));
 //-----------------------------------------------------------------------------
 
 #include "InsightsOptions.def"

--- a/Insights.h
+++ b/Insights.h
@@ -17,7 +17,7 @@ class ASTContext;
 /// \brief Global C++ Insights command line options.
 struct InsightsOptions
 {
-#define INSIGHTS_OPT(opt, name, deflt, description) bool name;
+#define INSIGHTS_OPT(opt, name, deflt, description, category) bool name;
 #include "InsightsOptions.def"
 };
 //-----------------------------------------------------------------------------

--- a/InsightsOptions.def
+++ b/InsightsOptions.def
@@ -7,14 +7,14 @@
 
 /// \brief C++ Insights options definition
 #ifndef INSIGHTS_OPT
-#define INSIGHTS_OPT(opt, name, deflt, description)
+#define INSIGHTS_OPT(opt, name, deflt, description, category)
 #endif
 
-INSIGHTS_OPT("alt-syntax-for", UseAltForSyntax, false, "Transform all for-loops into their equivalent while-loop.")
+INSIGHTS_OPT("alt-syntax-for", UseAltForSyntax, false, "Transform all for-loops into their equivalent while-loop.", gInsightCategory)
 INSIGHTS_OPT("alt-syntax-subscription",
              UseAltArraySubscriptionSyntax,
              false,
-             "Transform array subscriptions E1[E2] into (*(E1 + E2)).")
-INSIGHTS_OPT("show-all-implicit-casts", ShowAllImplicitCasts, false, "Show all implicit casts which can be noisy.")
-
+             "Transform array subscriptions E1[E2] into (*(E1 + E2)).", gInsightCategory)
+INSIGHTS_OPT("show-all-implicit-casts", ShowAllImplicitCasts, false, "Show all implicit casts which can be noisy.", gInsightCategory)
+INSIGHTS_OPT("edu-show-initlist", UseShowInitializerList, false, "Transform a std::initializer list", gInsightEduCategory)
 #undef INSIGHTS_OPT

--- a/docs/CommandLineOptions.md
+++ b/docs/CommandLineOptions.md
@@ -2,4 +2,5 @@
 
 * [alt-syntax-for](@ref alt_syntax_for)
 * [alt-syntax-subscription](@ref alt_syntax_subscription)
+* [edu-show-initlist](@ref edu_show_initlist)
 * [show-all-implicit-casts](@ref show_all_implicit_casts)

--- a/docs/OptionDocumentationGenerator.cpp
+++ b/docs/OptionDocumentationGenerator.cpp
@@ -45,7 +45,7 @@ static bool CreateFile(const std::string& optionName, bool optionDefault, const 
 
 int main()
 {
-#define INSIGHTS_OPT(opt, name, deflt, description) CreateFile(opt, deflt, description);
+#define INSIGHTS_OPT(opt, name, deflt, description, category) CreateFile(opt, deflt, description);
 #include "../InsightsOptions.def"
 
 #undef INSIGHTS_OPT
@@ -60,7 +60,7 @@ int main()
 
     std::vector<std::string> options{};
 
-#define INSIGHTS_OPT(opt, name, deflt, description) options.emplace_back(opt);
+#define INSIGHTS_OPT(opt, name, deflt, description, category) options.emplace_back(opt);
 #include "../InsightsOptions.def"
 
     sort(options.begin(), options.end());

--- a/docs/cmdl-examples/edu-show-initlist.cpp
+++ b/docs/cmdl-examples/edu-show-initlist.cpp
@@ -1,0 +1,3 @@
+#include <vector>
+
+std::vector<int> vec{40, 2};

--- a/tests/StdInitializerList2Test.cerr
+++ b/tests/StdInitializerList2Test.cerr
@@ -1,0 +1,7 @@
+.tmp.cpp:9:64: error: cannot initialize an array element of type 'const int' with an lvalue of type 'const int [2]'
+  std::initializer_list<int> list = std::initializer_list<int>{__list56, 2};
+                                                               ^~~~~~~~
+.tmp.cpp:38:41: error: cannot initialize an array element of type 'const int' with an lvalue of type 'const int [2]'
+      return std::initializer_list<int>{__list127, 2};
+                                        ^~~~~~~~~
+2 errors generated.

--- a/tests/StdInitializerList2Test.cpp
+++ b/tests/StdInitializerList2Test.cpp
@@ -1,0 +1,19 @@
+// cmdlineinsights:-edu-show-initlist
+#include <initializer_list>
+
+int main(int argc, const char*[])
+{
+    int i;
+    int x;
+    auto list = std::initializer_list<int>{i, x};
+
+    auto lamb = [=]{ return list; };
+
+    auto l = lamb();
+
+    auto lamb2 = [=]{ return std::initializer_list<int>{i, x}; };
+
+    auto l2 = lamb2();
+}
+
+

--- a/tests/StdInitializerList2Test.expect
+++ b/tests/StdInitializerList2Test.expect
@@ -1,0 +1,58 @@
+// cmdlineinsights:-edu-show-initlist
+#include <initializer_list>
+
+int main(int argc, const char **)
+{
+  int i;
+  int x;
+  const int __list56[2]{i, x};
+  std::initializer_list<int> list = std::initializer_list<int>{__list56, 2};
+    
+  class __lambda_10_17
+  {
+    public: 
+    inline /*constexpr */ std::initializer_list<int> operator()() const
+    {
+      return std::initializer_list<int>(list);
+    }
+    
+    private: 
+    std::initializer_list<int> list;
+    
+    public:
+    __lambda_10_17(std::initializer_list<int> _list)
+    : list{_list}
+    {}
+    
+  };
+  
+  __lambda_10_17 lamb = __lambda_10_17{std::initializer_list<int>(list)};
+  std::initializer_list<int> l = lamb.operator()();
+    
+  class __lambda_14_18
+  {
+    public: 
+    inline /*constexpr */ std::initializer_list<int> operator()() const
+    {
+      const int __list127[2]{i, x};
+      return std::initializer_list<int>{__list127, 2};
+    }
+    
+    private: 
+    int i;
+    int x;
+    
+    public:
+    __lambda_14_18(int _i, int _x)
+    : i{_i}
+    , x{_x}
+    {}
+    
+  };
+  
+  __lambda_14_18 lamb2 = __lambda_14_18{i, x};
+  std::initializer_list<int> l2 = lamb2.operator()();
+}
+
+
+

--- a/tests/StdInitializerList3Test.cerr
+++ b/tests/StdInitializerList3Test.cerr
@@ -1,0 +1,10 @@
+.tmp.cpp:20:38: error: cannot initialize an array element of type 'const int' with an lvalue of type 'const int [3]'
+  : v{Foo{std::initializer_list<int>{__list15, 3}}}
+                                     ^~~~~~~~
+.tmp.cpp:36:38: error: cannot initialize an array element of type 'const int' with an lvalue of type 'const int [2]'
+  : v{Foo{std::initializer_list<int>{__list15, 2}}}
+                                     ^~~~~~~~
+.tmp.cpp:52:38: error: cannot initialize an array element of type 'const int' with an lvalue of type 'const int [2]'
+  : v{Foo{std::initializer_list<int>{__list16, 2}}}
+                                     ^~~~~~~~
+3 errors generated.

--- a/tests/StdInitializerList3Test.cpp
+++ b/tests/StdInitializerList3Test.cpp
@@ -1,0 +1,37 @@
+// cmdlineinsights:-edu-show-initlist
+#include <initializer_list>
+
+struct Foo
+{
+    Foo(std::initializer_list<int> l) {}
+};
+
+class Test
+{
+public:
+    Test()
+    {}
+
+    Foo v{1,2,3};
+};
+
+
+class Best
+{
+public:
+    Best()
+    : v{1,2}
+    {}
+
+    Foo v{1,2,3};
+};
+
+class WestE
+{
+    Foo v{1,2,3};
+public:
+    WestE()
+    : v{1,2}
+    {}
+
+};

--- a/tests/StdInitializerList3Test.expect
+++ b/tests/StdInitializerList3Test.expect
@@ -1,0 +1,58 @@
+// cmdlineinsights:-edu-show-initlist
+#include <initializer_list>
+
+struct Foo
+{
+  inline Foo(std::initializer_list<int> l)
+  {
+  }
+  
+};
+
+
+
+class Test
+{
+  static inline const int __list15[3]{1, 2, 3};
+  
+  public: 
+  inline Test()
+  : v{Foo{std::initializer_list<int>{__list15, 3}}}
+  {
+  }
+  
+  Foo v;
+};
+
+
+
+
+class Best
+{
+  static inline const int __list15[2]{1, 2};
+  
+  public: 
+  inline Best()
+  : v{Foo{std::initializer_list<int>{__list15, 2}}}
+  {
+  }
+  
+  Foo v;
+};
+
+
+
+class WestE
+{
+  static inline const int __list16[2]{1, 2};
+  Foo v;
+  
+  public: 
+  inline WestE()
+  : v{Foo{std::initializer_list<int>{__list16, 2}}}
+  {
+  }
+  
+};
+
+

--- a/tests/StdInitializerList4Test.cerr
+++ b/tests/StdInitializerList4Test.cerr
@@ -1,0 +1,4 @@
+.tmp.cpp:5:90: error: cannot initialize an array element of type 'const int' with an lvalue of type 'const int [2]'
+std::vector<int> vec = std::vector<int, std::allocator<int> >{std::initializer_list<int>{__list0, 2}};
+                                                                                         ^~~~~~~
+1 error generated.

--- a/tests/StdInitializerList4Test.cpp
+++ b/tests/StdInitializerList4Test.cpp
@@ -1,0 +1,5 @@
+// cmdlineinsights:-edu-show-initlist
+#include <vector>
+
+std::vector<int> vec{40, 2};
+

--- a/tests/StdInitializerList4Test.expect
+++ b/tests/StdInitializerList4Test.expect
@@ -1,0 +1,7 @@
+// cmdlineinsights:-edu-show-initlist
+#include <vector>
+
+const int __list0[2]{40, 2};
+std::vector<int> vec = std::vector<int, std::allocator<int> >{std::initializer_list<int>{__list0, 2}};
+
+

--- a/tests/StdInitializerListTest.cerr
+++ b/tests/StdInitializerListTest.cerr
@@ -1,0 +1,7 @@
+.tmp.cpp:8:37: error: cannot initialize an array element of type 'const int' with an lvalue of type 'const int [3]'
+  return std::initializer_list<int>{__list54, 3};
+                                    ^~~~~~~~
+.tmp.cpp:15:37: error: cannot initialize an array element of type 'const int' with an lvalue of type 'const int [1]'
+  return std::initializer_list<int>{__list41, 1};
+                                    ^~~~~~~~
+2 errors generated.

--- a/tests/StdInitializerListTest.cpp
+++ b/tests/StdInitializerListTest.cpp
@@ -1,0 +1,24 @@
+// cmdlineinsights:-edu-show-initlist
+#include <cstdio>
+#include <initializer_list>
+
+auto f(int i, int j, int k)
+{
+  return std::initializer_list<int>{i, j, k};
+}
+
+auto f1(int i)
+{
+  return std::initializer_list<int>{i};
+}
+
+
+int main(int argc, const char*[])
+{
+    for(int i : f(argc+1, argc+2, argc+3)) {
+      printf("%d, ", i);
+    }
+
+    auto ff = f1(2);
+}
+

--- a/tests/StdInitializerListTest.expect
+++ b/tests/StdInitializerListTest.expect
@@ -1,0 +1,36 @@
+// cmdlineinsights:-edu-show-initlist
+#include <cstdio>
+#include <initializer_list>
+
+std::initializer_list<int> f(int i, int j, int k)
+{
+  const int __list54[3]{i, j, k};
+  return std::initializer_list<int>{__list54, 3};
+}
+
+
+std::initializer_list<int> f1(int i)
+{
+  const int __list41[1]{i};
+  return std::initializer_list<int>{__list41, 1};
+}
+
+
+
+int main(int argc, const char **)
+{
+  {
+    std::initializer_list<int> && __range1 = f(argc + 1, argc + 2, argc + 3);
+    const int * __begin1 = __range1.begin();
+    const int * __end1 = __range1.end();
+    for(; __begin1 != __end1; ++__begin1) 
+    {
+      int i = *__begin1;
+      printf("%d, ", i);
+    }
+    
+  }
+  std::initializer_list<int> ff = f1(2);
+}
+
+


### PR DESCRIPTION
This is somewhat of an educational transformation as the resulting code
will not compile. The compiler always does this expansion when passing a
std::initializer_list.

Please note also, that it is the way libc++ does implement the type.