### PR TITLE
Fixes `cppinsights` build with Clang-10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ endif()
 
 set(INSIGHTS_LLVM_CONFIG "llvm-config" CACHE STRING "LLVM config executable to use")
 
-set(INSIGHTS_MIN_LLVM_MAJOR_VERSION 9)
+set(INSIGHTS_MIN_LLVM_MAJOR_VERSION 10)
 set(INSIGHTS_MIN_LLVM_VERSION ${INSIGHTS_MIN_LLVM_MAJOR_VERSION}.0)
 
 if(NOT DEFINED LLVM_VERSION_MAJOR)  # used when build inside the clang tool/extra folder

--- a/CodeGenerator.cpp
+++ b/CodeGenerator.cpp
@@ -893,7 +893,7 @@ void CodeGenerator::InsertArg(const CoroutineSuspendExpr* stmt)
 
     // peal of __promise.yield_value
     if(const auto* matTemp = dyn_cast_or_null<MaterializeTemporaryExpr>(stmt->getCommonExpr())) {
-        const auto* temporary = matTemp->getTemporary();
+        const auto* temporary = matTemp->getSubExpr();
 
         if(const auto* memExpr = dyn_cast_or_null<CXXMemberCallExpr>(temporary)) {
             ForEachArg(memExpr->arguments(), [&](const auto& arg) { InsertArg(arg); });
@@ -1653,7 +1653,7 @@ void CodeGenerator::InsertArg(const CXXNewExpr* stmt)
 
 void CodeGenerator::InsertArg(const MaterializeTemporaryExpr* stmt)
 {
-    InsertArg(stmt->getTemporary());
+    InsertArg(stmt->getSubExpr());
 }
 //-----------------------------------------------------------------------------
 
@@ -2785,7 +2785,7 @@ void CodeGenerator::InsertArg(const CXXStdInitializerListExpr* stmt)
 
         const auto* mat  = dyn_cast<MaterializeTemporaryExpr>(stmt->getSubExpr());
         const auto  size = [&]() -> size_t {
-            if(const auto* list = dyn_cast_or_null<InitListExpr>(mat->GetTemporaryExpr())) {
+            if(const auto* list = dyn_cast_or_null<InitListExpr>(mat->getSubExpr())) {
                 return list->getNumInits();
             }
 


### PR DESCRIPTION
* `make tests` results: 254/297

Refer [here](https://github.com/llvm/llvm-project/commit/b0561b3346e7bf0ae974995ca95b917eebde18e1#diff-9cdfb9ce658909fbe0fcae6f5fb0365c) for upstream changes in llvm-project