### PR TITLE
Fixed #290: Added support for unions and anonymous structs.

### DIFF
--- a/CodeGenerator.cpp
+++ b/CodeGenerator.cpp
@@ -66,12 +66,13 @@ static const char* GetCastName(const CastKind castKind)
 }
 //-----------------------------------------------------------------------------
 
-static const char* GetClassOrStructTagName(const TagDecl& decl)
+static const char* GetTagDeclTypeName(const TagDecl& decl)
 {
-    const bool isClass{decl.isClass()};
-
-    if(isClass) {
+    if(decl.isClass()) {
         return kwClassSpace;
+
+    } else if(decl.isUnion()) {
+        return "union ";
 
     } else {
         return "struct ";
@@ -2405,7 +2406,7 @@ void CodeGenerator::InsertArg(const FriendDecl* stmt)
             if(const auto* ctd = dyn_cast_or_null<ClassTemplateDecl>(stmt->getFriendDecl())) {
                 InsertTemplateParameters(*ctd->getTemplateParameters());
 
-                cls = GetClassOrStructTagName(*ctd->getTemplatedDecl());
+                cls = GetTagDeclTypeName(*ctd->getTemplatedDecl());
             }
 
             mOutputFormatHelper.AppendNewLine("friend ", cls, GetName(*stmt->getFriendDecl()), ";");
@@ -2564,7 +2565,7 @@ void CodeGenerator::InsertArg(const CXXRecordDecl* stmt)
         }
     }
 
-    mOutputFormatHelper.Append(GetClassOrStructTagName(*stmt));
+    mOutputFormatHelper.Append(GetTagDeclTypeName(*stmt));
 
     InsertAttributes(stmt->attrs());
 

--- a/InsightsHelpers.h
+++ b/InsightsHelpers.h
@@ -146,6 +146,20 @@ static inline std::string GetLambdaName(const LambdaExpr& lambda)
 std::string GetName(const CXXRecordDecl& RD);
 //-----------------------------------------------------------------------------
 
+/// \brief Check whether this is an anonymous struct or union.
+///
+/// There is a dedicated function `isAnonymousStructOrUnion` which at this point no longer returns true. Hence this
+/// method uses an empty record decl name as indication for an anonymous struct/union.
+static inline bool IsAnonymousStructOrUnion(const CXXRecordDecl* cxxRecordDecl)
+{
+    if(cxxRecordDecl) {
+        return cxxRecordDecl->getName().empty();
+    }
+
+    return false;
+}
+//-----------------------------------------------------------------------------
+
 /// \brief Remove decltype from a QualType, if possible.
 const QualType GetDesugarType(const QualType& QT);
 // -----------------------------------------------------------------------------

--- a/tests/AnonymousStructInMacro2Test.cpp
+++ b/tests/AnonymousStructInMacro2Test.cpp
@@ -1,0 +1,6 @@
+#define macro(name) \
+    struct { int x; } name
+
+macro(myAnonStruct);
+macro(myAnonStruct2);
+

--- a/tests/AnonymousStructInMacro2Test.expect
+++ b/tests/AnonymousStructInMacro2Test.expect
@@ -1,0 +1,20 @@
+#define macro(name) \
+    struct { int x; } name
+struct __anon_4_1
+{
+  int x;
+  // inline __anon_4_1() noexcept = default;
+};
+
+
+__anon_4_1 myAnonStruct = __anon_4_1();
+struct __anon_5_1
+{
+  int x;
+  // inline __anon_5_1() noexcept = default;
+};
+
+
+__anon_5_1 myAnonStruct2 = __anon_5_1();
+
+

--- a/tests/AnonymousStructInMacro3Test.cpp
+++ b/tests/AnonymousStructInMacro3Test.cpp
@@ -1,0 +1,5 @@
+#define macro(name) \
+    struct { int x; } name;
+
+macro(myAnonStruct)
+

--- a/tests/AnonymousStructInMacro3Test.expect
+++ b/tests/AnonymousStructInMacro3Test.expect
@@ -1,0 +1,12 @@
+#define macro(name) \
+    struct { int x; } name;
+struct __anon_4_1
+{
+  int x;
+  // inline __anon_4_1() noexcept = default;
+};
+
+
+__anon_4_1 myAnonStruct = __anon_4_1();
+
+

--- a/tests/AnonymousStructInMacroTest.cpp
+++ b/tests/AnonymousStructInMacroTest.cpp
@@ -1,0 +1,5 @@
+#define macro(name) \
+    struct { int x; } name;
+
+macro(myAnonStruct);
+

--- a/tests/AnonymousStructInMacroTest.expect
+++ b/tests/AnonymousStructInMacroTest.expect
@@ -1,0 +1,12 @@
+#define macro(name) \
+    struct { int x; } name;
+struct __anon_4_1
+{
+  int x;
+  // inline __anon_4_1() noexcept = default;
+};
+
+
+__anon_4_1 myAnonStruct = __anon_4_1();
+;
+

--- a/tests/AnonymousStructTest.cpp
+++ b/tests/AnonymousStructTest.cpp
@@ -1,0 +1,23 @@
+// The problem with an anonymous struct is, that the resulting VarDecl rewrites the same source location.
+// In a namespace, where the namespace itself is matched, it works.
+namespace works {
+struct {
+    int c;
+} RR;
+}
+
+// However, the same code with the TU as root does not
+struct {
+    int c;
+    int c1;
+    int c2;
+    int c3;
+    int c4;
+    int c6;
+} RR;
+
+// However, the same code with the TU as root does not
+struct {
+    int c;
+} RR2;
+

--- a/tests/AnonymousStructTest.expect
+++ b/tests/AnonymousStructTest.expect
@@ -1,0 +1,39 @@
+// The problem with an anonymous struct is, that the resulting VarDecl rewrites the same source location.
+// In a namespace, where the namespace itself is matched, it works.
+namespace works
+{
+  struct __anon_4_1
+  {
+    int c;
+    // inline __anon_4_1() noexcept = default;
+  };
+  
+  __anon_4_1 RR = __anon_4_1();
+  
+}
+
+// However, the same code with the TU as root does not
+struct __anon_10_1
+{
+  int c;
+  int c1;
+  int c2;
+  int c3;
+  int c4;
+  int c6;
+  // inline __anon_10_1() noexcept = default;
+};
+
+__anon_10_1 RR = __anon_10_1();
+
+
+// However, the same code with the TU as root does not
+struct __anon_20_1
+{
+  int c;
+  // inline __anon_20_1() noexcept = default;
+};
+
+__anon_20_1 RR2 = __anon_20_1();
+
+

--- a/tests/Issue290.cpp
+++ b/tests/Issue290.cpp
@@ -1,0 +1,3 @@
+union U {
+  struct {} s;
+};

--- a/tests/Issue290.expect
+++ b/tests/Issue290.expect
@@ -1,0 +1,10 @@
+union U
+{
+  struct __anon_2_3
+  {
+  };
+  
+  __anon_2_3 s;
+};
+
+


### PR DESCRIPTION
To this point unions where shown as a struct, as Clang internally models
them as a CXXRecordDecl.

Also unsupported where anonymous structs. Due to the declaration order
in Clang a name based on line/column prefixed with `__anon_` is made up
to be able to refer to the struct later in a `FieldDecl`.