### PR TITLE
Fixed #311: Added support for attributes in general.

### DIFF
--- a/CodeGenerator.h
+++ b/CodeGenerator.h
@@ -183,6 +183,9 @@ public:
         mOutputFormatHelper.Append('>');
     }
 
+    void InsertAttributes(const Decl::attr_range&);
+    void InsertAttribute(const Attr&);
+
 protected:
     virtual bool InsertVarDecl() { return true; }
     virtual bool InsertComma() { return false; }

--- a/CodeGeneratorTypes.h
+++ b/CodeGeneratorTypes.h
@@ -122,6 +122,7 @@ SUPPORTED_STMT(CoroutineSuspendExpr)
 SUPPORTED_STMT(CoreturnStmt)
 SUPPORTED_STMT(DependentScopeDeclRefExpr)
 SUPPORTED_STMT(CXXRewrittenBinaryOperator)
+SUPPORTED_STMT(AttributedStmt)
 
 #undef IGNORED_DECL
 #undef IGNORED_STMT

--- a/FunctionDeclHandler.cpp
+++ b/FunctionDeclHandler.cpp
@@ -62,10 +62,20 @@ void FunctionDeclHandler::run(const MatchFinder::MatchResult& result)
 
         // Find the correct ending of the source range. In case of a declaration we need to find the ending semi,
         // otherwise the provided source range is correct.
-        const auto sr =
-            GetSourceRangeAfterSemi(funcDecl->getSourceRange(),
-                                    result,
-                                    funcDecl->doesThisDeclarationHaveABody() ? RequireSemi::No : RequireSemi::Yes);
+        const auto sr = [&] {
+            auto funcRange =
+                GetSourceRangeAfterSemi(funcDecl->getSourceRange(),
+                                        result,
+                                        funcDecl->doesThisDeclarationHaveABody() ? RequireSemi::No : RequireSemi::Yes);
+
+            // Adjust the begin location, if this decl has an attribute
+            if(funcDecl->hasAttrs()) {
+                // the -3 are a guess that seems to work
+                funcRange.setBegin((*funcDecl->attr_begin())->getLocation().getLocWithOffset(-3));
+            }
+
+            return funcRange;
+        }();
 
         // DPrint("fd rw:  %d %s\n", (sr.getBegin() == sr.getEnd()), outputFormatHelper.GetString());
 

--- a/OutputFormatHelper.cpp
+++ b/OutputFormatHelper.cpp
@@ -6,6 +6,7 @@
  ****************************************************************************/
 
 #include "OutputFormatHelper.h"
+#include "CodeGenerator.h"
 #include "InsightsHelpers.h"
 //-----------------------------------------------------------------------------
 
@@ -33,6 +34,10 @@ void OutputFormatHelper::AppendParameterList(const ArrayRef<ParmVarDecl*> parame
 {
     ForEachArg(parameters, [&](const auto& p) {
         const auto& name{GetName(*p)};
+
+        // Get the attributes and insert them, if there are any
+        CodeGenerator codeGenerator{*this};
+        codeGenerator.InsertAttributes(p->attrs());
 
         if(NameOnly::No == nameOnly) {
             const auto& type{p->getType()};

--- a/tests/AlignAsTest.cpp
+++ b/tests/AlignAsTest.cpp
@@ -1,0 +1,17 @@
+struct alignas(16) AlignedStruct
+{
+    float data[4];
+};
+ 
+alignas(128) char alignedArray[128];
+ 
+template <typename... Ts>
+struct AlignedStructWithPack
+{
+   char data alignas(Ts...);
+};
+ 
+int main()
+{
+    AlignedStructWithPack<int, char, double> a;
+}

--- a/tests/AlignAsTest.expect
+++ b/tests/AlignAsTest.expect
@@ -1,0 +1,33 @@
+struct alignas(16) AlignedStruct
+{
+  float data[4];
+};
+
+
+ 
+alignas(128) alignas(128) char alignedArray[128];
+
+ 
+template <typename... Ts>
+struct AlignedStructWithPack
+{
+   char data alignas(Ts...);
+};
+
+/* First instantiated from: AlignAsTest.cpp:16 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+struct AlignedStructWithPack<int, char, double>
+{
+  alignas(alignof(int)) alignas(alignof(char)) alignas(alignof(double)) char data;
+  // inline AlignedStructWithPack() noexcept = default;
+};
+
+#endif
+
+ 
+int main()
+{
+  AlignedStructWithPack<int, char, double> a = AlignedStructWithPack<int, char, double>();
+}
+

--- a/tests/AttributesTest.cpp
+++ b/tests/AttributesTest.cpp
@@ -1,0 +1,62 @@
+namespace test {
+    [[maybe_unused]] [[nodiscard]] inline int multipleGnuAttributes();
+
+    [[nodiscard]] int
+    forwardDeclWithAttributes();
+
+    int forwardDeclWithAttributes() { return 0; } // impl to former decl
+
+
+    // C++17:
+    [[using gnu: const, always_inline, hot]] [[nodiscard]] int usingAttribute [[gnu::always_inline]] ();
+
+    [[nodiscard]] int twiceTheSameAttributeOnDifferentPlace [[nodiscard]] ();
+
+    [[noreturn]] void noReturn();
+
+    [[deprecated]] void deprecatedFunc();
+
+    [[deprecated("Replaced by bar, which has an improved interface")]] void deprecatedWithMsgFunc();
+
+    void fallThroughAtrrTest(int n)
+    {
+        switch(n) {
+            case 1: [[fallthrough]];
+            case 2: break;
+        }
+    }
+
+    struct [[nodiscard]] nodiscardTest{};
+    struct [[nodiscard("just a test")]] nodiscardWithMsgTest{};
+
+    [[maybe_unused]] void maybeUnusedTest([[maybe_unused]] bool b)
+    {
+        [[maybe_unused]] bool b2 = b;
+    }
+
+// C++20
+#if 0
+int likelyTest(int i) {
+    switch(i) {
+    [[unlikely]] case 1: return 2;
+    [[likely]] case 2: return 1;
+    }
+    return 2;
+}
+#endif
+
+    // empty class
+    struct Empty
+    {
+    };
+
+    struct NoUniqueAddrTest
+    {
+        int                         i;
+        [[no_unique_address]] Empty e;
+    };
+
+}  // namespace test
+
+int main() {}
+

--- a/tests/AttributesTest.expect
+++ b/tests/AttributesTest.expect
@@ -1,0 +1,50 @@
+namespace test
+{
+  [[maybe_unused]] [[nodiscard("")]] inline int multipleGnuAttributes();
+  [[nodiscard("")]] int forwardDeclWithAttributes();
+  [[nodiscard("")]] int forwardDeclWithAttributes()
+  {
+    return 0;
+  }
+  [[gnu::const]] [[gnu::always_inline]] [[gnu::hot]] [[nodiscard("")]] int usingAttribute();
+  [[nodiscard("")]] [[nodiscard("")]] int twiceTheSameAttributeOnDifferentPlace();
+  [[noreturn]] void noReturn();
+  [[deprecated("")]] void deprecatedFunc();
+  [[deprecated("Replaced by bar, which has an improved interface")]] void deprecatedWithMsgFunc();
+  void fallThroughAtrrTest(int n)
+  {
+    switch(n) {
+      case 1: [[fallthrough]] ;
+      case 2: break;
+    }
+  }
+  struct [[nodiscard("")]] nodiscardTest
+  {
+  };
+  
+  struct [[nodiscard("just a test")]] nodiscardWithMsgTest
+  {
+  };
+  
+  [[maybe_unused]] void maybeUnusedTest([[maybe_unused]] bool b)
+  {
+    [[maybe_unused]] bool b2 = b;
+  }
+  struct Empty
+  {
+  };
+  
+  struct NoUniqueAddrTest
+  {
+    int i;
+    [[no_unique_address]] Empty e;
+  };
+  
+  
+}  // namespace test
+
+int main()
+{
+}
+
+

--- a/tests/AutoHandlerTest.expect
+++ b/tests/AutoHandlerTest.expect
@@ -42,7 +42,6 @@ inline constexpr char CEWest()
   return 'c';
 }
 
-
 [[maybe_unused]] inline constexpr char MUCEWest()
                  {
                    return 'c';
@@ -69,8 +68,8 @@ int main()
   char c = 'c';
   unsigned int u = 0U;
   unsigned int uu = u;
-  unsigned int mu = 0U;
-  unsigned int muu = u;
+  [[maybe_unused]] unsigned int mu = 0U;
+  [[maybe_unused]] unsigned int muu = u;
 }
 
 

--- a/tests/Issue311.cpp
+++ b/tests/Issue311.cpp
@@ -1,0 +1,6 @@
+struct alignas(double) foo {
+    int i;
+};
+
+static_assert(sizeof(foo) == 8);
+

--- a/tests/Issue311.expect
+++ b/tests/Issue311.expect
@@ -1,0 +1,10 @@
+struct alignas(alignof(double)) foo
+{
+  int i;
+};
+
+
+
+/* PASSED: static_assert(sizeof(foo) == 8); */
+
+

--- a/tests/p1143Test.cpp
+++ b/tests/p1143Test.cpp
@@ -1,0 +1,17 @@
+// cmdline:-std=c++2a
+// example taken from the standard
+const char *g() { return "dynamic initialization"; }
+constexpr const char *f(bool p) { return p ? "constant initializer" : g(); }
+
+
+constinit const char *c = f(true); // OK.
+
+namespace constInitTest {
+    constinit const char *c = f(true); // OK.
+}
+
+constinit int x = 3;
+
+int main() {
+    x = 4;
+}

--- a/tests/p1143Test.expect
+++ b/tests/p1143Test.expect
@@ -1,0 +1,31 @@
+// cmdline:-std=c++2a
+// example taken from the standard
+const char * g()
+{
+  return "dynamic initialization";
+}
+
+inline constexpr const char * f(bool p)
+{
+  return p ? "constant initializer" : g();
+}
+
+
+
+constinit const char * c = f(true);
+ // OK.
+
+namespace constInitTest
+{
+  constinit const char * c = f(true);
+  
+}
+
+constinit int x = 3;
+
+
+int main()
+{
+  x = 4;
+}
+


### PR DESCRIPTION
Before this patch C++ Insights did not support attributes. The missing
`alignas` specifier that is the reason for #311 is modeled as an
attribute. Hence, this patch also brings support for all other C++
attributes.

Along these lines, P1143 `constinit` which is also modeled as an attribute, is
supported as well.