### PR TITLE
Fixed std::initializer_list expansion bug when a return is before the

### DIFF
--- a/CodeGenerator.h
+++ b/CodeGenerator.h
@@ -300,10 +300,12 @@ protected:
     static constexpr auto MAX_FILL_VALUES_FOR_ARRAYS{
         uint64_t{100}};  //!< This is the upper limit of elements which will be shown for an array when filled by \c
                          //!< FillConstantArray.
-    llvm::Optional<size_t> mCurrentPos{};       //!< The position in mOutputFormatHelper where a potential
-                                                //!< std::initializer_list expansion must be inserted.
-    llvm::Optional<size_t> mCurrentFieldPos{};  //!< The position in mOutputFormatHelper in a class where where a
-                                                //!< potential std::initializer_list expansion must be inserted.
+    llvm::Optional<size_t> mCurrentPos{};        //!< The position in mOutputFormatHelper where a potential
+                                                 //!< std::initializer_list expansion must be inserted.
+    llvm::Optional<size_t> mCurrentReturnPos{};  //!< The position in mOutputFormatHelper from a return where a
+                                                 //!< potential std::initializer_list expansion must be inserted.
+    llvm::Optional<size_t> mCurrentFieldPos{};   //!< The position in mOutputFormatHelper in a class where where a
+                                                 //!< potential std::initializer_list expansion must be inserted.
     OutputFormatHelper* mOutputFormatHelperOutside{
         nullptr};  //!< Helper output buffer for std::initializer_list expansion.
 };

--- a/tests/StdInitializerList5Test.cpp
+++ b/tests/StdInitializerList5Test.cpp
@@ -1,0 +1,9 @@
+// Source: https://twitter.com/olafurw/status/1214927552990601217?s=20
+#include <initializer_list>
+
+int f(std::initializer_list<int> l) {}
+
+int main()
+{
+  return f({1, 2, 3});
+}

--- a/tests/StdInitializerList5Test.expect
+++ b/tests/StdInitializerList5Test.expect
@@ -1,0 +1,13 @@
+// Source: https://twitter.com/olafurw/status/1214927552990601217?s=20
+#include <initializer_list>
+
+int f(std::initializer_list<int> l)
+{
+}
+
+
+int main()
+{
+  return f(std::initializer_list<int>{1, 2, 3});
+}
+


### PR DESCRIPTION
expansion.

The following code:

```C++
int f(std::initializer_list<int> l);

int main()
{
  return f({1, 2, 3});
}
```

did put the initializer list after the return and not before it.