### PR TITLE
Fixed #313: Show `CK_NoOp` correctly.

### DIFF
--- a/tests/Issue223_2.expect
+++ b/tests/Issue223_2.expect
@@ -3,7 +3,7 @@
 
 int main()
 {
-  float f = static_cast<float>(static_cast<float>((3.0)));
+  float f = static_cast<float>((3.0));
   return static_cast<int>(f);
 }
 

--- a/tests/Issue313.cpp
+++ b/tests/Issue313.cpp
@@ -1,0 +1,13 @@
+// cmdlineinsights:--show-all-implicit-casts
+
+struct A {};
+struct B {
+   explicit operator A() { return {}; }
+};
+
+void DangerousFunc(const A&) {}
+
+int main()
+{
+  DangerousFunc(static_cast<A>(B{}));
+}

--- a/tests/Issue313.expect
+++ b/tests/Issue313.expect
@@ -1,0 +1,29 @@
+// cmdlineinsights:--show-all-implicit-casts
+
+struct A
+{
+};
+
+
+struct B
+{
+  using retType_5_4 = A;
+  inline operator retType_5_4 ()
+  {
+    return {};
+  }
+  
+};
+
+
+
+void DangerousFunc(const A &)
+{
+}
+
+
+int main()
+{
+  DangerousFunc(static_cast<const A>(static_cast<A>(B{}.operator A())));
+}
+

--- a/tests/Issue313_2.cpp
+++ b/tests/Issue313_2.cpp
@@ -1,0 +1,14 @@
+// cmdlineinsights:--show-all-implicit-casts
+struct A
+{
+    bool operator==(const A&) const { return true; }
+    bool operator!=(const A&) { return true; }
+};
+
+int main()
+{
+    A a{};
+
+    if(a == a) {} // a gets constified as object and parameter
+    if(a != a) {} // only the parameter gets constified, as != is not const
+}

--- a/tests/Issue313_2.expect
+++ b/tests/Issue313_2.expect
@@ -1,0 +1,28 @@
+// cmdlineinsights:--show-all-implicit-casts
+struct A
+{
+  inline bool operator==(const A &) const
+  {
+    return true;
+  }
+  
+  inline bool operator!=(const A &)
+  {
+    return true;
+  }
+  
+};
+
+
+
+int main()
+{
+  A a = {};
+  if(static_cast<const A>(a).operator==(static_cast<const A>(a))) {
+  }
+  
+  if(a.operator!=(static_cast<const A>(a))) {
+  }
+  
+}
+


### PR DESCRIPTION
`CK_NoOp` stands for adding `const` or other qualifiers. Show this
conversion, if `--show-all-implicit-casts` is active.

This patch enables showing implicit casts for member-function calls
as well.