### PR TITLE
Fixed Issue #186: Build fails on Arch Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,19 +8,21 @@ include(CMakePrintHelpers)
 
 # TODO: enable those options on Windows once tested
 if(NOT WIN32)
-    option(DEBUG               "Enable debug"              Off)
-    option(INSIGHTS_STRIP      "Strip insight after build" On )
-    option(INSIGHTS_TIDY       "Run clang-tidy"            Off)
-    option(INSIGHTS_IWYU       "Run include-what-you-use"  Off)
-    option(INSIGHTS_COVERAGE   "Enable code coverage"      Off)
-    option(INSIGHTS_USE_LIBCPP "Enable code coverage"      Off)
+    option(DEBUG                        "Enable debug"               Off)
+    option(INSIGHTS_STRIP               "Strip insight after build"  On )
+    option(INSIGHTS_TIDY                "Run clang-tidy"             Off)
+    option(INSIGHTS_IWYU                "Run include-what-you-use"   Off)
+    option(INSIGHTS_COVERAGE            "Enable code coverage"       Off)
+    option(INSIGHTS_USE_LIBCPP          "Enable code coverage"       Off)
+    option(INSIGHTS_USE_SYSTEM_INCLUDES "Elevate to system includes" On )
 else()
-    set(DEBUG               Off)
-    set(INSIGHTS_STRIP      Off)
-    set(INSIGHTS_TIDY       Off)
-    set(INSIGHTS_IWYU       Off)
-    set(INSIGHTS_COVERAGE   Off)
-    set(INSIGHTS_USE_LIBCPP Off)
+    set(DEBUG                         Off)
+    set(INSIGHTS_STRIP                Off)
+    set(INSIGHTS_TIDY                 Off)
+    set(INSIGHTS_IWYU                 Off)
+    set(INSIGHTS_COVERAGE             Off)
+    set(INSIGHTS_USE_LIBCPP           Off)
+    set(INSIGHTS_USE_SYSTEM_INCLUDES  On )
 endif()
 
 option(INSIGHTS_STATIC     "Use static linking"        Off)
@@ -162,13 +164,15 @@ if (BUILD_INSIGHTS_OUTSIDE_LLVM)
             "[ \t]*[\r\n]+[ \t]*" ";"
             CONFIG_OUTPUT ${CONFIG_OUTPUT})
 
-        # make all includes system include to prevent the compiler to warn about issues in LLVM/Clang
-        if(NOT WIN32)
-            string(REGEX REPLACE "-I" "-isystem" CONFIG_OUTPUT "${CONFIG_OUTPUT}")
-        else()
-            if(IS_MSVC_CL)
-                # See https://devblogs.microsoft.com/cppblog/broken-warnings-theory/
-                string(REGEX REPLACE "-I" "/external:I" CONFIG_OUTPUT "${CONFIG_OUTPUT}")
+        if(INSIGHTS_USE_SYSTEM_INCLUDES)
+            # make all includes system include to prevent the compiler to warn about issues in LLVM/Clang
+            if(NOT WIN32)
+                string(REGEX REPLACE "-I" "-isystem" CONFIG_OUTPUT "${CONFIG_OUTPUT}")
+            else()
+                if(IS_MSVC_CL)
+                    # See https://devblogs.microsoft.com/cppblog/broken-warnings-theory/
+                    string(REGEX REPLACE "-I" "/external:I" CONFIG_OUTPUT "${CONFIG_OUTPUT}")
+                endif()
             endif()
         endif()
 
@@ -473,13 +477,28 @@ add_clang_tool(insights
     TemplateHandler.cpp
 )
 
-# general include also provided by clang-build
-target_link_libraries(insights
-  PRIVATE
-  clangTooling
-  clangASTMatchers
-  ${ADDITIONAL_LIBS}
-)
+
+if(CLANG_LINK_CLANG_DYLIB)
+    if (NOT LLVM_LINK_LLVM_DYLIB)
+        message(FATAL_ERROR "CLANG_LINK_CLANG_DYLIB and LLVM_LINK_LLVM_DYLIB must have the same value.")
+    endif()
+    target_link_libraries(insights PRIVATE clang-cpp)
+else()
+    # general include also provided by clang-build
+    target_link_libraries(insights
+        PRIVATE
+        clangTooling
+        clangASTMatchers
+        ${ADDITIONAL_LIBS}
+    )
+endif()
+
+if(LLVM_LINK_LLVM_DYLIB)
+    if (NOT CLANG_LINK_CLANG_DYLIB)
+        message(FATAL_ERROR "CLANG_LINK_CLANG_DYLIB and LLVM_LINK_LLVM_DYLIB must have the same value.")
+    endif()
+    target_link_libraries(insights PRIVATE LLVM)
+endif()
 
 if(CLANG_TIDY_EXE AND INSIGHTS_TIDY)
   set(RUN_CLANG_TIDY On)
@@ -684,6 +703,7 @@ message(STATUS "Debug                 : ${DEBUG}")
 message(STATUS "Code Coverage         : ${INSIGHTS_COVERAGE}")
 message(STATUS "Static linking        : ${INSIGHTS_STATIC}")
 message(STATUS "Strip executable      : ${INSIGHTS_STRIP}")
+message(STATUS "Elevate includes:     : ${INSIGHTS_USE_SYSTEM_INCLUDES}")
 message(STATUS "clang-tidy            : ${RUN_CLANG_TIDY}")
 message(STATUS "include-what-you-use  : ${RUN_IWYU}")
 message(STATUS "")

--- a/Readme.md
+++ b/Readme.md
@@ -105,6 +105,14 @@ C++ Insights can be build inside the clang-source tree or outside.
 
 See [Readme_Windows.md](Readme_Windows.md)
 
+### Building on Arch Linux
+
+To build with `extra/clang` use the following extra flags: `-DINSIGHTS_USE_SYSTEM_INCLUDES=off -DCLANG_LINK_CLANG_DYLIB=on -DLLVM_LINK_LLVM_DYLIB=on`
+
+See https://github.com/andreasfertig/cppinsights/issues/186 for an explanation of why `INSIGHTS_USE_SYSTEM_INCLUDES` needs to be turned off.
+
+`extra/clang` and `extra/llvm` provide `/usr/lib/{libclangAST.so,libLLVM*.a,libLLVM.so}`. `libclangAST.so` needs `libLLVM.so` and there would be a conflict if `libLLVM*.a` (instead of `libLLVM.so`) are linked. See https://bugs.archlinux.org/task/60512
+
 ### Building outside clang
 
 You need to have a clang installation in the search path.


### PR DESCRIPTION
Fixed Issue #186: 

- Added a flag to `CMakeLists.txt` to not elevate the includes to system includes (i.e. skipping the regex replacement from `-I` to `-isystem`). 

That resolved the issue described in issue #186 but it uncovered another issue:
```
  % cmake -G"Ninja" ../cppinsights
cmake -G"Ninja" ../cppinsights
-- llvm_config(LLVM_CXXFLAGS)=>-I/usr/include    -fno-exceptions -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS;
-- llvm_config(LLVM_LDFLAGS)=>-L/usr/lib;
-- llvm_config(LLVM_LIBS2)=>-lLLVM-10;
-- llvm_config(LLVM_LIBDIR)=>/usr/lib;
-- llvm_config(LLVM_INCLUDE_DIR)=>/usr/include;
-- llvm_config(LLVM_SYSTEM_LIBS2)=>;
-- llvm_config(LLVM_PACKAGE_VERSION)=>10.0.1;
-- llvm_config(LLVM_INCLUDE_DIR)=>/usr/include;
-- Generating version.h
-- Found clang-tidy: /usr/bin/clang-tidy
-- Could not find the program include-what-you-use
-- Could NOT find Doxygen (missing: DOXYGEN_EXECUTABLE) 
-- Found Python3: /usr/bin/python3.8. Target tests enabled.
-- 
-- [ Build summary ]
-- CMAKE_GENERATOR       : Ninja
-- CMAKE_EXE_LINKER_FLAGS: 
-- Compiler ID           : GNU
-- Compiler version      : 10.2.0
-- Compiler path         : /usr/bin/c++
-- llvm-config           : /usr/bin/llvm-config
-- Min LLVM major version: 10
-- Install path          : /usr/local
-- Clang resource dir    : 
-- CMAKE_SOURCE_DIR      : /home/jyno/tools/cppinsights/cppinsights
-- CMAKE_BINARY_DIR      : /home/jyno/tools/cppinsights/build
-- Git repo url          : https://github.com/andreasfertig/cppinsights.git
-- Git commit hash       : 87525d1ee5f29a9ecc6036904396ceb3020c64f8
-- Debug                 : OFF
-- Code Coverage         : OFF
-- Static linking        : OFF
-- Strip executable      : ON
-- Elevate includes:     : ON
-- clang-tidy            : Off
-- include-what-you-use  : Off
-- 
-- Configuring done
-- Generating done
-- Build files have been written to: /home/jyno/tools/cppinsights/build

  % ninja
ninja
[1/14] Building CXX object docs/CMakeFiles/OptionDocumentationGenerator.dir/OptionDocumentationGenerator.cpp.o
[2/14] Linking CXX executable docs/OptionDocumentationGenerator
[3/14] Building CXX object CMakeFiles/insights.dir/InsightsBase.cpp.o
[4/14] Building CXX object CMakeFiles/insights.dir/DPrint.cpp.o
[5/14] Building CXX object CMakeFiles/insights.dir/OutputFormatHelper.cpp.o
[6/14] Building CXX object CMakeFiles/insights.dir/StaticAssertHandler.cpp.o
[7/14] Building CXX object CMakeFiles/insights.dir/RecordDeclHandler.cpp.o
[8/14] Building CXX object CMakeFiles/insights.dir/InsightsHelpers.cpp.o
[9/14] Building CXX object CMakeFiles/insights.dir/GlobalVariableHandler.cpp.o
[10/14] Building CXX object CMakeFiles/insights.dir/TemplateHandler.cpp.o
[11/14] Building CXX object CMakeFiles/insights.dir/FunctionDeclHandler.cpp.o
[12/14] Building CXX object CMakeFiles/insights.dir/Insights.cpp.o
[13/14] Building CXX object CMakeFiles/insights.dir/CodeGenerator.cpp.o
[14/14] Linking CXX executable insights
FAILED: insights 
: && /usr/bin/c++   CMakeFiles/insights.dir/CodeGenerator.cpp.o CMakeFiles/insights.dir/DPrint.cpp.o CMakeFiles/insights.dir/FunctionDeclHandler.cpp.o CMakeFiles/insights.dir/GlobalVariableHandler.cpp.o CMakeFiles/insights.dir/Insights.cpp.o CMakeFiles/insights.dir/InsightsBase.cpp.o CMakeFiles/insights.dir/InsightsHelpers.cpp.o CMakeFiles/insights.dir/OutputFormatHelper.cpp.o CMakeFiles/insights.dir/RecordDeclHandler.cpp.o CMakeFiles/insights.dir/StaticAssertHandler.cpp.o CMakeFiles/insights.dir/TemplateHandler.cpp.o -o insights  -lclangTooling  -lclangASTMatchers  -L/usr/lib  -lclangFrontend  -lclangDriver  -lclangSerialization  -lclangParse  -lclangSema  -lclangAnalysis  -lclangEdit  -lclangAST  -lclangLex  -lclangBasic  -lclangRewrite  -lLLVM-10 && cd /home/jyno/tools/cppinsights/build && /usr/bin/strip -s insights
/usr/bin/ld: cannot find -lclangTooling
/usr/bin/ld: cannot find -lclangASTMatchers
/usr/bin/ld: cannot find -lclangFrontend
/usr/bin/ld: cannot find -lclangDriver
/usr/bin/ld: cannot find -lclangSerialization
/usr/bin/ld: cannot find -lclangParse
/usr/bin/ld: cannot find -lclangSema
/usr/bin/ld: cannot find -lclangAnalysis
/usr/bin/ld: cannot find -lclangEdit
/usr/bin/ld: cannot find -lclangAST
/usr/bin/ld: cannot find -lclangLex
/usr/bin/ld: cannot find -lclangBasic
/usr/bin/ld: cannot find -lclangRewrite
collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.
```

This was an out of clang build run on a Manjaro system:
```
  % cat /etc/lsb-release
DISTRIB_ID=ManjaroLinux
DISTRIB_RELEASE=20.1
DISTRIB_CODENAME=Mikah
DISTRIB_DESCRIPTION="Manjaro Linux"
```

This is an issue similar to one experienced by building [ccls](https://github.com/MaskRay/ccls/wiki/Build#arch-linux) on Arch. I followed the same pattern here by toggling on `CLANG_LINK_CLANG_DYLIB` and `LLVM_LINK_LLVM_DYLIB` (and linking against the same libs `ccls` uses in those cases).

Using the new flags (`DCLANG_LINK_CLANG_DYLIB=on -DLLVM_LINK_LLVM_DYLIB=on -DINSIGHTS_USE_SYSTEM_INCLUDES=off`), I'm now able to get a clean out-of-clang build of `insights`:
```
  % cmake -G"Ninja" -DCLANG_LINK_CLANG_DYLIB=on -DLLVM_LINK_LLVM_DYLIB=on -DINSIGHTS_USE_SYSTEM_INCLUDES=off ../cppinsights
cmake -G"Ninja" -DCLANG_LINK_CLANG_DYLIB=on -DLLVM_LINK_LLVM_DYLIB=on -DINSIGHTS_USE_SYSTEM_INCLUDES=off ../cppinsights
-- The CXX compiler identification is GNU 10.2.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- llvm_config(LLVM_CXXFLAGS)=>-I/usr/include    -fno-exceptions -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS;
-- llvm_config(LLVM_LDFLAGS)=>-L/usr/lib;
-- llvm_config(LLVM_LIBS2)=>-lLLVM-10;
-- llvm_config(LLVM_LIBDIR)=>/usr/lib;
-- llvm_config(LLVM_INCLUDE_DIR)=>/usr/include;
-- llvm_config(LLVM_SYSTEM_LIBS2)=>;
-- llvm_config(LLVM_PACKAGE_VERSION)=>10.0.1;
-- llvm_config(LLVM_INCLUDE_DIR)=>/usr/include;
-- Generating version.h
-- Found clang-tidy: /usr/bin/clang-tidy
-- Could not find the program include-what-you-use
-- Could NOT find Doxygen (missing: DOXYGEN_EXECUTABLE) 
-- Found Python3: /usr/bin/python3.8 (found version "3.8.5") found components: Interpreter 
-- Found Python3: /usr/bin/python3.8. Target tests enabled.
-- 
-- [ Build summary ]
-- CMAKE_GENERATOR       : Ninja
-- CMAKE_EXE_LINKER_FLAGS: 
-- Compiler ID           : GNU
-- Compiler version      : 10.2.0
-- Compiler path         : /usr/bin/c++
-- llvm-config           : /usr/bin/llvm-config
-- Min LLVM major version: 10
-- Install path          : /usr/local
-- Clang resource dir    : 
-- CMAKE_SOURCE_DIR      : /home/jyno/tools/cppinsights-fork/cppinsights
-- CMAKE_BINARY_DIR      : /home/jyno/tools/cppinsights-fork/build
-- Git repo url          : git@github.com:galorojo/cppinsights.git
-- Git commit hash       : 96b7611a6a0b93df6812b8bb027a2e35dbfe01b0
-- Debug                 : OFF
-- Code Coverage         : OFF
-- Static linking        : OFF
-- Strip executable      : ON
-- Elevate includes:     : off
-- clang-tidy            : Off
-- include-what-you-use  : Off
-- 
-- Configuring done
-- Generating done
-- Build files have been written to: /home/jyno/tools/cppinsights-fork/build

  % ninja
ninja
[1/14] Building CXX object docs/CMakeFiles/OptionDocumentationGenerator.dir/OptionDocumentationGenerator.cpp.o
[2/14] Linking CXX executable docs/OptionDocumentationGenerator
[3/14] Building CXX object CMakeFiles/insights.dir/InsightsBase.cpp.o
[4/14] Building CXX object CMakeFiles/insights.dir/DPrint.cpp.o
[5/14] Building CXX object CMakeFiles/insights.dir/OutputFormatHelper.cpp.o
[6/14] Building CXX object CMakeFiles/insights.dir/FunctionDeclHandler.cpp.o
[7/14] Building CXX object CMakeFiles/insights.dir/StaticAssertHandler.cpp.o
[8/14] Building CXX object CMakeFiles/insights.dir/InsightsHelpers.cpp.o
[9/14] Building CXX object CMakeFiles/insights.dir/GlobalVariableHandler.cpp.o
[10/14] Building CXX object CMakeFiles/insights.dir/RecordDeclHandler.cpp.o
[11/14] Building CXX object CMakeFiles/insights.dir/TemplateHandler.cpp.o
[12/14] Building CXX object CMakeFiles/insights.dir/Insights.cpp.o
[13/14] Building CXX object CMakeFiles/insights.dir/CodeGenerator.cpp.o
[14/14] Linking CXX executable insights

```

I also edited the `Readme` with the special instructions to build on Arch. 

**Note:** Due to how `ADDITIONAL_LIBS` is set up for an out-of-clang build, we need `CLANG_LINK_CLANG_DYLIB` and `LLVM_LINK_LLVM_DYLIB` to have the same value, otherwise things break, so I added an error message to make sure miss-matched values are not provided. 
