### PR TITLE
Fixed inherited constructor's access specifier.

### DIFF
--- a/CodeGenerator.cpp
+++ b/CodeGenerator.cpp
@@ -1091,7 +1091,7 @@ void CodeGenerator::InsertArg(const FunctionDecl* stmt)
         }
 
         InsertTemplateGuardBegin(stmt);
-        InsertAccessModifierAndNameWithReturnType(*stmt, SkipAccess::Yes);
+        InsertAccessModifierAndNameWithReturnType(*stmt);
 
         if(not InsertLambdaStaticInvoker(dyn_cast_or_null<CXXMethodDecl>(stmt))) {
             if(stmt->doesThisDeclarationHaveABody()) {
@@ -2315,7 +2315,7 @@ void CodeGenerator::InsertCXXMethodHeader(const CXXMethodDecl* stmt, OutputForma
     }
 
     InsertTemplateGuardBegin(stmt);
-    InsertAccessModifierAndNameWithReturnType(*stmt, SkipAccess::Yes, cxxInheritedCtorDecl);
+    InsertAccessModifierAndNameWithReturnType(*stmt, cxxInheritedCtorDecl);
 
     if(stmt->isDeleted()) {
         mOutputFormatHelper.AppendNewLine(kwSpaceEqualsDelete);
@@ -3609,7 +3609,6 @@ void CodeGenerator::InsertConceptConstraint(const VarDecl* varDecl)
 //-----------------------------------------------------------------------------
 
 void CodeGenerator::InsertAccessModifierAndNameWithReturnType(const FunctionDecl&       decl,
-                                                              const SkipAccess          skipAccess,
                                                               const CXXConstructorDecl* cxxInheritedCtorDecl)
 {
     bool        isLambda{false};
@@ -3627,10 +3626,6 @@ void CodeGenerator::InsertAccessModifierAndNameWithReturnType(const FunctionDecl
 
         isLambda             = methodDecl->getParent()->isLambda();
         isFirstCxxMethodDecl = (nullptr == methodDecl->getPreviousDecl());
-    }
-
-    if((isFirstCxxMethodDecl && (SkipAccess::No == skipAccess)) || cxxInheritedCtorDecl) {
-        mOutputFormatHelper.Append(AccessToStringWithColon(decl));
     }
 
     // types of conversion decls can be invalid to type at this place. So introduce a using

--- a/CodeGenerator.h
+++ b/CodeGenerator.h
@@ -154,8 +154,6 @@ public:
 
     void InsertTemplateArgs(const ClassTemplateSpecializationDecl& clsTemplateSpe);
 
-    STRONG_BOOL(SkipAccess);
-
     /// \brief Insert the code for a FunctionDecl.
     ///
     /// This inserts the code of a FunctionDecl (and everything which is derived from one). It takes care of
@@ -165,7 +163,6 @@ public:
     /// @param skipAccess Show or hide access modifiers (public, private, protected). The default is to show them.
     /// @param cxxInheritedCtorDecl If not null, the type and name of this decl is used for the parameters.
     void InsertAccessModifierAndNameWithReturnType(const FunctionDecl&       decl,
-                                                   const SkipAccess          skipAccess           = SkipAccess::No,
                                                    const CXXConstructorDecl* cxxInheritedCtorDecl = nullptr);
 
     /// Track whether we have at least one local static variable in this TU.

--- a/tests/usingConstructorTest.expect
+++ b/tests/usingConstructorTest.expect
@@ -20,12 +20,12 @@ class Bar : public Foo
   public: 
   int mX;
   // inline Bar() = delete;
-  public: inline Bar(double amount) noexcept(false)
+  inline Bar(double amount) noexcept(false)
   : Foo(amount)
   {
   }
   
-  public: inline Bar(int x, int y) noexcept(false)
+  inline Bar(int x, int y) noexcept(false)
   : Foo(x, y)
   {
   }
@@ -41,7 +41,7 @@ class Bla : public Foo
   int mX;
   public: 
   // inline Bla() = delete;
-  public: inline Bla(int x, int y) noexcept(false)
+  inline Bla(int x, int y) noexcept(false)
   : Foo(x, y)
   {
   }


### PR DESCRIPTION
The access specifier for inherited constructors was duplicated. The
remove of this duplication lead to the drop of an now unused parameter
for `InsertAccessModifierAndNameWithReturnType`.