### PR TITLE
EvaluateAsFloat() fix return value

### DIFF
--- a/InsightsHelpers.cpp
+++ b/InsightsHelpers.cpp
@@ -331,7 +331,7 @@ const std::string EvaluateAsFloat(const FloatingLiteral& expr)
         str.append(".0");
     }
 
-    return str.str();
+    return std::string(str.str());
 }
 //-----------------------------------------------------------------------------
 


### PR DESCRIPTION
fix err: could not convert ‘str.llvm::SmallString<16>::str()’ from ‘llvm::StringRef’ to ‘const string’