### PR TITLE
Fixed #325: Added missing parenthesis.

### DIFF
--- a/CodeGenerator.cpp
+++ b/CodeGenerator.cpp
@@ -1692,7 +1692,9 @@ void CodeGenerator::InsertArg(const CXXNewExpr* stmt)
 
 void CodeGenerator::InsertArg(const MaterializeTemporaryExpr* stmt)
 {
-    InsertArg(GetTemporary(stmt));
+    // At least in case of a tenary operator wrapped inside a MaterializeTemporaryExpr parens are necessary
+    const auto* temporary = GetTemporary(stmt);
+    WrapInParensIfNeeded(isa<ConditionalOperator>(temporary), [&] { InsertArg(temporary); });
 }
 //-----------------------------------------------------------------------------
 

--- a/tests/Issue324.cpp
+++ b/tests/Issue324.cpp
@@ -1,0 +1,16 @@
+struct Str {
+  Str(const char* string) : string(string) {}
+  
+  operator const char*() const { 
+    return string; 
+  }
+  
+  const char* string;
+};
+
+Str globalString = "test";
+
+
+const char* getString(bool empty) {
+  return empty ? "" : globalString;
+}

--- a/tests/Issue324.expect
+++ b/tests/Issue324.expect
@@ -1,0 +1,28 @@
+struct Str
+{
+  inline Str(const char * string)
+  : string{string}
+  {
+  }
+  
+  using retType_4_3 = const char *;
+  inline operator retType_4_3 () const
+  {
+    return this->string;
+  }
+  
+  const char * string;
+  // inline constexpr Str(const Str &) noexcept = default;
+};
+
+
+
+Str globalString = Str("test");
+
+
+
+const char * getString(bool empty)
+{
+  return static_cast<const char *>((empty ? Str("") : Str(globalString)).operator const char *());
+}
+


### PR DESCRIPTION
If we have a tenary-operator used within a `MaterializeTemporaryExpr`
the expression needs to be wrapped in parenthesis to make it correct.