### PR TITLE
Run test on Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -297,7 +297,7 @@ script:
     cmake --build . --config Release -j 2
     # Invoke the binary to ensure that it is at least a little bit alive. It looks like that a failing linking does not
     # make the build fail.
-    ./Release/insights.exe --version
+    ./insights.exe --version
   else
     make -j 2
   fi
@@ -321,7 +321,7 @@ script:
   fi
 - |
   if [[ "${TRAVIS_OS_NAME}" == "windows" ]] && [[ "${TRAVIS_BRANCH}" = "master" ]]; then
-      export BIN_FILE_DIR=${TRAVIS_BUILD_DIR}/build/Release/
+      export BIN_FILE_DIR=${TRAVIS_BUILD_DIR}/build/
       export BIN_FILE_NAME=insights.exe
       export ARCHIVE_FILE_NAME=${TRAVIS_BUILD_DIR}/insights-windows
       export ARCHIVE_EXT=zip

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -288,6 +288,19 @@ if (BUILD_INSIGHTS_OUTSIDE_LLVM)
     endif()
     
     if(IS_MSVC_CL)
+        add_definitions(/Wall)
+        add_definitions(/WX)     # Warnings as errors
+        add_definitions(/wd4577) # 'noexcept' used with no exception handling mode specified; termination on exception is not guaranteed. Specify EHsc
+        add_definitions(/wd5045) # spectre mitigation introduced
+        add_definitions(/wd4514) # unreferenced inline function removed
+        add_definitions(/wd4710) # inline function _not_ inlined
+        add_definitions(/wd4711) # selected for automatic inline
+        add_definitions(/wd4820) # padding introduced
+        add_definitions(/wd4459) # hides global symbol disabled for now
+        add_definitions(/wd4626 /wd5027 /wd4623 /wd4625 /wd5026) # implicitly deleted operators
+        add_definitions(/wd4061) # enumerator 'clang::CK_BitCast' in switch of enum 'clang::CastKind' is not explicitly handled by a case label
+        #add_definitions(/err)
+        
         # To support /external:I:
         # - enables "system headers" and
         # - sets warning level 0 for them

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 # 3.8* is required because of C++17 support
 
 set(CXX_STANDARD_REQUIRED ON)
@@ -68,13 +68,13 @@ if(NOT IS_CLANG AND MSVC)
     set(IS_MSVC_CL 1)
 endif()
 
-cmake_print_variables(
-    CMAKE_CXX_COMPILER_ID
-    BUILD_INSIGHTS_OUTSIDE_LLVM
-    IS_CLANG
-    IS_GNU
-    IS_MSVC_CL
-    MSVC)
+# cmake_print_variables(
+#     CMAKE_CXX_COMPILER_ID
+#     BUILD_INSIGHTS_OUTSIDE_LLVM
+#     IS_CLANG
+#     IS_GNU
+#     IS_MSVC_CL
+#     MSVC)
 
 if (BUILD_INSIGHTS_OUTSIDE_LLVM)
     function(check_compiler COMPILER version)
@@ -370,6 +370,22 @@ if (${LLVM_PACKAGE_VERSION} VERSION_LESS ${INSIGHTS_MIN_LLVM_VERSION})
     message(FATAL_ERROR "LLVM version ${INSIGHTS_MIN_LLVM_VERSION} or higher required. Current version is: ${LLVM_PACKAGE_VERSION}.")
 endif()
 
+
+if(WIN32)
+    # First for the generic no-config case (e.g. with mingw)
+    set( CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR} )
+    set( CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR} )
+    set( CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR} )
+    # Second, for multi-config builds (e.g. msvc)
+        foreach( OUTPUTCONFIG ${CMAKE_CONFIGURATION_TYPES} )
+                string( TOUPPER ${OUTPUTCONFIG} OUTPUTCONFIG )
+                set( CMAKE_RUNTIME_OUTPUT_DIRECTORY_${OUTPUTCONFIG} ${CMAKE_BINARY_DIR} )
+                set( CMAKE_LIBRARY_OUTPUT_DIRECTORY_${OUTPUTCONFIG} ${CMAKE_BINARY_DIR} )
+                set( CMAKE_ARCHIVE_OUTPUT_DIRECTORY_${OUTPUTCONFIG} ${CMAKE_BINARY_DIR} )
+            endforeach( OUTPUTCONFIG CMAKE_CONFIGURATION_TYPES )
+endif()
+
+
 # clang 8 and later or better ld warn, if the visibility is not the same as for the libs.
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 
@@ -414,7 +430,7 @@ find_program(
   DOC "Path to clang-tidy executable"
   )
 if(NOT CLANG_TIDY_EXE)
-  message(STATUS "clang-tidy not found.")
+  message(STATUS "Could not find the program clang-tidy.")
 
 else()
   message(STATUS "Found clang-tidy: ${CLANG_TIDY_EXE}")
@@ -518,31 +534,45 @@ if (NOT WIN32)
             COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/docs/postProcessDoxygen.py ${CMAKE_CURRENT_BINARY_DIR}/html
         )
 
-        if(NOT WIN32)
-            add_dependencies(doc gen-options)
-        endif()
+        add_dependencies(doc gen-options)
     endif()
+endif ()
 
-    # XXX: hack to allow coverage build to run tests which fail
-    set(TEST_FAILURE_IS_OK "")
-    if(INSIGHTS_COVERAGE)
-        set(TEST_FAILURE_IS_OK "--failure-is-ok")
-    endif()
+# XXX: hack to allow coverage build to run tests which fail
+set(TEST_FAILURE_IS_OK "")
+if(INSIGHTS_COVERAGE)
+    set(TEST_FAILURE_IS_OK "--failure-is-ok")
+endif()
 
-    set(TEST_USE_LIBCPP "")
-    if(INSIGHTS_USE_LIBCPP)
-        set(TEST_USE_LIBCPP "--use-libcpp")
-    endif()
+set(TEST_USE_LIBCPP "")
+if(INSIGHTS_USE_LIBCPP)
+    set(TEST_USE_LIBCPP "--use-libcpp")
+endif()
+
+# Look for Python3, only relevant for target tests. As linux currently ships cmake 3.11.4 we need to workaround
+if(${CMAKE_VERSION} VERSION_LESS "3.12.0") 
+    set(Python3_EXECUTABLE "/usr/bin/python")
+    set(Python3_FOUND "Yes")
+else()
+    find_package(Python3 COMPONENTS Interpreter )
+endif()
+
+if (NOT Python3_FOUND)
+    message(WARNING "Could not find the program Python3. Target tests disabled.")
+else()
+    message(STATUS "Found Python3: ${Python3_EXECUTABLE}. Target tests enabled.")
 
     # add a target to generate run tests
     add_custom_target(tests
-        COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/tests/runTest.py --insights ${CMAKE_CURRENT_BINARY_DIR}/insights --cxx ${CMAKE_CXX_COMPILER} ${TEST_FAILURE_IS_OK} ${TEST_USE_LIBCPP}
-        COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/tests/testSTDIN.sh ${CMAKE_CURRENT_BINARY_DIR}/insights
-        DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/insights ${CMAKE_CURRENT_SOURCE_DIR}/tests/runTest.py
+        COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/tests/runTest.py --insights ${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_FILE_NAME:insights> --cxx ${CMAKE_CXX_COMPILER} ${TEST_FAILURE_IS_OK} ${TEST_USE_LIBCPP}
+        COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/tests/testSTDIN.sh ${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_FILE_NAME:insights>
+        DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_FILE_NAME:insights> ${CMAKE_CURRENT_SOURCE_DIR}/tests/runTest.py
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests
         COMMENT "Running tests" VERBATIM
     )
+endif()
 
+if (NOT WIN32)
     add_custom_target(update-tests
         COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/tests/runTest.py --insights ${CMAKE_CURRENT_BINARY_DIR}/insights --cxx ${CMAKE_CXX_COMPILER} --update-tests ${TEST_FAILURE_IS_OK}
         COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/tests/testSTDIN.sh ${CMAKE_CURRENT_BINARY_DIR}/insights
@@ -631,9 +661,7 @@ if (NOT WIN32)
             COMMENT "Analyzing clang-tidy output..."
         )
     endif()
-endif ()
 
-if(NOT WIN32)
     add_subdirectory(docs)
 endif()
 

--- a/CodeGenerator.cpp
+++ b/CodeGenerator.cpp
@@ -2595,11 +2595,11 @@ void CodeGenerator::InsertArg(const CXXRecordDecl* stmt)
 
         SmallVector<std::string, 5> ctorInitializerList{};
         std::string                 ctorArguments{"{"};
-        OnceTrue                    bFirst{};
+        OnceTrue                    firstCtorArgument{};
 
         auto addToInits =
             [&](std::string name, const FieldDecl* fd, bool isThis, const Expr* expr, bool /*useBraces*/) {
-                if(bFirst) {
+                if(firstCtorArgument) {
                 } else {
                     mOutputFormatHelper.Append(", ");
                     ctorArguments.append(", ");
@@ -2686,9 +2686,9 @@ void CodeGenerator::InsertArg(const CXXRecordDecl* stmt)
             } else {
                 mOutputFormatHelper.AppendNewLine();
 
-                OnceTrue bFirst{};
+                OnceTrue firstCtorInitializer{};
                 for(const auto& initializer : ctorInitializerList) {
-                    if(bFirst) {
+                    if(firstCtorInitializer) {
                         mOutputFormatHelper.Append(": ");
                     } else {
                         mOutputFormatHelper.Append(", ");

--- a/CodeGenerator.cpp
+++ b/CodeGenerator.cpp
@@ -2988,9 +2988,8 @@ void CodeGenerator::HandleLocalStaticNonTrivialClass(const VarDecl* stmt)
 {
     mHaveLocalStatic = true;
 
-    const auto* cxxRecordDecl = stmt->getType()->getAsCXXRecordDecl();
-    auto&       langOpts{GetLangOpts(*stmt)};
-    const bool  threadSafe{langOpts.ThreadsafeStatics && langOpts.CPlusPlus11 &&
+    auto&      langOpts{GetLangOpts(*stmt)};
+    const bool threadSafe{langOpts.ThreadsafeStatics && langOpts.CPlusPlus11 &&
                           (stmt->isLocalVarDecl() /*|| NonTemplateInline*/) && !stmt->getTLSKind()};
 
     const std::string internalVarName{BuildInternalVarName(GetName(*stmt))};

--- a/Insights.cpp
+++ b/Insights.cpp
@@ -118,7 +118,9 @@ public:
             const auto& mainFileId = sm.getMainFileID();
             const auto  loc        = sm.translateFileLineCol(sm.getFileEntryForID(mainFileId), 1, 1);
 
-            mRewriter.InsertText(loc, "#include <new> // for thread-safe static's placement new\n");
+            mRewriter.InsertText(loc,
+                                 "#include <new> // for thread-safe static's placement new\n#include <cstdint> // for "
+                                 "uint64_t under Linux/GCC\n");
         }
     }
 

--- a/InsightsHelpers.cpp
+++ b/InsightsHelpers.cpp
@@ -231,8 +231,8 @@ SourceLocation FindLocationAfterSemi(const SourceLocation                       
         // if we do not find a ; then it can possibly be a paren init like this:
         // int x(23);
         // Try to find the right paren which seems to also contain the semi.
-        else if(const auto locEnd2{findLocation(tok::r_paren)}; locEnd2.isValid()) {
-            return locEnd2;
+        else if(const auto locEnd3{findLocation(tok::r_paren)}; locEnd3.isValid()) {
+            return locEnd3;
         }
     }
 

--- a/InsightsHelpers.cpp
+++ b/InsightsHelpers.cpp
@@ -948,7 +948,7 @@ std::string GetTypeNameAsParameter(const QualType& t, const std::string& varName
     const bool isFunctionPointer = HasTypeWithSubType<ReferenceType, FunctionProtoType>(t);
     const bool isArrayRef        = HasTypeWithSubType<ReferenceType, ArrayType>(t);
     // Special case for Issue81, auto returns an array-ref and to catch auto deducing an array (Issue106)
-    const bool isAutoType             = dyn_cast_or_null<AutoType>(t.getTypePtrOrNull());
+    const bool isAutoType             = (nullptr != dyn_cast_or_null<AutoType>(t.getTypePtrOrNull()));
     const auto pointerToArrayBaseType = isAutoType ? t->getContainedAutoType()->getDeducedType() : t;
     const bool isPointerToArray       = HasTypeWithSubType<PointerType, ArrayType>(pointerToArrayBaseType);
 

--- a/InsightsHelpers.h
+++ b/InsightsHelpers.h
@@ -23,12 +23,6 @@
 
 namespace clang::insights {
 
-static inline bool IsNewLine(const char c)
-{
-    return '\n' == c;
-}
-//-----------------------------------------------------------------------------
-
 std::string BuildInternalVarName(const std::string& varName);
 //-----------------------------------------------------------------------------
 

--- a/InsightsMatchers.h
+++ b/InsightsMatchers.h
@@ -18,10 +18,6 @@
 namespace clang {
 namespace ast_matchers {
 
-// XXX: recent clang source has a declType matcher. Try to figure out a migration path.
-extern const internal::VariadicDynCastAllOfMatcher<Type, DecltypeType> myDecltypeType;
-//-----------------------------------------------------------------------------
-
 /* don't replace stuff in template definitions */
 static const auto isTemplate = anyOf(hasAncestor(classTemplateDecl()),
                                      hasAncestor(functionTemplateDecl()),
@@ -32,8 +28,8 @@ static const auto isAutoAncestor =
     hasAncestor(varDecl(anyOf(hasType(autoType().bind("autoType")),
                               hasType(qualType(hasDescendant(autoType().bind("autoType")))),
                               /* decltype and decltype(auto) */
-                              hasType(myDecltypeType().bind("dt")),
-                              hasType(qualType(hasDescendant(myDecltypeType().bind("dt")))))));
+                              hasType(decltypeType().bind("dt")),
+                              hasType(qualType(hasDescendant(decltypeType().bind("dt")))))));
 //-----------------------------------------------------------------------------
 
 /// \brief Shut up a unused variable warnings

--- a/InsightsStrCat.h
+++ b/InsightsStrCat.h
@@ -29,7 +29,7 @@ static inline std::string ConvertToBoolString(bool b)
 static inline std::string ToString(const llvm::APSInt& val)
 {
     if(1 == val.getBitWidth()) {
-        return details::ConvertToBoolString(val.getExtValue());
+        return details::ConvertToBoolString(0 != val.getExtValue());
     }
 
     return val.toString(10);

--- a/OutputFormatHelper.cpp
+++ b/OutputFormatHelper.cpp
@@ -11,11 +11,11 @@
 
 namespace clang::insights {
 
-static const std::string MakeIndent(const int indent)
+static const std::string MakeIndent(const unsigned indent)
 {
     std::string str{};
 
-    for(int i = 1; i < indent; i++) {
+    for(unsigned i = 1; i < indent; i++) {
         str += ' ';
     }
 

--- a/tests/StaticHandler4Test.expect
+++ b/tests/StaticHandler4Test.expect
@@ -1,4 +1,5 @@
 #include <new> // for thread-safe static's placement new
+#include <cstdint> // for uint64_t under Linux/GCC
 void X() noexcept(false)
 {
   throw ;

--- a/tests/StaticHandler5Test.expect
+++ b/tests/StaticHandler5Test.expect
@@ -1,4 +1,5 @@
 #include <new> // for thread-safe static's placement new
+#include <cstdint> // for uint64_t under Linux/GCC
 // cmdline:-std=c++98
 void X()
 {

--- a/tests/StaticHandler6Test.expect
+++ b/tests/StaticHandler6Test.expect
@@ -1,4 +1,5 @@
 #include <new> // for thread-safe static's placement new
+#include <cstdint> // for uint64_t under Linux/GCC
 void X() noexcept(true);
 
 

--- a/tests/StaticHandlerTest.expect
+++ b/tests/StaticHandlerTest.expect
@@ -1,4 +1,5 @@
 #include <new> // for thread-safe static's placement new
+#include <cstdint> // for uint64_t under Linux/GCC
 #include <cstdio>
 #include <cstring>
 #include <new> // need this for after the transformation when a placement new is used

--- a/tests/StaticInLambdaTest.expect
+++ b/tests/StaticInLambdaTest.expect
@@ -1,4 +1,5 @@
 #include <new> // for thread-safe static's placement new
+#include <cstdint> // for uint64_t under Linux/GCC
 #include <cstdio>
 #include <cstring>
 #include <new> // need this for after the transformation when a placement new is used

--- a/tests/TypeIdInTemplateTest.cpp
+++ b/tests/TypeIdInTemplateTest.cpp
@@ -1,6 +1,7 @@
 #define INSIGHTS_USE_TEMPLATE
 
 #include <string>
+#include <typeinfo>
 
 template <typename T>
 class Foo{

--- a/tests/TypeIdInTemplateTest.expect
+++ b/tests/TypeIdInTemplateTest.expect
@@ -1,6 +1,7 @@
 #define INSIGHTS_USE_TEMPLATE
 
 #include <string>
+#include <typeinfo>
 
 template <typename T>
 class Foo{
@@ -12,7 +13,7 @@ public:
 
 };
 
-/* First instantiated from: TypeIdInTemplateTest.cpp:19 */
+/* First instantiated from: TypeIdInTemplateTest.cpp:20 */
 #ifdef INSIGHTS_USE_TEMPLATE
 template<>
 class Foo<int>

--- a/tests/autoRefAndConstTest.expect
+++ b/tests/autoRefAndConstTest.expect
@@ -1,4 +1,5 @@
 #include <new> // for thread-safe static's placement new
+#include <cstdint> // for uint64_t under Linux/GCC
 #include <vector>
 
 const std::vector<int, std::allocator<int> > & getTheData()


### PR DESCRIPTION
Added support for `runTest.py` under Windows.

To achieve this, the binary name in `CMakeLists.txt` is now platform
independent. In addition `cmake` is used to find the name of the `python3`
binary. The Windows binary is now located directly in the build folder
and now longer under `Release` or `Debug`.

To be as independent as possible, differences in test results are shown
via Python `difflib` instead of the former Unix `diff`.