### PR TITLE
Fixed `DependentScopeDeclRefExpr`.

### DIFF
--- a/CodeGenerator.cpp
+++ b/CodeGenerator.cpp
@@ -344,11 +344,13 @@ void CodeGenerator::InsertArg(const CXXForRangeStmt* rangeForStmt)
 }
 //-----------------------------------------------------------------------------
 
-static void InsertQualifierAndName(const DeclarationName&     declName,
-                                   const NestedNameSpecifier* qualifier,
-                                   OutputFormatHelper&        outputFormatHelper)
+void CodeGenerator::InsertQualifierAndName(const DeclarationName&     declName,
+                                           const NestedNameSpecifier* qualifier,
+                                           const bool                 hasTemplateKeyword)
 {
-    outputFormatHelper.Append(ScopeHandler::RemoveCurrentScope(GetNestedName(qualifier)), declName.getAsString());
+    mOutputFormatHelper.Append(ScopeHandler::RemoveCurrentScope(GetNestedName(qualifier)),
+                               hasTemplateKeyword ? "template " : "",
+                               declName.getAsString());
 }
 //-----------------------------------------------------------------------------
 
@@ -360,21 +362,13 @@ void CodeGenerator::InsertNamespace(const NestedNameSpecifier* stmt)
 
 void CodeGenerator::InsertArg(const UnresolvedLookupExpr* stmt)
 {
-    InsertQualifierAndName(stmt->getName(), stmt->getQualifier(), mOutputFormatHelper);
-
-    if(stmt->getNumTemplateArgs()) {
-        InsertTemplateArgs(*stmt);
-    }
+    InsertQualifierAndNameWithTemplateArgs(stmt->getName(), stmt);
 }
 //-----------------------------------------------------------------------------
 
 void CodeGenerator::InsertArg(const DependentScopeDeclRefExpr* stmt)
 {
-    if(stmt->hasTemplateKeyword()) {
-        mOutputFormatHelper.Append("template ");
-    }
-
-    InsertQualifierAndName(stmt->getDeclName(), stmt->getQualifier(), mOutputFormatHelper);
+    InsertQualifierAndNameWithTemplateArgs(stmt->getDeclName(), stmt);
 }
 //-----------------------------------------------------------------------------
 
@@ -2376,7 +2370,7 @@ void CodeGenerator::InsertArg(const UsingDecl* stmt)
 
     mOutputFormatHelper.Append("using ");
 
-    InsertQualifierAndName(stmt->getDeclName(), stmt->getQualifier(), mOutputFormatHelper);
+    InsertQualifierAndName(stmt->getDeclName(), stmt->getQualifier(), false);
 
     mOutputFormatHelper.AppendNewLine(";");
 

--- a/CodeGenerator.h
+++ b/CodeGenerator.h
@@ -218,6 +218,23 @@ protected:
     bool InsertLambdaStaticInvoker(const CXXMethodDecl* cxxMethodDecl);
     void InsertTemplateParameters(const TemplateParameterList& list);
 
+    template<typename T>
+    void InsertQualifierAndNameWithTemplateArgs(const DeclarationName& declName, const T* stmt)
+    {
+        InsertQualifierAndName(declName, stmt->getQualifier(), stmt->hasTemplateKeyword());
+
+        if(stmt->getNumTemplateArgs()) {
+            InsertTemplateArgs(*stmt);
+        } else if(stmt->hasExplicitTemplateArgs()) {
+            // we have empty templates arguments, but angle brackets provided by the user
+            mOutputFormatHelper.Append("<>");
+        }
+    }
+
+    void InsertQualifierAndName(const DeclarationName&     declName,
+                                const NestedNameSpecifier* qualifier,
+                                const bool                 hasTemplateKeyword);
+
     /// For a special case, when a LambdaExpr occurs in a Constructor from an
     /// in class initializer, there is a need for a more narrow scope for the \c LAMBDA_SCOPE_HELPER.
     void InsertCXXMethodHeader(const CXXMethodDecl* stmt, OutputFormatHelper& initOutputFormatHelper);

--- a/tests/DependentScopeDeclRefExprTest.cpp
+++ b/tests/DependentScopeDeclRefExprTest.cpp
@@ -42,6 +42,21 @@ struct dependentScope4
 
 }
 
+namespace DependentScopeDeclRefExpr {
+
+template <typename T>
+struct A;
+
+template <typename T>
+void test() {
+  A<T>::foo;
+  A<T>::template foo;
+  A<T>::template foo<>;
+  A<T>::template foo<T>;
+}
+
+} // namespace DependentScopeDeclRefExpr
+
 int main()
 {
     auto a = Test::dependentScope<int>::result;

--- a/tests/DependentScopeDeclRefExprTest.expect
+++ b/tests/DependentScopeDeclRefExprTest.expect
@@ -49,7 +49,7 @@ namespace Test
     inline static constexpr const bool result = true;
   };
   
-  /* First instantiated from: DependentScopeDeclRefExprTest.cpp:47 */
+  /* First instantiated from: DependentScopeDeclRefExprTest.cpp:62 */
   #ifdef INSIGHTS_USE_TEMPLATE
   template<>
   struct dependentScope<int, false>
@@ -64,7 +64,7 @@ namespace Test
     inline static constexpr const bool result = has<T>::value;
   };
   
-  /* First instantiated from: DependentScopeDeclRefExprTest.cpp:48 */
+  /* First instantiated from: DependentScopeDeclRefExprTest.cpp:63 */
   #ifdef INSIGHTS_USE_TEMPLATE
   template<>
   struct dependentScope2<int>
@@ -80,7 +80,7 @@ namespace Test
     inline static constexpr const bool result = has<T, U>::value;
   };
   
-  /* First instantiated from: DependentScopeDeclRefExprTest.cpp:49 */
+  /* First instantiated from: DependentScopeDeclRefExprTest.cpp:64 */
   #ifdef INSIGHTS_USE_TEMPLATE
   template<>
   struct dependentScope3<int>
@@ -96,7 +96,7 @@ namespace Test
     inline static constexpr const typename has<T>::type result = has<T>::value;
   };
   
-  /* First instantiated from: DependentScopeDeclRefExprTest.cpp:50 */
+  /* First instantiated from: DependentScopeDeclRefExprTest.cpp:65 */
   #ifdef INSIGHTS_USE_TEMPLATE
   template<>
   struct dependentScope4<bool>
@@ -107,6 +107,21 @@ namespace Test
   #endif
   
 }
+
+namespace DependentScopeDeclRefExpr
+{
+  template<typename T>
+  struct A;
+  template<typename T>
+  void test()
+  {
+    A<T>::foo;
+    A<T>::template foo;
+    A<T>::template foo<>;
+    A<T>::template foo<T>;
+  }
+  
+} // namespace DependentScopeDeclRefExpr
 
 int main()
 {


### PR DESCRIPTION
It was not treading the `template` keyword correctly.