### PR TITLE
Fixed #286: Desugar decltype(x) even when it is an LValueReference.

### DIFF
--- a/tests/AutoHandlerTest.expect
+++ b/tests/AutoHandlerTest.expect
@@ -68,9 +68,9 @@ int main()
   float f = 1.0F;
   char c = 'c';
   unsigned int u = 0U;
-  decltype(u) uu = u;
+  unsigned int uu = u;
   unsigned int mu = 0U;
-  decltype(u) muu = u;
+  unsigned int muu = u;
 }
 
 

--- a/tests/Issue255.expect
+++ b/tests/Issue255.expect
@@ -163,7 +163,7 @@ void test()
     for(; __begin1.operator!=(__end1); __begin1.operator++()) 
     {
       int element = __begin1.operator*();
-      /* PASSED: static_assert(std::is_same_v<decltype(element), int>); */
+      /* PASSED: static_assert(std::is_same_v<int, int>); */
     }
     
   }

--- a/tests/Issue286.cpp
+++ b/tests/Issue286.cpp
@@ -1,0 +1,8 @@
+#include <vector>
+struct S {
+	std::vector<int> v{};
+    decltype(v)& getV () {
+      return v;
+    }
+};
+

--- a/tests/Issue286.expect
+++ b/tests/Issue286.expect
@@ -1,0 +1,13 @@
+#include <vector>
+struct S
+{
+  std::vector<int, std::allocator<int> > v = std::vector<int, std::allocator<int> >{};
+  inline std::vector<int, std::allocator<int> > & getV()
+  {
+    return this->v;
+  }
+  
+};
+
+
+

--- a/tests/Issue286_2.cpp
+++ b/tests/Issue286_2.cpp
@@ -1,0 +1,9 @@
+int main()
+{
+    int x= 2;
+
+    decltype(x)& y = x;
+
+    //return y;
+}
+

--- a/tests/Issue286_2.expect
+++ b/tests/Issue286_2.expect
@@ -1,0 +1,7 @@
+int main()
+{
+  int x = 2;
+  int & y = x;
+}
+
+

--- a/tests/StructuredBindingsHandler3Test.expect
+++ b/tests/StructuredBindingsHandler3Test.expect
@@ -9,7 +9,7 @@ namespace std
 }
 namespace std
 {
-  template<size_t , typename type_parameter_0_1>
+  template<unsigned long , typename type_parameter_0_1>
   struct tuple_element;
   /* First instantiated from: StructuredBindingsHandler3Test.cpp:17 */
   #ifdef INSIGHTS_USE_TEMPLATE
@@ -94,7 +94,7 @@ struct std::tuple_size<constant::Q>
 };
 
 
-template<size_t N>
+template<unsigned long N>
 struct std::tuple_element<N, constant::Q>
 {
   using type = int;


### PR DESCRIPTION
This case was missed before and should be expanded as well. A few other
places turned up which profit from that change.