### PR TITLE
Fixed #365: `CXXDeductionGuideDecl` appeared in the middle of a template

### DIFF
--- a/tests/Issue365.cpp
+++ b/tests/Issue365.cpp
@@ -1,0 +1,13 @@
+template<long Len = 128, long BlockSize = 128, class T = wchar_t>
+class String {
+public:
+  bool Format(const wchar_t FormatStr[], ...) { return true; }
+};
+
+void FTest() {
+  double d{};
+
+  String s;
+  s.Format(L"%i", d);
+}
+

--- a/tests/Issue365.expect
+++ b/tests/Issue365.expect
@@ -1,0 +1,39 @@
+template<long Len = 128, long BlockSize = 128, class T = wchar_t>
+class String {
+public:
+  bool Format(const wchar_t FormatStr[], ...) { return true; }
+};
+
+/* First instantiated from: Issue365.cpp:10 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+class String<128, 128, wchar_t>
+{
+  
+  public: 
+  inline bool Format(const wchar_t * FormatStr, ...)
+  {
+    return true;
+  }
+  
+  // inline constexpr String() noexcept = default;
+};
+
+#endif
+
+
+
+/* First instantiated from: Issue365.cpp:10 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+String -> String<128, 128, wchar_t>;
+#endif
+
+void FTest()
+{
+  double d = {};
+  String<128, 128, wchar_t> s = String<128, 128, wchar_t>();
+  s.Format(L"%i", d);
+}
+
+


### PR DESCRIPTION
As `CXXDeductionGuideDecl` are made by the compiler their line/column
information can tell that it appears right in the middle of a primary
template. This fix adds a check whether to trust and use the information
from `CXXDeductionGuideDecl` or the one from the deduced template.