### PR TITLE
Fixed #333: Check for valid `SourceLocation` of attributes.

### DIFF
--- a/FunctionDeclHandler.cpp
+++ b/FunctionDeclHandler.cpp
@@ -70,8 +70,14 @@ void FunctionDeclHandler::run(const MatchFinder::MatchResult& result)
 
             // Adjust the begin location, if this decl has an attribute
             if(funcDecl->hasAttrs()) {
-                // the -3 are a guess that seems to work
-                funcRange.setBegin((*funcDecl->attr_begin())->getLocation().getLocWithOffset(-3));
+                // Find the first attribute with a valid source-location
+                for(const auto& attr : funcDecl->attrs()) {
+                    if(const auto location = attr->getLocation(); location.isValid()) {
+                        // the -3 are a guess that seems to work
+                        funcRange.setBegin(location.getLocWithOffset(-3));
+                        return funcRange;
+                    }
+                }
             }
 
             return funcRange;

--- a/tests/Issue333.cpp
+++ b/tests/Issue333.cpp
@@ -1,0 +1,20 @@
+#include <cstdio>
+#include <cstdlib>
+
+// replacement of a minimal set of functions:
+void* operator new(std::size_t sz) {
+    std::printf("global op new called, size = %zu\n",sz);
+    return std::malloc(sz);
+}
+void operator delete(void* ptr) noexcept
+{
+   std::puts("global op delete called");
+   std::free(ptr);
+}
+int main() {
+     int* p1 = new int;
+     delete p1;
+ 
+     int* p2 = new int[10]; // guaranteed to call the replacement in C++11
+     delete[] p2;
+}

--- a/tests/Issue333.expect
+++ b/tests/Issue333.expect
@@ -1,0 +1,24 @@
+#include <cstdio>
+#include <cstdlib>
+
+// replacement of a minimal set of functions:
+__attribute__((visibility("default"))) void * operator new(std::size_t sz)
+{
+  printf("global op new called, size = %zu\n", sz);
+  return malloc(sz);
+}
+
+__attribute__((visibility("default"))) void operator delete(void * ptr) noexcept
+{
+  puts("global op delete called");
+  free(ptr);
+}
+
+int main()
+{
+  int * p1 = new int;
+  delete p1;
+  int * p2 = new int[10];
+  delete[] p2;
+}
+


### PR DESCRIPTION
Functions like `operator new` and `operator delete` carry a hidden
attribute `__attribute__((visibility("default")))` which has no valid
`SourceLocation` as it is inherited from the STL. This patch adds code
to use only a valid `SourceLocation` to apply the offset to it to get
the replacement range of the `FunctionDecl`.