### PR TITLE
Fixed #277: Consistently show the underlaying type of a binding.

### DIFF
--- a/CodeGenerator.cpp
+++ b/CodeGenerator.cpp
@@ -3775,7 +3775,7 @@ void StructuredBindingsCodeGenerator::InsertArg(const BindingDecl* stmt)
     if(const auto* holdingVar = stmt->getHoldingVar()) {
         // A rvalue reference boils down to just the type. If it is a reference then it is a lvalue reference at this
         // point. Hence we need to strip the &&.
-        type = holdingVar->getType();
+        type = holdingVar->getType().getCanonicalType();
         if(type->isRValueReferenceType()) {
             type = type.getNonReferenceType();
         }

--- a/tests/Issue131.expect
+++ b/tests/Issue131.expect
@@ -4,6 +4,6 @@ std::tuple<int, float> foo();
 
  
 std::tuple<int, float> __foo5 = foo();
-std::tuple_element<0, std::tuple<int, float> >::type a = std::get<0UL>(static_cast<std::tuple<int, float> &&>(__foo5));
-std::tuple_element<1, std::tuple<int, float> >::type b = std::get<1UL>(static_cast<std::tuple<int, float> &&>(__foo5));
+int a = std::get<0UL>(static_cast<std::tuple<int, float> &&>(__foo5));
+float b = std::get<1UL>(static_cast<std::tuple<int, float> &&>(__foo5));
 

--- a/tests/Issue20.expect
+++ b/tests/Issue20.expect
@@ -4,7 +4,7 @@ int main()
 {
   std::map<int, int> map = std::map<int, int, std::less<int>, std::allocator<std::pair<const int, int> > >{std::initializer_list<std::pair<const int, int> >{std::pair<const int, int>{1, 2}}, std::less<int>()};
   std::pair<const int, int> __operator6 = std::pair<const int, int>(map.begin().operator*());
-  std::tuple_element<0, std::pair<const int, int> >::type key = std::get<0UL>(static_cast<std::pair<const int, int> &&>(__operator6));
-  std::tuple_element<1, std::pair<const int, int> >::type value = std::get<1UL>(static_cast<std::pair<const int, int> &&>(__operator6));
+  const int key = std::get<0UL>(static_cast<std::pair<const int, int> &&>(__operator6));
+  int value = std::get<1UL>(static_cast<std::pair<const int, int> &&>(__operator6));
 }
 

--- a/tests/Issue277.cpp
+++ b/tests/Issue277.cpp
@@ -1,0 +1,22 @@
+#include <tuple>
+
+struct Point {
+  	int data[2];
+};
+
+template <std::size_t N>
+constexpr int& get(Point& p) {
+  return p.data[N];
+}
+
+template <typename T> struct type_t { using type = T; };
+
+namespace std {
+  template <> struct tuple_size<Point> : integral_constant<size_t, 2> { };
+  template <size_t N> struct tuple_element<N, Point> : type_t<int> { };
+}
+
+int f(Point p) {
+  auto& [x, y] = p;
+  return x;
+}

--- a/tests/Issue277.expect
+++ b/tests/Issue277.expect
@@ -1,0 +1,70 @@
+#include <tuple>
+
+struct Point
+{
+  int data[2];
+};
+
+
+
+template <std::size_t N>
+constexpr int& get(Point& p) {
+  return p.data[N];
+}
+
+/* First instantiated from: Issue277.cpp:20 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+inline constexpr int & get<0>(Point & p)
+{
+  return p.data[0UL];
+}
+#endif
+
+
+/* First instantiated from: Issue277.cpp:20 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+inline constexpr int & get<1>(Point & p)
+{
+  return p.data[1UL];
+}
+#endif
+
+
+template <typename T> struct type_t { using type = T; };
+
+/* First instantiated from: Issue277.cpp:16 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+struct type_t<int>
+{
+  using type = int;
+};
+
+#endif
+
+
+namespace std
+{
+  template<>
+  struct tuple_size<Point> : public integral_constant<unsigned long, 2>
+  {
+  };
+  
+  template<size_t N>
+  struct tuple_element<N, Point> : public type_t<int>
+  {
+  };
+  
+  
+}
+
+int f(Point p)
+{
+  Point & __p20 = p;
+  int & x = get<0UL>(__p20);
+  int & y = get<1UL>(__p20);
+  return x;
+}
+

--- a/tests/Issue277_2.cpp
+++ b/tests/Issue277_2.cpp
@@ -1,0 +1,21 @@
+#include <tuple>
+
+struct Point {
+  	int data[2];
+};
+
+template <std::size_t N>
+constexpr int& get(Point& p) {
+  return p.data[N];
+}
+
+namespace std {
+  template <> struct tuple_size<Point> : integral_constant<size_t, 2> { };
+  template <size_t N> struct tuple_element<N, Point> : tuple_element<N-1, Point> { };
+  template <> struct tuple_element<0, Point> { using type = int; };
+}
+
+int f(Point p) {
+  auto& [x, y] = p;
+  return x;
+}

--- a/tests/Issue277_2.expect
+++ b/tests/Issue277_2.expect
@@ -1,0 +1,63 @@
+#include <tuple>
+
+struct Point
+{
+  int data[2];
+};
+
+
+
+template <std::size_t N>
+constexpr int& get(Point& p) {
+  return p.data[N];
+}
+
+/* First instantiated from: Issue277_2.cpp:19 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+inline constexpr int & get<0>(Point & p)
+{
+  return p.data[0UL];
+}
+#endif
+
+
+/* First instantiated from: Issue277_2.cpp:19 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+inline constexpr int & get<1>(Point & p)
+{
+  return p.data[1UL];
+}
+#endif
+
+
+namespace std
+{
+  template<>
+  struct tuple_size<Point> : public integral_constant<unsigned long, 2>
+  {
+  };
+  
+  template<size_t N>
+  struct tuple_element<N, Point> : public tuple_element<N - 1, Point>
+  {
+  };
+  
+  template<>
+  struct tuple_element<0, Point>
+  {
+    using type = int;
+  };
+  
+  
+}
+
+int f(Point p)
+{
+  Point & __p19 = p;
+  int & x = get<0UL>(__p19);
+  int & y = get<1UL>(__p19);
+  return x;
+}
+

--- a/tests/Issue381.expect
+++ b/tests/Issue381.expect
@@ -4,7 +4,7 @@ int main()
 {
   std::tuple<int, int> tup = std::tuple<int, int>{2, 5};
   std::tuple<int, int> __tup6 = std::tuple<int, int>(tup);
-  std::tuple_element<0, std::tuple<int, int> >::type a = std::get<0UL>(static_cast<std::tuple<int, int> &&>(__tup6));
-  std::tuple_element<1, std::tuple<int, int> >::type b = std::get<1UL>(static_cast<std::tuple<int, int> &&>(__tup6));
+  int a = std::get<0UL>(static_cast<std::tuple<int, int> &&>(__tup6));
+  int b = std::get<1UL>(static_cast<std::tuple<int, int> &&>(__tup6));
 }
 

--- a/tests/StructuredBindingsHandler3Test.expect
+++ b/tests/StructuredBindingsHandler3Test.expect
@@ -105,15 +105,15 @@ namespace constant
 {
   Q q = Q();
   Q __q17 = Q(q);
-  std::tuple_element<0, Q>::type a = get<0UL>(static_cast<Q &&>(__q17));
-  std::tuple_element<1, Q>::type b = get<1UL>(static_cast<Q &&>(__q17));
-  std::tuple_element<2, Q>::type c = get<2UL>(static_cast<Q &&>(__q17));
+  int a = get<0UL>(static_cast<Q &&>(__q17));
+  int b = get<1UL>(static_cast<Q &&>(__q17));
+  int c = get<2UL>(static_cast<Q &&>(__q17));
   inline constexpr bool f()
   {
     Q __q19 = Q(q);
-    std::tuple_element<0, Q>::type a = get<0UL>(static_cast<Q &&>(__q19));
-    std::tuple_element<1, Q>::type b = get<1UL>(static_cast<Q &&>(__q19));
-    std::tuple_element<2, Q>::type c = get<2UL>(static_cast<Q &&>(__q19));
+    int a = get<0UL>(static_cast<Q &&>(__q19));
+    int b = get<1UL>(static_cast<Q &&>(__q19));
+    int c = get<2UL>(static_cast<Q &&>(__q19));
     return ((a == 0) && (b == 1)) && (c == 4);
   }
   inline constexpr int g()
@@ -121,9 +121,9 @@ namespace constant
     int * p = nullptr;
     {
       Q __q26 = Q(q);
-      std::tuple_element<0, Q>::type a = get<0UL>(static_cast<Q &&>(__q26));
-      std::tuple_element<1, Q>::type b = get<1UL>(static_cast<Q &&>(__q26));
-      std::tuple_element<2, Q>::type c = get<2UL>(static_cast<Q &&>(__q26));
+      int a = get<0UL>(static_cast<Q &&>(__q26));
+      int b = get<1UL>(static_cast<Q &&>(__q26));
+      int c = get<2UL>(static_cast<Q &&>(__q26));
       p = &c;
     };
     return *p;

--- a/tests/StructuredBindingsHandler5Test.expect
+++ b/tests/StructuredBindingsHandler5Test.expect
@@ -155,8 +155,8 @@ int main()
 {
   Point p = Point{1, 2};
   Point & __p64 = p;
-  std::tuple_element<0, Point>::type & x = __p64.get<0>();
-  std::tuple_element<1, Point>::type y = __p64.get<1>();
+  double & x = __p64.get<0>();
+  double y = __p64.get<1>();
   printf("x:%lf y:%lf\n", p.GetX(), p.GetY());
   ++x;
   ++y;
@@ -164,7 +164,7 @@ int main()
   printf("x:%lf y:%lf\n", p.GetX(), p.GetY());
   constexpr const Point p2 = Point{3, 4};
   const Point & __p273 = p2;
-  std::tuple_element<0, const Point>::type & x2 = __p273.get<0>();
-  std::tuple_element<1, const Point>::type y2 = static_cast<const double>(__p273.get<1>());
+  const double & x2 = __p273.get<0>();
+  const double y2 = static_cast<const double>(__p273.get<1>());
 }
 

--- a/tests/StructuredBindingsHandler6Test.expect
+++ b/tests/StructuredBindingsHandler6Test.expect
@@ -117,8 +117,8 @@ int main()
 {
   Point p = Point{1, 2};
   Point __p58 = Point(p);
-  std::tuple_element<0, Point>::type x = static_cast<const Point &&>(__p58).get<0>();
-  std::tuple_element<1, Point>::type y = static_cast<const Point &&>(__p58).get<1>();
+  double x = static_cast<const Point &&>(__p58).get<0>();
+  double y = static_cast<const Point &&>(__p58).get<1>();
   printf("x:%lf y:%lf\n", p.GetX(), p.GetY());
   printf("x:%lf y:%lf\n", x, y);
   char ar[2] = {7, 8};
@@ -141,12 +141,12 @@ int main()
   const char a19 = __aa75[1];
   std::tuple<int, char, double> muple = std::make_tuple(1, 'a', 2.2999999999999998);
   std::tuple<int, char, double> & __muple80 = muple;
-  std::tuple_element<0, std::tuple<int, char, double> >::type & i = std::get<0UL>(__muple80);
-  std::tuple_element<1, std::tuple<int, char, double> >::type & c = std::get<1UL>(__muple80);
-  std::tuple_element<2, std::tuple<int, char, double> >::type & d = std::get<2UL>(__muple80);
+  int & i = std::get<0UL>(__muple80);
+  char & c = std::get<1UL>(__muple80);
+  double & d = std::get<2UL>(__muple80);
   std::tuple<int, char, double> __muple82 = std::tuple<int, char, double>(muple);
-  std::tuple_element<0, std::tuple<int, char, double> >::type ii = std::get<0UL>(static_cast<std::tuple<int, char, double> &&>(__muple82));
-  std::tuple_element<1, std::tuple<int, char, double> >::type cc = std::get<1UL>(static_cast<std::tuple<int, char, double> &&>(__muple82));
-  std::tuple_element<2, std::tuple<int, char, double> >::type dd = std::get<2UL>(static_cast<std::tuple<int, char, double> &&>(__muple82));
+  int ii = std::get<0UL>(static_cast<std::tuple<int, char, double> &&>(__muple82));
+  char cc = std::get<1UL>(static_cast<std::tuple<int, char, double> &&>(__muple82));
+  double dd = std::get<2UL>(static_cast<std::tuple<int, char, double> &&>(__muple82));
 }
 

--- a/tests/StructuredBindingsHandler9Test.expect
+++ b/tests/StructuredBindingsHandler9Test.expect
@@ -4,12 +4,12 @@ std::tuple<int, float> foo = std::tuple<int, float>();
 
  
 std::tuple<int, float> __foo5 = std::tuple<int, float>(foo);
-std::tuple_element<0, std::tuple<int, float> >::type a = std::get<0UL>(static_cast<std::tuple<int, float> &&>(__foo5));
-std::tuple_element<1, std::tuple<int, float> >::type b = std::get<1UL>(static_cast<std::tuple<int, float> &&>(__foo5));
+int a = std::get<0UL>(static_cast<std::tuple<int, float> &&>(__foo5));
+float b = std::get<1UL>(static_cast<std::tuple<int, float> &&>(__foo5));
 
 std::tuple<int, float> & __foo6 = foo;
-std::tuple_element<0, std::tuple<int, float> >::type & ra = std::get<0UL>(__foo6);
-std::tuple_element<1, std::tuple<int, float> >::type & rb = std::get<1UL>(__foo6);
+int & ra = std::get<0UL>(__foo6);
+float & rb = std::get<1UL>(__foo6);
 
 
 
@@ -33,6 +33,6 @@ std::tuple<int, float> Func();
 
  
 const std::tuple<int, float> & __Func18 = Func();
-std::tuple_element<0, const std::tuple<int, float> >::type & fa = std::get<0UL>(__Func18);
-std::tuple_element<1, const std::tuple<int, float> >::type & fb = std::get<1UL>(__Func18);
+const int & fa = std::get<0UL>(__Func18);
+const float & fb = std::get<1UL>(__Func18);
 

--- a/tests/TupeInRangeBasedForTest.expect
+++ b/tests/TupeInRangeBasedForTest.expect
@@ -30,7 +30,7 @@ int main()
     {
       std::tuple<std::basic_string<char>, int> __operator15 = std::tuple<std::basic_string<char>, int>(__begin1.operator*());
       std::basic_string<char> s = std::get<0UL>(static_cast<std::tuple<std::basic_string<char>, int> &&>(__operator15));
-      std::tuple_element<1, std::tuple<std::basic_string<char>, int> >::type n = std::get<1UL>(static_cast<std::tuple<std::basic_string<char>, int> &&>(__operator15));
+      int n = std::get<1UL>(static_cast<std::tuple<std::basic_string<char>, int> &&>(__operator15));
       printf("c=%s, n=%d\n", s.c_str(), n);
     }
     


### PR DESCRIPTION
In structured bindings, when we have a tuple-like type, show the
underlaying type behind `std::tuple_element<>::type`. Most of the time
this is what is the most interesting.