### PR TITLE
Fixed `if` or `switch` with initialization.

### DIFF
--- a/CodeGenerator.cpp
+++ b/CodeGenerator.cpp
@@ -502,13 +502,7 @@ void CodeGenerator::InsertArg(const SwitchStmt* stmt)
     if(hasInit) {
         mOutputFormatHelper.OpenScope();
 
-        if(const auto* conditionVar = stmt->getConditionVariable()) {
-            InsertArg(conditionVar);
-        }
-
-        if(const auto* init = stmt->getInit()) {
-            InsertArg(init);
-        }
+        InsertIfOrSwitchInitVariables(stmt);
     }
 
     mOutputFormatHelper.Append(kwSwitch);
@@ -1609,6 +1603,21 @@ void CodeGenerator::HandleCompoundStmt(const CompoundStmt* stmt)
 }
 //-----------------------------------------------------------------------------
 
+void CodeGenerator::InsertIfOrSwitchInitVariables(same_as_any_of<const IfStmt, const SwitchStmt> auto* stmt)
+{
+    if(const auto* conditionVar = stmt->getConditionVariable()) {
+        InsertArg(conditionVar);
+    }
+
+    if(const auto* init = stmt->getInit()) {
+        InsertArg(init);
+        if(not isa<DeclStmt>(init)) {
+            mOutputFormatHelper.AppendSemiNewLine();
+        }
+    }
+}
+//-----------------------------------------------------------------------------
+
 void CodeGenerator::InsertArg(const IfStmt* stmt)
 {
     auto       cexpr{stmt->isConstexpr() ? kwSpaceConstExpr : emptySV};
@@ -1617,13 +1626,7 @@ void CodeGenerator::InsertArg(const IfStmt* stmt)
     if(hasInit) {
         mOutputFormatHelper.OpenScope();
 
-        if(const auto* conditionVar = stmt->getConditionVariable()) {
-            InsertArg(conditionVar);
-        }
-
-        if(const auto* init = stmt->getInit()) {
-            InsertArg(init);
-        }
+        InsertIfOrSwitchInitVariables(stmt);
     }
 
     mOutputFormatHelper.Append("if"sv, cexpr);

--- a/CodeGenerator.h
+++ b/CodeGenerator.h
@@ -278,6 +278,8 @@ protected:
     /// \brief Check whether or not this statement will add curlys or parentheses and add them only if required.
     void InsertCurlysIfRequired(const Stmt* stmt);
 
+    void InsertIfOrSwitchInitVariables(same_as_any_of<const IfStmt, const SwitchStmt> auto* stmt);
+
     STRONG_BOOL(AddNewLineAfter);
 
     void WrapInCompoundIfNeeded(const Stmt* stmt, const AddNewLineAfter addNewLineAfter);

--- a/InsightsUtility.h
+++ b/InsightsUtility.h
@@ -19,4 +19,7 @@
 using void_func_ref = llvm::function_ref<void()>;
 //-----------------------------------------------------------------------------
 
+template<typename T, typename... Ts>
+concept same_as_any_of = (std::same_as<T, Ts> || ...);
+
 #endif /* INSIGHTS_UTILITY_H */

--- a/tests/IfSwitchInitHandlerTest.cpp
+++ b/tests/IfSwitchInitHandlerTest.cpp
@@ -18,6 +18,14 @@ auto Foo()
 }
 
 
+void Fun()
+{
+    if(Open(); true) {}
+
+    switch(Open(); 1) {
+        default: break;
+    }
+}
 
 
 int main()

--- a/tests/IfSwitchInitHandlerTest.expect
+++ b/tests/IfSwitchInitHandlerTest.expect
@@ -35,6 +35,23 @@ int Foo()
 
 
 
+void Fun()
+{
+  {
+    Open();
+    if(true) {
+    } 
+    
+  }
+  
+  {
+    Open();
+    switch(1) {
+      default: break;
+    }
+  }
+}
+
 
 
 int main()


### PR DESCRIPTION
In the case where the initialization of an `if` or `switch` was only a
call, the newline was missing.