### PR TITLE
Pre Clang 10 cleanup.

### DIFF
--- a/ClangCompat.h
+++ b/ClangCompat.h
@@ -29,34 +29,9 @@ struct IsClangNewerThan
 // inline constexpr bool IsClangNewerThan8 = IsClangNewerThan<8>::value;
 //-----------------------------------------------------------------------------
 
-template<typename T>
-auto inline GetBeginLoc(const T& decl)
-{
-    return decl.getBeginLoc();
-}
-//-----------------------------------------------------------------------------
-
-template<typename T>
-auto inline GetBeginLoc(const T* decl)
-{
-    return decl->getBeginLoc();
-}
-//-----------------------------------------------------------------------------
-
-template<typename T>
-auto inline GetEndLoc(const T* decl)
-{
-    return decl->getEndLoc();
-}
-//-----------------------------------------------------------------------------
-
 inline auto* GetTemporary(const MaterializeTemporaryExpr* stmt)
 {
-#if IS_CLANG_NEWER_THAN(9)
     return stmt->getSubExpr();
-#else
-    return stmt->getTemporary();
-#endif
 }
 //-----------------------------------------------------------------------------
 

--- a/CodeGenerator.cpp
+++ b/CodeGenerator.cpp
@@ -1779,11 +1779,7 @@ void CodeGenerator::InsertArg(const CXXNewExpr* stmt)
             CodeGenerator      codeGenerator{ofm};
 
             ofm.Append("["sv);
-#if IS_CLANG_NEWER_THAN(8)
             codeGenerator.InsertArg(stmt->getArraySize().getValue());
-#else
-            codeGenerator.InsertArg(stmt->getArraySize());
-#endif
             ofm.Append(']');
 
             // In case of multi dimension the first dimension is the getArraySize() while the others are part of the
@@ -3827,18 +3823,6 @@ template<typename T>
 void CodeGenerator::WrapInCurlys(T&& lambda, const AddSpaceAtTheEnd addSpaceAtTheEnd)
 {
     WrapInParensOrCurlys(BraceKind::Curlys, std::forward<T>(lambda), addSpaceAtTheEnd);
-}
-//-----------------------------------------------------------------------------
-
-static bool IsReference(const QualType& type)
-{
-    return GetDesugarType(type)->isLValueReferenceType();
-}
-//-----------------------------------------------------------------------------
-
-static bool IsReference(const ValueDecl& valDecl)
-{
-    return IsReference(valDecl.getType());
 }
 //-----------------------------------------------------------------------------
 

--- a/FunctionDeclHandler.cpp
+++ b/FunctionDeclHandler.cpp
@@ -54,7 +54,7 @@ FunctionDeclHandler::FunctionDeclHandler(Rewriter& rewrite, MatchFinder& matcher
 void FunctionDeclHandler::run(const MatchFinder::MatchResult& result)
 {
     if(const auto* funcDecl = result.Nodes.getNodeAs<FunctionDecl>("funcDecl")) {
-        const auto         columnNr = GetSM(result).getSpellingColumnNumber(GetBeginLoc(funcDecl)) - 1;
+        const auto         columnNr = GetSM(result).getSpellingColumnNumber(funcDecl->getBeginLoc()) - 1;
         OutputFormatHelper outputFormatHelper{columnNr};
         CodeGenerator      codeGenerator{outputFormatHelper};
 

--- a/Insights.cpp
+++ b/Insights.cpp
@@ -157,15 +157,7 @@ public:
     std::unique_ptr<ASTConsumer> CreateASTConsumer(CompilerInstance& CI, StringRef /*file*/) override
     {
         mRewriter.setSourceMgr(CI.getSourceManager(), CI.getLangOpts());
-        return
-#if IS_CLANG_NEWER_THAN(9)
-
-            std
-#else
-            llvm
-#endif
-
-            ::make_unique<CppInsightASTConsumer>(mRewriter);
+        return std ::make_unique<CppInsightASTConsumer>(mRewriter);
     }
 
 private:

--- a/InsightsHelpers.cpp
+++ b/InsightsHelpers.cpp
@@ -280,7 +280,7 @@ static void InsertAfter(std::string& source, const std::string_view& find, const
 static std::string MakeLineColumnName(const Decl& decl, const std::string_view prefix)
 {
     const auto& sm       = GetSM(decl);
-    const auto  locBegin = GetBeginLoc(decl);
+    const auto  locBegin = decl.getBeginLoc();
     // In case of a macro expansion the expansion(line/column) number gives a unique value.
     const auto lineNo = locBegin.isMacroID() ? sm.getExpansionLineNumber(locBegin) : sm.getSpellingLineNumber(locBegin);
     const auto columnNo =
@@ -696,15 +696,9 @@ private:
 
         mData.Append(')');
 
-#if IS_CLANG_NEWER_THAN(8)
         if(not type->getMethodQuals().empty()) {
             mData.Append(" "sv, type->getMethodQuals().getAsString());
         }
-#else
-        if(not type->getTypeQuals().empty()) {
-            mData.Append(" ", type->getTypeQuals().getAsString());
-        }
-#endif
 
         /// Currently, we are skipping `T->getRefQualifier()` and the exception specification, as well as the trailing
         /// return type.
@@ -1279,7 +1273,7 @@ std::string GetName(const VarDecl& VD)
             return std::string{};
         }()};
 
-        return {BuildInternalVarName(baseVarName, GetBeginLoc(decompositionDeclStmt), GetSM(*decompositionDeclStmt))};
+        return {BuildInternalVarName(baseVarName, decompositionDeclStmt->getBeginLoc(), GetSM(*decompositionDeclStmt))};
     }
 
     std::string_view name{VD.getName()};

--- a/InsightsMatchers.h
+++ b/InsightsMatchers.h
@@ -50,15 +50,14 @@ AST_POLYMORPHIC_MATCHER(isMacroOrInvalidLocation, AST_POLYMORPHIC_SUPPORTED_TYPE
 {
     SILENCE;
 
-    return (insights::IsMacroLocation(insights::GetBeginLoc(Node)) ||
-            insights::IsInvalidLocation(insights::GetBeginLoc(Node)));
+    return (insights::IsMacroLocation(Node.getBeginLoc()) || insights::IsInvalidLocation(Node.getBeginLoc()));
 }
 
 AST_POLYMORPHIC_MATCHER(isInvalidLocation, AST_POLYMORPHIC_SUPPORTED_TYPES(Decl, Stmt))
 {
     SILENCE;
 
-    return insights::IsInvalidLocation(insights::GetBeginLoc(Node));
+    return insights::IsInvalidLocation(Node.getBeginLoc());
 }
 
 }  // namespace ast_matchers

--- a/TemplateHandler.cpp
+++ b/TemplateHandler.cpp
@@ -119,7 +119,7 @@ void TemplateHandler::run(const MatchFinder::MatchResult& result)
 
         OutputFormatHelper outputFormatHelper = InsertInstantiatedTemplate(functionDecl);
         const auto         endOfCond          = FindLocationAfterRBrace(
-            GetEndLoc(endLocDecl),
+            endLocDecl->getEndLoc(),
             result,
             isa<CXXDeductionGuideDecl>(
                 functionDecl));  // if we lift the "not getBody()" restriction above we need to take this in account
@@ -136,7 +136,7 @@ void TemplateHandler::run(const MatchFinder::MatchResult& result)
         OutputFormatHelper outputFormatHelper = InsertInstantiatedTemplate(clsTmplSpecDecl);
 
         if(const auto* clsTmplDecl = result.Nodes.getNodeAs<ClassTemplateDecl>("decl")) {
-            const auto endOfCond = FindLocationAfterSemi(GetEndLoc(clsTmplDecl), result);
+            const auto endOfCond = FindLocationAfterSemi(clsTmplDecl->getEndLoc(), result);
             InsertIndentedText(endOfCond, outputFormatHelper);
 
         } else {  // explicit specialization, we have to remove the specialization
@@ -145,7 +145,7 @@ void TemplateHandler::run(const MatchFinder::MatchResult& result)
 
     } else if(const auto* vd = result.Nodes.getNodeAs<VarTemplateDecl>("vd")) {
         OutputFormatHelper outputFormatHelper = InsertInstantiatedTemplate(vd);
-        const auto         endOfCond          = FindLocationAfterSemi(GetEndLoc(vd), result);
+        const auto         endOfCond          = FindLocationAfterSemi(vd->getEndLoc(), result);
 
         mRewrite.ReplaceText({vd->getSourceRange().getBegin(), endOfCond.getLocWithOffset(1)},
                              outputFormatHelper.GetString());


### PR DESCRIPTION
Removed code that is used by Clang < 10 which is no longer supported by
this project.