### PR TITLE
Fixed #404: Unintentional swapping of array dimensions.

### DIFF
--- a/tests/Issue404.cerr
+++ b/tests/Issue404.cerr
@@ -1,0 +1,10 @@
+.tmp.cpp:22:21: error: 'S' does not refer to a value
+     S arr2[3][2] = S [3][2]();
+                    ^
+.tmp.cpp:1:8: note: declared here
+struct S
+       ^
+.tmp.cpp:24:27: error: expected '(' for function-style cast or type construction
+T<int> arr3[3][2] = T<int>[3][2]();
+                    ~~~~~~^
+2 errors generated.

--- a/tests/Issue404.cpp
+++ b/tests/Issue404.cpp
@@ -1,0 +1,6 @@
+struct S {};
+template<typename> struct T {};
+
+   int arr1[3][2];
+     S arr2[3][2];
+T<int> arr3[3][2];

--- a/tests/Issue404.expect
+++ b/tests/Issue404.expect
@@ -1,0 +1,25 @@
+struct S
+{
+  // inline constexpr S() noexcept = default;
+};
+
+
+template<typename> struct T {};
+
+/* First instantiated from: Issue404.cpp:6 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+struct T<int>
+{
+  // inline constexpr T() noexcept = default;
+};
+
+#endif
+
+
+   int arr1[3][2];
+
+     S arr2[3][2] = S [3][2]();
+
+T<int> arr3[3][2] = T<int>[3][2]();
+


### PR DESCRIPTION
While this fix addresses the original issue, the construction of an
array as shown is invalid. This could be something resolved by #406.