### PR TITLE
Fixed #354: Attribute which appeared after return type was broken.

### DIFF
--- a/FunctionDeclHandler.cpp
+++ b/FunctionDeclHandler.cpp
@@ -73,8 +73,13 @@ void FunctionDeclHandler::run(const MatchFinder::MatchResult& result)
                 // Find the first attribute with a valid source-location
                 for(const auto& attr : funcDecl->attrs()) {
                     if(const auto location = attr->getLocation(); location.isValid()) {
-                        // the -3 are a guess that seems to work
-                        funcRange.setBegin(location.getLocWithOffset(-3));
+
+                        // only use the begin location of the attribute, if it is before the one of the function decl.
+                        if(funcRange.getBegin() > location) {
+                            // the -3 are a guess that seems to work
+                            funcRange.setBegin(location.getLocWithOffset(-3));
+                        }
+
                         return funcRange;
                     }
                 }

--- a/tests/Issue354.cpp
+++ b/tests/Issue354.cpp
@@ -1,0 +1,5 @@
+unsigned __attribute__((const))
+ctz(unsigned x)
+{
+	return 0;
+}

--- a/tests/Issue354.expect
+++ b/tests/Issue354.expect
@@ -1,0 +1,5 @@
+__attribute__((const)) unsigned int ctz(unsigned int x)
+{
+  return 0;
+}
+


### PR DESCRIPTION
The current implementation assumed that attributes always
come before the return-type. However, this is not the case.
This patch uses the attribute location only if it is before
the location of the function declaration.