### PR TITLE
Fixed #349: Name pointer to member variable `MemberVarPtr`.

### DIFF
--- a/CodeGenerator.cpp
+++ b/CodeGenerator.cpp
@@ -809,10 +809,12 @@ void CodeGenerator::InsertArg(const VarDecl* stmt)
         if(InsertVarDecl()) {
             mOutputFormatHelper.Append(GetQualifiers(*stmt));
 
-            if(const auto type = GetDesugarType(stmt->getType());
-               type->isFunctionPointerType() || isa<MemberPointerType>(type.getTypePtrOrNull())) {
-                const auto        lineNo = GetSM(*stmt).getSpellingLineNumber(stmt->getSourceRange().getBegin());
-                const std::string funcPtrName{StrCat("FuncPtr_", lineNo, " ")};
+            const auto type = GetDesugarType(stmt->getType());
+            const bool isMemberPointer{isa<MemberPointerType>(type.getTypePtrOrNull())};
+            if(type->isFunctionPointerType() || isMemberPointer) {
+                const auto        lineNo    = GetSM(*stmt).getSpellingLineNumber(stmt->getSourceRange().getBegin());
+                const auto        ptrPrefix = isMemberPointer ? memberVariablePointerPrefix : functionPointerPrefix;
+                const std::string funcPtrName{StrCat(ptrPrefix, lineNo, " ")};
 
                 mOutputFormatHelper.AppendNewLine("using ", funcPtrName, "= ", GetName(type), ";");
                 mOutputFormatHelper.Append(funcPtrName, GetName(*stmt));

--- a/InsightsStaticStrings.h
+++ b/InsightsStaticStrings.h
@@ -59,4 +59,8 @@ static constexpr const char kwSpaceConstExpr[] = BUILD_WITH_SPACE_BEFORE(KW_CONS
 static constexpr const char kwSpaceVolatile[]  = BUILD_WITH_SPACE_BEFORE(KW_VOLATILE);
 //-----------------------------------------------------------------------------
 
+static constexpr const char memberVariablePointerPrefix[] = "MemberVarPtr_";
+static constexpr const char functionPointerPrefix[]       = "FuncPtr_";
+//-----------------------------------------------------------------------------
+
 #endif /* INSIGHTS_STATIC_STRINGS_H */

--- a/tests/Issue279.expect
+++ b/tests/Issue279.expect
@@ -8,7 +8,7 @@ struct S
 
 int main()
 {
-  using FuncPtr_5 = void (S::*)();
-  FuncPtr_5 p = &S::f;
+  using MemberVarPtr_5 = void (S::*)();
+  MemberVarPtr_5 p = &S::f;
 }
 

--- a/tests/Issue349.cpp
+++ b/tests/Issue349.cpp
@@ -1,0 +1,9 @@
+struct S{
+  int mem;
+};
+
+int main()
+{
+  S s;
+  auto m = &S::mem;
+}

--- a/tests/Issue349.expect
+++ b/tests/Issue349.expect
@@ -1,0 +1,15 @@
+struct S
+{
+  int mem;
+  // inline S() noexcept = default;
+};
+
+
+
+int main()
+{
+  S s = S();
+  using MemberVarPtr_8 = int S::*;
+  MemberVarPtr_8 m = &S::mem;
+}
+

--- a/tests/NullToMemberPointerTest.expect
+++ b/tests/NullToMemberPointerTest.expect
@@ -15,14 +15,14 @@ class NullToMemberPtrTest
 
 int main()
 {
-  using FuncPtr_12 = int NullToMemberPtrTest::*;
-  FuncPtr_12 mMember1 = static_cast<int NullToMemberPtrTest::*>(nullptr);
-  using FuncPtr_14 = int NullToMemberPtrTest::*;
-  FuncPtr_14 mMember2 = static_cast<int NullToMemberPtrTest::*>(0);
-  using FuncPtr_16 = int (NullToMemberPtrTest::*)(int);
-  FuncPtr_16 Func1 = static_cast<int (NullToMemberPtrTest::*)(int)>(nullptr);
-  using FuncPtr_18 = int (NullToMemberPtrTest::*)(int);
-  FuncPtr_18 Func2 = static_cast<int (NullToMemberPtrTest::*)(int)>(0);
+  using MemberVarPtr_12 = int NullToMemberPtrTest::*;
+  MemberVarPtr_12 mMember1 = static_cast<int NullToMemberPtrTest::*>(nullptr);
+  using MemberVarPtr_14 = int NullToMemberPtrTest::*;
+  MemberVarPtr_14 mMember2 = static_cast<int NullToMemberPtrTest::*>(0);
+  using MemberVarPtr_16 = int (NullToMemberPtrTest::*)(int);
+  MemberVarPtr_16 Func1 = static_cast<int (NullToMemberPtrTest::*)(int)>(nullptr);
+  using MemberVarPtr_18 = int (NullToMemberPtrTest::*)(int);
+  MemberVarPtr_18 Func2 = static_cast<int (NullToMemberPtrTest::*)(int)>(0);
 }
 
 


### PR DESCRIPTION
This patch distinguished between a function-pointer and a
member-variable-pointer. A function-pointer is still prefixed with
`FuncPtr`.