### PR TITLE
Fixed #391: Placement of `final` was wrong for a class template.

### DIFF
--- a/CodeGenerator.cpp
+++ b/CodeGenerator.cpp
@@ -2651,6 +2651,10 @@ void CodeGenerator::InsertArg(const CXXRecordDecl* stmt)
 
     mOutputFormatHelper.Append(GetName(*stmt));
 
+    if(classTemplateSpecializationDecl) {
+        InsertTemplateArgs(*classTemplateSpecializationDecl);
+    }
+
     if(stmt->hasAttr<FinalAttr>()) {
         mOutputFormatHelper.Append(" final");
     }
@@ -2659,10 +2663,6 @@ void CodeGenerator::InsertArg(const CXXRecordDecl* stmt)
     if(not stmt->hasDefinition() || not stmt->isCompleteDefinition()) {
         mOutputFormatHelper.AppendSemiNewLine();
         return;
-    }
-
-    if(classTemplateSpecializationDecl) {
-        InsertTemplateArgs(*classTemplateSpecializationDecl);
     }
 
     if(stmt->getNumBases()) {

--- a/InsightsHelpers.cpp
+++ b/InsightsHelpers.cpp
@@ -1021,6 +1021,9 @@ std::string GetTypeNameAsParameter(const QualType& t, const std::string& varName
             typeName += StrCat(" ", varName);
         }
 
+    } else if(isa<MemberPointerType>(t)) {
+        InsertAfter(typeName, "::*", varName);
+
     } else if(isPointerToArray) {
         if(Contains(typeName, "(*")) {
             InsertAfter(typeName, "(*", varName);

--- a/tests/Final2Test.cpp
+++ b/tests/Final2Test.cpp
@@ -1,0 +1,11 @@
+template<typename T>
+class FinalTest final
+{
+};
+
+
+int main()
+{
+    FinalTest<int> a{};
+}
+

--- a/tests/Final2Test.expect
+++ b/tests/Final2Test.expect
@@ -1,0 +1,22 @@
+template<typename T>
+class FinalTest final
+{
+};
+
+/* First instantiated from: Final2Test.cpp:9 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+class FinalTest<int> final
+{
+};
+
+#endif
+
+
+
+int main()
+{
+  FinalTest<int> a = {};
+}
+
+

--- a/tests/Issue374.expect
+++ b/tests/Issue374.expect
@@ -2,8 +2,8 @@ struct S;
 
 struct T
 {
-  int S::* s_mptr;
-  int T::* t_mptr;
+  int S::*s_mptr;
+  int T::*t_mptr;
   using MemberVarPtr_7 = int T::*;
   static MemberVarPtr_7 static_mptr;
   template<int S::* >
@@ -16,12 +16,12 @@ struct T
   void f();
   struct N
   {
-    int S::* s_mptr;
-    int T::* t_mptr;
-    int N::* n_mptr;
+    int S::*s_mptr;
+    int T::*t_mptr;
+    int N::*n_mptr;
   };
   
-  int N::* n_mptr;
+  int N::*n_mptr;
 };
 
 

--- a/tests/Issue391.cpp
+++ b/tests/Issue391.cpp
@@ -1,0 +1,101 @@
+// cmdline:-std=c++2a
+#include <functional>
+#include <iostream>
+
+namespace tnt
+{
+    template <typename T>
+    [[nodiscard]] constexpr std::string_view type_name() noexcept
+    {
+        // thx Boost.UT authors
+        // https://github.com/boost-ext/ut/blob/3b05dca6a629497910cf8e92aebcaead0124c8b4/include/boost/ut.hpp#L228
+#if defined(_MSC_VER) and not defined(__clang__)
+        return {__FUNCSIG__ + 89, sizeof(__FUNCSIG__) - 106};
+#elif defined(__clang__)
+        return {__PRETTY_FUNCTION__ + 39, sizeof(__PRETTY_FUNCTION__) - 41};
+#elif defined(__GNUC__)
+        return {__PRETTY_FUNCTION__ + 54, sizeof(__PRETTY_FUNCTION__) - 105};
+#endif
+    }
+
+    template <auto A>
+    [[nodiscard]] constexpr std::string_view value_name() noexcept
+    {
+        // thx Boost.UT authors
+        // https://github.com/boost-ext/ut/blob/3b05dca6a629497910cf8e92aebcaead0124c8b4/include/boost/ut.hpp#L228
+#if defined(_MSC_VER) and not defined(__clang__)
+        return {__FUNCSIG__ + 89, sizeof(__FUNCSIG__) - 106};
+#elif defined(__clang__)
+        return {__PRETTY_FUNCTION__ + 40, sizeof(__PRETTY_FUNCTION__) - 42};
+#elif defined(__GNUC__)
+        return {__PRETTY_FUNCTION__ + 60, sizeof(__PRETTY_FUNCTION__) - 111};
+#endif
+    }
+
+    template <typename>
+    struct wrapper;
+
+    template <typename T>
+    struct printer final
+    {
+        explicit constexpr printer(T const& ref) noexcept
+            : data{std::addressof(ref)} {}
+
+        printer(T const&&) = delete;
+
+        template <typename R, typename... Args>
+        void operator()(std::string_view name, R (T::*ptr)(Args...))
+        {
+          	std::cout << "\t" << type_name<R>() << ' ' << name << " = " << std::invoke(ptr, data) << ";\n";
+        }
+
+        template <typename R>
+        void operator()(std::string_view name, R T::*ptr)
+        {
+          	std::cout << "\t" << type_name<R>() << ' ' << name << " = " << std::invoke(ptr, data) << ";\n";
+        }
+
+    private:
+        const T* data;
+    };
+
+    template <typename T>
+        requires requires { &tnt::wrapper<T>::template operator()<printer<T>>; }
+    struct serializer final
+    {
+        template <typename Vis>
+        static constexpr void get_visit(Vis &&vis)
+        {
+            wrap(std::forward<Vis>(vis));
+        }
+
+        static constexpr wrapper<T> wrap;
+    };
+}
+
+struct my_type final
+{
+    int a;
+    std::string_view b;
+};
+
+template <>
+struct tnt::wrapper<my_type> final
+{
+    template <typename Vis>
+    constexpr void operator ()(Vis &&vis) const
+    {
+        vis("a", &my_type::a);
+        vis("b", &my_type::b);
+    }
+};
+
+int main()
+{
+    constexpr my_type t{.a = 10, .b = "42"};
+  	std::cout << "struct " << tnt::type_name<my_type>() << " "
+      << (std::is_final_v<my_type> ? "final" : "") << "\n{\n";
+    tnt::printer<my_type> p{t};
+    tnt::serializer<my_type>::get_visit(p);
+	std::cout << "};\n";
+}

--- a/tests/Issue391.expect
+++ b/tests/Issue391.expect
@@ -1,0 +1,194 @@
+// cmdline:-std=c++2a
+#include <functional>
+#include <iostream>
+
+namespace tnt
+{
+  template<typename T>
+  [[nodiscard("")]] inline constexpr std::basic_string_view<char, std::char_traits<char> > type_name() noexcept
+  {
+    return {__PRETTY_FUNCTION__ + 39, sizeof(__PRETTY_FUNCTION__) - 41};
+  }
+  
+  /* First instantiated from: Issue391.cpp:96 */
+  #ifdef INSIGHTS_USE_TEMPLATE
+  template<>
+  [[nodiscard("")]] inline constexpr std::basic_string_view<char, std::char_traits<char> > type_name<my_type>() noexcept
+  {
+    return std::basic_string_view<char, std::char_traits<char> >{"std::string_view tnt::type_name() [T = my_type]" + 39, sizeof("std::string_view tnt::type_name() [T = my_type]") - 41};
+  }
+  #endif
+  
+  
+  /* First instantiated from: Issue391.cpp:55 */
+  #ifdef INSIGHTS_USE_TEMPLATE
+  template<>
+  [[nodiscard("")]] inline constexpr std::basic_string_view<char, std::char_traits<char> > type_name<int>() noexcept
+  {
+    return std::basic_string_view<char, std::char_traits<char> >{"std::string_view tnt::type_name() [T = int]" + 39, sizeof("std::string_view tnt::type_name() [T = int]") - 41};
+  }
+  #endif
+  
+  
+  /* First instantiated from: Issue391.cpp:55 */
+  #ifdef INSIGHTS_USE_TEMPLATE
+  template<>
+  [[nodiscard("")]] inline constexpr std::basic_string_view<char, std::char_traits<char> > type_name<std::basic_string_view<char, std::char_traits<char> > >() noexcept
+  {
+    return std::basic_string_view<char, std::char_traits<char> >{"std::string_view tnt::type_name() [T = std::__1::basic_string_view<char, std::__1::char_traits<char> >]" + 39, sizeof("std::string_view tnt::type_name() [T = std::__1::basic_string_view<char, std::__1::char_traits<char> >]") - 41};
+  }
+  #endif
+  
+  template<auto A>
+  [[nodiscard("")]] inline constexpr std::basic_string_view<char, std::char_traits<char> > value_name() noexcept
+  {
+    return {__PRETTY_FUNCTION__ + 40, sizeof(__PRETTY_FUNCTION__) - 42};
+  }
+  template<typename type_parameter_0_0>
+  struct wrapper;
+  template<typename T>
+  struct printer final
+  {
+    inline explicit constexpr printer(const T & ref) noexcept
+    : data{std::addressof(ref)}
+    {
+    }
+    
+    // inline printer(const T &&) = delete;
+    template<typename R, typename ... Args>
+    inline void operator()(std::basic_string_view<char, std::char_traits<char> > name, R (T::*ptr)(Args...))
+    {
+      (((((std::operator<<(std::cout, "\t") << type_name<R>()) << ' ') << name) << " = ") << std::invoke(ptr, this->data)) << ";\n";
+    }
+    template<typename R>
+    inline void operator()(std::basic_string_view<char, std::char_traits<char> > name, R T::*ptr)
+    {
+      (((((std::operator<<(std::cout, "\t") << type_name<R>()) << ' ') << name) << " = ") << std::invoke(ptr, this->data)) << ";\n";
+    }
+    
+    private: 
+    const T * data;
+  };
+  
+  /* First instantiated from: Issue391.cpp:98 */
+  #ifdef INSIGHTS_USE_TEMPLATE
+  template<>
+  struct printer<my_type> final
+  {
+    inline explicit constexpr printer(const my_type & ref) noexcept
+    : data{std::addressof(ref)}
+    {
+    }
+    
+    // inline printer(const my_type &&) = delete;
+    template<typename R, typename ... Args>
+    inline void operator()(std::basic_string_view<char, std::char_traits<char> > name, R (my_type::*ptr)(Args...));
+    template<typename R>
+    inline void operator()(std::basic_string_view<char, std::char_traits<char> > name, R my_type::*ptr);
+    
+    /* First instantiated from: Issue391.cpp:88 */
+    #ifdef INSIGHTS_USE_TEMPLATE
+    template<>
+    inline void operator()<int>(std::basic_string_view<char, std::char_traits<char> > name, int my_type::*ptr)
+    {
+      std::operator<<(std::operator<<(std::operator<<(std::operator<<(std::operator<<(std::operator<<(std::cout, "\t"), type_name<int>()), ' '), std::basic_string_view<char, std::char_traits<char> >(name)), " = ").operator<<(std::invoke(ptr, this->data)), ";\n");
+    }
+    #endif
+    
+    
+    /* First instantiated from: Issue391.cpp:89 */
+    #ifdef INSIGHTS_USE_TEMPLATE
+    template<>
+    inline void operator()<std::basic_string_view<char, std::char_traits<char> > >(std::basic_string_view<char, std::char_traits<char> > name, std::basic_string_view<char, std::char_traits<char> > my_type::*ptr)
+    {
+      std::operator<<(std::operator<<(std::operator<<(std::operator<<(std::operator<<(std::operator<<(std::operator<<(std::cout, "\t"), type_name<std::basic_string_view<char, std::char_traits<char> > >()), ' '), std::basic_string_view<char, std::char_traits<char> >(name)), " = "), std::basic_string_view<char, std::char_traits<char> >(std::invoke(ptr, this->data))), ";\n");
+    }
+    #endif
+    
+    
+    private: 
+    const my_type * data;
+    public: 
+  };
+  
+  #endif
+  template<typename T>
+  requires requires{
+    &wrapper<T>::template operator()<printer<T> >;
+  }
+  struct serializer final
+  {
+    template<typename Vis>
+    static inline constexpr void get_visit(Vis && vis)
+    {
+      wrap(std::forward<Vis>(vis));
+    }
+    inline static constexpr const wrapper<T> wrap;
+  };
+  
+  /* First instantiated from: Issue391.cpp:99 */
+  #ifdef INSIGHTS_USE_TEMPLATE
+  template<>
+  struct serializer<my_type> final
+  {
+    template<typename Vis>
+    static inline constexpr void get_visit(Vis && vis);
+    
+    /* First instantiated from: Issue391.cpp:99 */
+    #ifdef INSIGHTS_USE_TEMPLATE
+    template<>
+    static inline constexpr void get_visit<printer<my_type> &>(printer<my_type> & vis)
+    {
+      wrap.operator()(std::forward<printer<my_type> &>(vis));
+    }
+    #endif
+    
+    inline static constexpr const wrapper<my_type> wrap = wrapper<my_type>();
+  };
+  
+  #endif
+  
+}
+
+struct my_type final
+{
+  int a;
+  std::basic_string_view<char, std::char_traits<char> > b;
+};
+
+
+
+template<>
+struct tnt::wrapper<my_type> final
+{
+  template<typename Vis>
+  inline constexpr void operator()(Vis && vis) const
+  {
+    vis("a", &my_type::a);
+    vis("b", &my_type::b);
+  }
+  
+  /* First instantiated from: Issue391.cpp:69 */
+  #ifdef INSIGHTS_USE_TEMPLATE
+  template<>
+  inline constexpr void operator()<tnt::printer<my_type> &>(tnt::printer<my_type> & vis) const
+  {
+    vis.operator()(std::basic_string_view<char, std::char_traits<char> >("a"), &my_type::a);
+    vis.operator()(std::basic_string_view<char, std::char_traits<char> >("b"), &my_type::b);
+  }
+  #endif
+  
+  // inline constexpr tnt::wrapper() noexcept = default;
+};
+
+
+
+int main()
+{
+  constexpr const my_type t = {10, std::basic_string_view<char, std::char_traits<char> >("42")};
+  std::operator<<(std::operator<<(std::operator<<(std::operator<<(std::operator<<(std::cout, "struct "), tnt::type_name<my_type>()), " "), (std::is_final_v<my_type> ? "final" : "")), "\n{\n");
+  tnt::printer<my_type> p = tnt::printer<my_type>{t};
+  tnt::serializer<my_type>::get_visit(p);
+  std::operator<<(std::cout, "};\n");
+}
+

--- a/tests/MemberPointerTest.cpp
+++ b/tests/MemberPointerTest.cpp
@@ -1,0 +1,24 @@
+// cmdline:-std=c++11
+
+#define INSIGHTS_USE_TEMPLATE
+
+struct Other {
+    double Callback(int, double) { return 3.14; }
+};
+
+
+template<typename T>
+struct Test
+{
+    template <typename R, typename... Args>
+    void fun(R (T::*ptr)(Args...))
+    {
+    }    
+};
+
+int main()
+{
+    Test<Other> t{};
+
+    t.fun(&Other::Callback);
+}

--- a/tests/MemberPointerTest.expect
+++ b/tests/MemberPointerTest.expect
@@ -1,0 +1,52 @@
+// cmdline:-std=c++11
+
+#define INSIGHTS_USE_TEMPLATE
+
+struct Other
+{
+  inline double Callback(int, double)
+  {
+    return 3.1400000000000001;
+  }
+  
+};
+
+
+
+
+template<typename T>
+struct Test
+{
+    template <typename R, typename... Args>
+    void fun(R (T::*ptr)(Args...))
+    {
+    }    
+};
+
+/* First instantiated from: MemberPointerTest.cpp:21 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+struct Test<Other>
+{
+  template<typename R, typename ... Args>
+  inline void fun(R (Other::*ptr)(Args...));
+  
+  /* First instantiated from: MemberPointerTest.cpp:23 */
+  #ifdef INSIGHTS_USE_TEMPLATE
+  template<>
+  inline void fun<double, int, double>(double (Other::*ptr)(int, double))
+  {
+  }
+  #endif
+  
+};
+
+#endif
+
+
+int main()
+{
+  Test<Other> t = {};
+  t.fun<double, int, double>(&Other::Callback);
+}
+

--- a/tests/conceptsConstraintsTest.cpp
+++ b/tests/conceptsConstraintsTest.cpp
@@ -1,4 +1,6 @@
 // cmdline:-std=c++2a
+#define INSIGHTS_USE_TEMPLATE
+
 namespace Constraints {
     // N4861: [temp.constr.op]
     template<typename T>

--- a/tests/conceptsConstraintsTest.expect
+++ b/tests/conceptsConstraintsTest.expect
@@ -1,4 +1,6 @@
 // cmdline:-std=c++2a
+#define INSIGHTS_USE_TEMPLATE
+
 namespace Constraints
 {
   template<typename T>
@@ -7,7 +9,7 @@ namespace Constraints
   {
   }
   
-  /* First instantiated from: conceptsConstraintsTest.cpp:24 */
+  /* First instantiated from: conceptsConstraintsTest.cpp:26 */
   #ifdef INSIGHTS_USE_TEMPLATE
   template<>
   void f<int>(int)
@@ -27,14 +29,14 @@ namespace Constraints
   struct WrapN;
   #ifdef INSIGHTS_USE_TEMPLATE
   template<>
-  struct WrapN;
+  struct WrapN<1>;
   #endif
   template<unsigned int N>
   using AddOneTy = WrapN<N + 1>;
   template<unsigned int M>
   void g(AddOneTy<2 * M> *);
   
-  /* First instantiated from: conceptsConstraintsTest.cpp:18 */
+  /* First instantiated from: conceptsConstraintsTest.cpp:20 */
   #ifdef INSIGHTS_USE_TEMPLATE
   template<>
   void g<0>(WrapN<1> *);


### PR DESCRIPTION
Aside from fixing the position of `final` in a class template this patch
corrects the transformation of a member-pointer, which was also invalid.