### PR TITLE
Fixed #292: Show more hidden conversions to improve overload resolution information.

### DIFF
--- a/InsightsMatchers.h
+++ b/InsightsMatchers.h
@@ -50,32 +50,6 @@ AST_MATCHER(FunctionDecl, isTemplateInstantiationPlain)
     return Node.isTemplateInstantiation();
 }
 
-static inline bool IsMatchingCast(const CastKind kind)
-{
-    switch(kind) {
-        case CastKind::CK_Dependent: [[fallthrough]];
-        case CastKind::CK_IntegralCast: [[fallthrough]];
-        case CastKind::CK_IntegralToBoolean: [[fallthrough]];
-        case CastKind::CK_IntegralToPointer: [[fallthrough]];
-        case CastKind::CK_PointerToIntegral: [[fallthrough]];
-        case CastKind::CK_BitCast: [[fallthrough]];
-        case CastKind::CK_UncheckedDerivedToBase: [[fallthrough]];
-        case CastKind::CK_ToUnion: [[fallthrough]];
-        case CastKind::CK_UserDefinedConversion: [[fallthrough]];
-        case CastKind::CK_AtomicToNonAtomic: [[fallthrough]];
-        case CastKind::CK_DerivedToBase: [[fallthrough]];
-        case CastKind::CK_FloatingCast: [[fallthrough]];
-        case CastKind::CK_IntegralToFloating: [[fallthrough]];
-        case CastKind::CK_FloatingToIntegral: [[fallthrough]];
-        /* these are implicit conversions. We get them right, but they may end up in a compiler internal type,
-         * which leads to compiler errors */
-        // case CastKind::CK_NoOp:
-        case CastKind::CK_NonAtomicToAtomic: return true;
-        default: return false;
-    }
-}
-//-----------------------------------------------------------------------------
-
 AST_POLYMORPHIC_MATCHER(isMacroOrInvalidLocation, AST_POLYMORPHIC_SUPPORTED_TYPES(Decl, Stmt))
 {
     SILENCE;

--- a/tests/Issue292.cpp
+++ b/tests/Issue292.cpp
@@ -1,0 +1,11 @@
+// cmdlineinsights:--show-all-implicit-casts
+class H {
+  public:
+  H(const char*, int, double, double);
+  H(const char*, int, double*);
+  ~H();
+};
+
+auto foo() {
+  return H{"hai",4,0};
+}

--- a/tests/Issue292.expect
+++ b/tests/Issue292.expect
@@ -1,0 +1,20 @@
+// cmdlineinsights:--show-all-implicit-casts
+class H
+{
+  
+  public: 
+  H(const char *, int, double, double);
+  
+  H(const char *, int, double *);
+  
+  ~H() noexcept;
+  
+};
+
+
+
+H foo()
+{
+  return H{static_cast<const char *>("hai"), 4, static_cast<double *>(0)};
+}
+

--- a/tests/NullToMemberPointerTest.cpp
+++ b/tests/NullToMemberPointerTest.cpp
@@ -1,0 +1,20 @@
+// cmdlineinsights:--show-all-implicit-casts
+class NullToMemberPtrTest
+{
+public:
+    int Fun(int) { return 1; }
+
+    int mMember;
+};
+
+int main()
+{
+    int NullToMemberPtrTest::*mMember1 = nullptr;
+
+    int NullToMemberPtrTest::*mMember2 = 0;
+
+    int (NullToMemberPtrTest::*Func1)(int) = nullptr;
+
+    int (NullToMemberPtrTest::*Func2)(int) = 0;
+}
+

--- a/tests/NullToMemberPointerTest.expect
+++ b/tests/NullToMemberPointerTest.expect
@@ -1,0 +1,28 @@
+// cmdlineinsights:--show-all-implicit-casts
+class NullToMemberPtrTest
+{
+  
+  public: 
+  inline int Fun(int)
+  {
+    return 1;
+  }
+  
+  int mMember;
+};
+
+
+
+int main()
+{
+  using FuncPtr_12 = int NullToMemberPtrTest::*;
+  FuncPtr_12 mMember1 = static_cast<int NullToMemberPtrTest::*>(nullptr);
+  using FuncPtr_14 = int NullToMemberPtrTest::*;
+  FuncPtr_14 mMember2 = static_cast<int NullToMemberPtrTest::*>(0);
+  using FuncPtr_16 = int (NullToMemberPtrTest::*)(int);
+  FuncPtr_16 Func1 = static_cast<int (NullToMemberPtrTest::*)(int)>(nullptr);
+  using FuncPtr_18 = int (NullToMemberPtrTest::*)(int);
+  FuncPtr_18 Func2 = static_cast<int (NullToMemberPtrTest::*)(int)>(0);
+}
+
+


### PR DESCRIPTION
Some implicit conversions have been hidden from the start. As this issue
lays out, this is suboptimal for some of them. This change enabled more
conversion that turn up if `--show-all-implicit-casts` is enabled.