### PR TITLE
Fixed #323: Missing final specialization is now there.

### DIFF
--- a/InsightsHelpers.cpp
+++ b/InsightsHelpers.cpp
@@ -28,11 +28,12 @@ ScopeHandler::ScopeHandler(const Decl* d)
     if(const auto* recordDecl = dyn_cast_or_null<CXXRecordDecl>(d)) {
         mScope.append(GetName(*recordDecl));
 
-        const bool isClassTemplateSpecialization{isa<ClassTemplatePartialSpecializationDecl>(recordDecl) ||
-                                                 isa<ClassTemplateSpecializationDecl>(recordDecl)};
+        if(const auto* classTmplSpec = dyn_cast_or_null<ClassTemplateSpecializationDecl>(recordDecl)) {
+            OutputFormatHelper ofm{};
+            CodeGenerator      codeGenerator{ofm};
+            codeGenerator.InsertTemplateArgs(*classTmplSpec);
 
-        if(isClassTemplateSpecialization) {
-            mScope.append("<>");
+            mScope.append(ofm.GetString());
         }
 
     } else if(const auto* namespaceDecl = dyn_cast_or_null<NamespaceDecl>(d)) {

--- a/tests/ClassOperatorHandler7Test.expect
+++ b/tests/ClassOperatorHandler7Test.expect
@@ -34,7 +34,7 @@ struct A<int *>
     // inline constexpr B() noexcept = default;
   };
   
-  A<int *>::B foo;
+  B foo;
   // inline constexpr A() noexcept = default;
 };
 
@@ -50,7 +50,7 @@ struct A<T *>
     
   };
   
-  A<T *>::B foo;
+  B foo;
 };
 
 

--- a/tests/Issue101.expect
+++ b/tests/Issue101.expect
@@ -244,7 +244,7 @@ template<>
 struct compose<add_pointer>
 {
   using continuation = typename add_pointer::continuation;
-  template<typename C = compose<add_pointer>::continuation>
+  template<typename C = continuation>
   struct to;
   /* First instantiated from: Issue101.cpp:213 */
   #ifdef INSIGHTS_USE_TEMPLATE
@@ -252,7 +252,7 @@ struct compose<add_pointer>
   struct to<identity>
   {
     template<typename ... Ts>
-    using result = to<add_pointer::to<identity> >::result<Ts...>;
+    using result = compose<>::to<add_pointer::to<identity> >::result<Ts...>;
   };
   
   #endif
@@ -262,7 +262,7 @@ struct compose<add_pointer>
   struct to<add_const::to<identity> >
   {
     template<typename ... Ts>
-    using result = to<add_pointer::to<add_const::to<identity> > >::result<Ts...>;
+    using result = compose<>::to<add_pointer::to<add_const::to<identity> > >::result<Ts...>;
   };
   
   #endif
@@ -272,7 +272,7 @@ struct compose<add_pointer>
   struct to<wrap>
   {
     template<typename ... Ts>
-    using result = to<add_pointer::to<wrap> >::result<Ts...>;
+    using result = compose<>::to<add_pointer::to<wrap> >::result<Ts...>;
   };
   
   #endif
@@ -287,7 +287,7 @@ template<>
 struct compose<add_pointer, add_const>
 {
   using continuation = typename add_pointer::continuation;
-  template<typename C = compose<add_pointer, add_const>::continuation>
+  template<typename C = continuation>
   struct to;
   /* First instantiated from: Issue101.cpp:213 */
   #ifdef INSIGHTS_USE_TEMPLATE
@@ -320,7 +320,7 @@ template<>
 struct compose<add_const>
 {
   using continuation = typename add_const::continuation;
-  template<typename C = compose<add_const>::continuation>
+  template<typename C = continuation>
   struct to;
   /* First instantiated from: Issue101.cpp:169 */
   #ifdef INSIGHTS_USE_TEMPLATE
@@ -328,7 +328,7 @@ struct compose<add_const>
   struct to<add_pointer::to<identity> >
   {
     template<typename ... Ts>
-    using result = to<add_const::to<add_pointer::to<identity> > >::result<Ts...>;
+    using result = compose<>::to<add_const::to<add_pointer::to<identity> > >::result<Ts...>;
   };
   
   #endif
@@ -338,7 +338,7 @@ struct compose<add_const>
   struct to<add_pointer::to<wrap> >
   {
     template<typename ... Ts>
-    using result = to<add_const::to<add_pointer::to<wrap> > >::result<Ts...>;
+    using result = compose<>::to<add_const::to<add_pointer::to<wrap> > >::result<Ts...>;
   };
   
   #endif
@@ -353,7 +353,7 @@ template<>
 struct compose<add_const, add_pointer>
 {
   using continuation = typename add_const::continuation;
-  template<typename C = compose<add_const, add_pointer>::continuation>
+  template<typename C = continuation>
   struct to;
   /* First instantiated from: Issue101.cpp:213 */
   #ifdef INSIGHTS_USE_TEMPLATE

--- a/tests/Issue323.cpp
+++ b/tests/Issue323.cpp
@@ -1,0 +1,16 @@
+template<typename... Args> struct count;
+
+template<>
+struct count<> {
+  static const int value = 0;
+};
+
+template<typename T, typename... Args>
+struct count<T, Args...>
+{
+  static const int value = 1 + count<Args...>::value;
+};
+
+static_assert(count<double>::value == 1, 
+              "2 elements");
+

--- a/tests/Issue323.expect
+++ b/tests/Issue323.expect
@@ -1,0 +1,32 @@
+template<typename... Args> struct count;
+
+/* First instantiated from: Issue323.cpp:14 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+struct count<double>
+{
+  static const int value = 1 + count<>::value;
+};
+
+#endif
+
+
+template<>
+struct count<>
+{
+  static const int value = 0;
+};
+
+
+
+template<typename T, typename ... Args>
+struct count<T, Args...>
+{
+  static const int value = 1 + count<Args...>::value;
+};
+
+
+
+/* PASSED: static_assert(count<double>::value == 1, "2 elements"); */
+
+

--- a/tests/Issue60.expect
+++ b/tests/Issue60.expect
@@ -44,7 +44,7 @@ struct Index<&Person::age>
   using Key = Key_t<&Person::age>;
   using POD = POD_t<&Person::age>;
   std::map<int, int, std::less<int>, std::allocator<std::pair<const int, int> > > data;
-  static inline Index<&Person::age>::Key extractKey(const Index<&Person::age>::POD & pod);
+  static inline Key extractKey(const POD & pod);
   
   // inline ~Index() noexcept = default;
   // inline Index() noexcept = default;

--- a/tests/Issue92.expect
+++ b/tests/Issue92.expect
@@ -116,27 +116,27 @@ struct generator<unsigned int>
   
   struct iterator
   {
-    std::experimental::coroutine_handle<generator<unsigned int>::promise_type> hco;
+    std::experimental::coroutine_handle<promise_type> hco;
     bool done;
-    inline iterator(std::experimental::coroutine_handle<generator<unsigned int>::promise_type> hco, bool done)
-    : hco{std::experimental::coroutine_handle<generator<unsigned int>::promise_type>(hco)}
+    inline iterator(std::experimental::coroutine_handle<promise_type> hco, bool done)
+    : hco{std::experimental::coroutine_handle<promise_type>(hco)}
     , done{done}
     {
     }
     
-    inline generator<unsigned int>::iterator & operator++()
+    inline iterator & operator++()
     {
       static_cast<std::experimental::coroutine_handle<void>&>(this->hco).resume();
       this->done = static_cast<const std::experimental::coroutine_handle<void>&>(this->hco).done();
       return *this;
     }
     
-    inline bool operator==(const generator<unsigned int>::iterator & o) const
+    inline bool operator==(const iterator & o) const
     {
       return static_cast<int>(this->done) == static_cast<int>(o.done);
     }
     
-    inline bool operator!=(const generator<unsigned int>::iterator & o) const
+    inline bool operator!=(const iterator & o) const
     {
       return !((*this).operator==(o));
     }
@@ -150,19 +150,19 @@ struct generator<unsigned int>
     
   };
   
-  inline generator<unsigned int>::iterator begin()
+  inline iterator begin()
   {
     static_cast<std::experimental::coroutine_handle<void>&>(this->p).resume();
-    return generator<unsigned int>::iterator{std::experimental::coroutine_handle<generator<unsigned int>::promise_type>(this->p), static_cast<const std::experimental::coroutine_handle<void>&>(this->p).done()};
+    return iterator{std::experimental::coroutine_handle<promise_type>(this->p), static_cast<const std::experimental::coroutine_handle<void>&>(this->p).done()};
   }
   
-  inline generator<unsigned int>::iterator end()
+  inline iterator end()
   {
-    return generator<unsigned int>::iterator{std::experimental::coroutine_handle<generator<unsigned int>::promise_type>(this->p), true};
+    return iterator{std::experimental::coroutine_handle<promise_type>(this->p), true};
   }
   
   inline generator(generator<unsigned int> && rhs)
-  : p{std::experimental::coroutine_handle<generator<unsigned int>::promise_type>(rhs.p)}
+  : p{std::experimental::coroutine_handle<promise_type>(rhs.p)}
   {
     rhs.p.operator=(nullptr);
   }
@@ -176,12 +176,12 @@ struct generator<unsigned int>
   
   
   private: 
-  inline explicit generator(generator<unsigned int>::promise_type * p)
-  : p{std::experimental::coroutine_handle<generator<unsigned int>::promise_type>::from_promise(*p)}
+  inline explicit generator(promise_type * p)
+  : p{std::experimental::coroutine_handle<promise_type>::from_promise(*p)}
   {
   }
   
-  std::experimental::coroutine_handle<generator<unsigned int>::promise_type> p;
+  std::experimental::coroutine_handle<promise_type> p;
   public: 
   // inline constexpr generator(const generator<unsigned int> &) = delete;
 };

--- a/tests/TemplateKeywordTest.expect
+++ b/tests/TemplateKeywordTest.expect
@@ -16,13 +16,13 @@ namespace detail
   struct to<int>
   {
     template<typename ... Ts>
-    struct detail::to<int>::result;
+    struct result;
     /* First instantiated from: TemplateKeywordTest.cpp:31 */
     #ifdef INSIGHTS_USE_TEMPLATE
     template<>
-    struct detail::to<int>::result<int, char>
+    struct result<int, char>
     {
-      // inline constexpr detail::to<int>::result() noexcept = default;
+      // inline constexpr result() noexcept = default;
     };
     
     #endif

--- a/tests/TemplateSpecializationWithDependentTypeTest.expect
+++ b/tests/TemplateSpecializationWithDependentTypeTest.expect
@@ -19,7 +19,7 @@ struct A<int *>
     // inline constexpr B() noexcept = default;
   };
   
-  A<int *>::B foo;
+  B foo;
   // inline constexpr A() noexcept = default;
 };
 
@@ -33,7 +33,7 @@ struct A<T *>
   {
   };
   
-  A<T *>::B foo;
+  B foo;
 };
 
 


### PR DESCRIPTION
For other instantiations this change removes namespaces. However, all of
them seem redundant. With this patch they look cleaner and correct.