### PR TITLE
Fixed #298: Handle additional semi at the end of a function template.

### DIFF
--- a/tests/Issue298.cpp
+++ b/tests/Issue298.cpp
@@ -1,0 +1,2 @@
+template <typename T> void fun (T&& t) { };
+void test() { fun(1); }

--- a/tests/Issue298.expect
+++ b/tests/Issue298.expect
@@ -1,0 +1,15 @@
+template <typename T> void fun (T&& t) { }
+
+/* First instantiated from: Issue298.cpp:2 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+void fun<int>(int && t)
+{
+}
+#endif
+;
+void test()
+{
+  fun(1);
+}
+


### PR DESCRIPTION
Getting the correct end location of a function template seems to be
challenging. In case of #298 it is followed by an additional semi which
results in an `EmptyDecl`. This fix takes a possible `EmptyDecl` into
account and tries to find the end depending whether a semi is required.
Which is for example in case of CTAD.