### PR TITLE
Fixed #400: Show value of a `ConstantExpr` instead of the subexpr in

### DIFF
--- a/CodeGenerator.cpp
+++ b/CodeGenerator.cpp
@@ -1579,7 +1579,15 @@ void CodeGenerator::InsertArg(const IfStmt* stmt)
 
     mOutputFormatHelper.Append("if", cexpr);
 
-    WrapInParens([&]() { InsertArg(stmt->getCond()); }, AddSpaceAtTheEnd::Yes);
+    WrapInParens(
+        [&]() {
+            mShowConstantExprValue = ShowConstantExprValue::Yes;
+
+            InsertArg(stmt->getCond());
+
+            mShowConstantExprValue = ShowConstantExprValue::No;
+        },
+        AddSpaceAtTheEnd::Yes);
 
     WrapInCompoundIfNeeded(stmt->getThen(), AddNewLineAfter::No);
 
@@ -2086,6 +2094,13 @@ void CodeGenerator::InsertArg(const CXXThrowExpr* stmt)
 
 void CodeGenerator::InsertArg(const ConstantExpr* stmt)
 {
+    if((ShowConstantExprValue::Yes == mShowConstantExprValue) && stmt->hasAPValueResult()) {
+        if(const auto value = stmt->getAPValueResult(); value.isInt()) {
+            mOutputFormatHelper.Append(value.getInt());
+            return;
+        }
+    }
+
     InsertArg(stmt->getSubExpr());
 }
 //-----------------------------------------------------------------------------

--- a/CodeGenerator.h
+++ b/CodeGenerator.h
@@ -333,7 +333,9 @@ protected:
     STRONG_BOOL(SkipVarDecl);
     STRONG_BOOL(UseCommaInsteadOfSemi);
     STRONG_BOOL(NoEmptyInitList);
+    STRONG_BOOL(ShowConstantExprValue);
 
+    ShowConstantExprValue mShowConstantExprValue{ShowConstantExprValue::No};
     SkipVarDecl           mSkipVarDecl;
     UseCommaInsteadOfSemi mUseCommaInsteadOfSemi;
     NoEmptyInitList       mNoEmptyInitList{

--- a/tests/ClassOpInTemplateFunctionTest.expect
+++ b/tests/ClassOpInTemplateFunctionTest.expect
@@ -41,7 +41,7 @@ class Foo
   template<>
   inline constexpr int get<1>() const noexcept
   {
-    if constexpr(1 == 1) {
+    if constexpr(true) {
       return this->mX;
     } 
     

--- a/tests/Issue199.expect
+++ b/tests/Issue199.expect
@@ -10,7 +10,7 @@ void f(U, T... rest)
 template<>
 void f<int, int>(int, int __rest1)
 {
-  if constexpr(1 != 0) {
+  if constexpr(true) {
     f(__rest1);
   } 
   
@@ -23,7 +23,7 @@ void f<int, int>(int, int __rest1)
 template<>
 void f<int>(int)
 {
-  if constexpr(0 != 0) {
+  if constexpr(false) {
   } 
   
 }

--- a/tests/Issue200.expect
+++ b/tests/Issue200.expect
@@ -10,7 +10,7 @@ void f(U, T... rest)
 template<>
 void f<int, int>(int, int __rest1)
 {
-  if constexpr(1 != 0) {
+  if constexpr(true) {
     f(__rest1);
   } 
   

--- a/tests/Issue400.cpp
+++ b/tests/Issue400.cpp
@@ -1,0 +1,18 @@
+// cmdline:-std=c++20
+
+#include <concepts>
+
+auto foo(auto x)
+{
+   if constexpr (std::same_as<int, decltype(x)>)
+   {
+      return 1;
+   }
+   return 2;
+}
+
+int main()
+{
+	foo(1);
+    foo(1.0);
+}

--- a/tests/Issue400.expect
+++ b/tests/Issue400.expect
@@ -1,0 +1,44 @@
+// cmdline:-std=c++20
+
+#include <concepts>
+
+auto foo(auto x)
+{
+   if constexpr (std::same_as<int, decltype(x)>)
+   {
+      return 1;
+   }
+   return 2;
+}
+
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+int foo<int>(int x)
+{
+  if constexpr(true) {
+    return 1;
+  } 
+  
+  return 2;
+}
+#endif
+
+
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+int foo<double>(double x)
+{
+  if constexpr(false) {
+  } 
+  
+  return 2;
+}
+#endif
+
+
+int main()
+{
+  foo(1);
+  foo(1.0);
+}
+

--- a/tests/NonTypeTemplateParameterPackTest.expect
+++ b/tests/NonTypeTemplateParameterPackTest.expect
@@ -18,7 +18,7 @@ class Test
   template<>
   inline int sum<1, 5, 7>()
   {
-    if constexpr(2 > 0) {
+    if constexpr(true) {
       return 1 + this->sum<5>();
     } 
     
@@ -31,7 +31,7 @@ class Test
   template<>
   inline int sum<5, 7>()
   {
-    if constexpr(1 > 0) {
+    if constexpr(true) {
       return 5 + this->sum<7>();
     } 
     
@@ -44,7 +44,7 @@ class Test
   template<>
   inline int sum<7>()
   {
-    if constexpr(0 > 0) {
+    if constexpr(false) {
     } else /* constexpr */ {
       return 7;
     } 
@@ -68,7 +68,7 @@ class Test
   template<>
   inline int summ<int, int, int>(int && i, int && __rest1, int && __rest2)
   {
-    if constexpr(2 > 0) {
+    if constexpr(true) {
       return i + this->summ<int &, int &>(__rest1, __rest2);
     } 
     
@@ -81,7 +81,7 @@ class Test
   template<>
   inline int summ<int &, int &>(int & i, int & rest)
   {
-    if constexpr(1 > 0) {
+    if constexpr(true) {
       return i + this->summ<int &>(rest);
     } 
     
@@ -94,7 +94,7 @@ class Test
   template<>
   inline int summ<int &>(int & i)
   {
-    if constexpr(0 > 0) {
+    if constexpr(false) {
     } else /* constexpr */ {
       return i;
     } 

--- a/tests/StructuredBindingsHandler5Test.expect
+++ b/tests/StructuredBindingsHandler5Test.expect
@@ -74,9 +74,9 @@ class Point
   template<>
   inline constexpr double & get<0>() noexcept
   {
-    if constexpr(0UL == 1) {
+    if constexpr(false) {
     } else /* constexpr */ {
-      if constexpr(0UL == 0) {
+      if constexpr(true) {
         return (this->mY);
       } 
       
@@ -90,7 +90,7 @@ class Point
   template<>
   inline constexpr double get<1>() noexcept
   {
-    if constexpr(1UL == 1) {
+    if constexpr(true) {
       return this->GetX();
     } 
     
@@ -115,9 +115,9 @@ class Point
   template<>
   inline constexpr const double & get<0>() const noexcept
   {
-    if constexpr(0UL == 1) {
+    if constexpr(false) {
     } else /* constexpr */ {
-      if constexpr(0UL == 0) {
+      if constexpr(true) {
         return (this->mY);
       } 
       
@@ -131,7 +131,7 @@ class Point
   template<>
   inline constexpr double get<1>() const noexcept
   {
-    if constexpr(1UL == 1) {
+    if constexpr(true) {
       return this->GetX();
     } 
     

--- a/tests/StructuredBindingsHandler6Test.expect
+++ b/tests/StructuredBindingsHandler6Test.expect
@@ -83,9 +83,9 @@ class Point
   template<>
   inline constexpr double get<0>() const noexcept
   {
-    if constexpr(0UL == 1) {
+    if constexpr(false) {
     } else /* constexpr */ {
-      if constexpr(0UL == 0) {
+      if constexpr(true) {
         return this->mY;
       } 
       
@@ -99,7 +99,7 @@ class Point
   template<>
   inline constexpr double get<1>() const noexcept
   {
-    if constexpr(1UL == 1) {
+    if constexpr(true) {
       return this->GetX();
     } 
     

--- a/tests/TemplateArgumentsTest.expect
+++ b/tests/TemplateArgumentsTest.expect
@@ -14,7 +14,7 @@ static inline decltype(auto) Normalize(const T& arg)
 template<>
 inline char const (&Normalize<char [8]>(char const (&arg)[8]))[8]
 {
-  if constexpr(std::is_same_v<char [8], std::basic_string<char, std::char_traits<char>, std::allocator<char> > >) {
+  if constexpr(false) {
   } else /* constexpr */ {
     return arg;
   } 
@@ -27,7 +27,7 @@ inline char const (&Normalize<char [8]>(char const (&arg)[8]))[8]
 template<>
 inline const int & Normalize<int>(const int & arg)
 {
-  if constexpr(std::is_same_v<int, std::basic_string<char, std::char_traits<char>, std::allocator<char> > >) {
+  if constexpr(false) {
   } else /* constexpr */ {
     return arg;
   } 
@@ -40,7 +40,7 @@ inline const int & Normalize<int>(const int & arg)
 template<>
 inline const char * Normalize<std::basic_string<char, std::char_traits<char>, std::allocator<char> > >(const std::basic_string<char, std::char_traits<char>, std::allocator<char> > & arg)
 {
-  if constexpr(std::is_same_v<std::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::basic_string<char, std::char_traits<char>, std::allocator<char> > >) {
+  if constexpr(true) {
     return arg.c_str();
   } 
   


### PR DESCRIPTION
constexpr if.