### PR TITLE
Fixed #408: Keep scope of variable.

### DIFF
--- a/CodeGenerator.cpp
+++ b/CodeGenerator.cpp
@@ -856,7 +856,19 @@ void CodeGenerator::InsertArg(const VarDecl* stmt)
             } else {
                 mOutputFormatHelper.Append(GetQualifiers(*stmt));
 
-                const auto varName = FormatVarTemplateSpecializationDecl(stmt, GetName(*stmt));
+                const auto scope = [&] {
+                    if(const auto* ctx = stmt->getDeclContext(); stmt->getLexicalDeclContext() != ctx) {
+                        OutputFormatHelper scopeOfm{};
+                        CodeGenerator      codeGenerator{scopeOfm};
+                        codeGenerator.ParseDeclContext(ctx);
+
+                        return ScopeHandler::RemoveCurrentScope(scopeOfm.GetString());
+                    }
+
+                    return std::string{};
+                }();
+
+                const auto varName = FormatVarTemplateSpecializationDecl(stmt, StrCat(scope, GetName(*stmt)));
 
                 // TODO: to keep the special handling for lambdas, do this only for template specializations
                 if(stmt->getType()->getAs<TemplateSpecializationType>()) {

--- a/tests/Issue408.cpp
+++ b/tests/Issue408.cpp
@@ -1,0 +1,5 @@
+namespace ns {
+    extern int a;
+};
+
+int ns::a = 1;

--- a/tests/Issue408.expect
+++ b/tests/Issue408.expect
@@ -1,0 +1,8 @@
+namespace ns
+{
+  extern int a;
+  
+}
+
+int ns::a = 1;
+

--- a/tests/StaticDataMemberKeepScopeTest.cpp
+++ b/tests/StaticDataMemberKeepScopeTest.cpp
@@ -1,0 +1,5 @@
+struct S {
+    static const int x;
+};
+
+const int S::x = 3;

--- a/tests/StaticDataMemberKeepScopeTest.expect
+++ b/tests/StaticDataMemberKeepScopeTest.expect
@@ -1,0 +1,9 @@
+struct S
+{
+  static const int x;
+};
+
+
+
+const int S::x = 3;
+


### PR DESCRIPTION
Previously the scope of a variable was lost if it was a static data
member with an initialization outside of the class, or a variable
declared in a namespace and initialized outside the namespace.