### PR TITLE
Fixed a special case of inherited constructors.

### DIFF
--- a/CodeGenerator.cpp
+++ b/CodeGenerator.cpp
@@ -1411,7 +1411,9 @@ void CodeGenerator::InsertArg(const CXXInheritedCtorInitExpr* stmt)
 
     mOutputFormatHelper.Append(GetName(GetDesugarType(stmt->getType()), Unqualified::Yes));
     WrapInParens([&]() {
-        mOutputFormatHelper.AppendParameterList(constructorDecl.parameters(), OutputFormatHelper::NameOnly::Yes);
+        mOutputFormatHelper.AppendParameterList(constructorDecl.parameters(),
+                                                OutputFormatHelper::NameOnly::Yes,
+                                                OutputFormatHelper::GenMissingParamName::Yes);
     });
 }
 //-----------------------------------------------------------------------------
@@ -3723,7 +3725,9 @@ void CodeGenerator::InsertFunctionNameWithReturnType(const FunctionDecl&       d
 
     // if a CXXInheritedCtorDecl was passed as a pointer us this to get the parameters from.
     if(cxxInheritedCtorDecl) {
-        outputFormatHelper.AppendParameterList(cxxInheritedCtorDecl->parameters());
+        outputFormatHelper.AppendParameterList(cxxInheritedCtorDecl->parameters(),
+                                               OutputFormatHelper::NameOnly::No,
+                                               OutputFormatHelper::GenMissingParamName::Yes);
     } else {
         outputFormatHelper.AppendParameterList(decl.parameters());
     }

--- a/OutputFormatHelper.cpp
+++ b/OutputFormatHelper.cpp
@@ -20,10 +20,21 @@ void OutputFormatHelper::Indent(unsigned count)
 }
 //-----------------------------------------------------------------------------
 
-void OutputFormatHelper::AppendParameterList(const ArrayRef<ParmVarDecl*> parameters, const NameOnly nameOnly)
+void OutputFormatHelper::AppendParameterList(const ArrayRef<ParmVarDecl*> parameters,
+                                             const NameOnly               nameOnly,
+                                             const GenMissingParamName    genMissingParamName)
 {
+    int count{};
+
     ForEachArg(parameters, [&](const auto& p) {
-        const auto& name{GetName(*p)};
+        auto name{GetName(*p)};
+
+        // A special case for CXXInheritedCtor. A user can omit the parameters name, but wihtout a name the call to the
+        // base constructor may look like calling the default constructor. In such a case we create a name.
+        if((GenMissingParamName::Yes == genMissingParamName) && (0 == name.length())) {
+            name = BuildInternalVarName(StrCat("param", count));
+            ++count;
+        }
 
         // Get the attributes and insert them, if there are any
         CodeGenerator codeGenerator{*this};

--- a/OutputFormatHelper.h
+++ b/OutputFormatHelper.h
@@ -100,11 +100,14 @@ public:
     }
 
     STRONG_BOOL(NameOnly);
+    STRONG_BOOL(GenMissingParamName);
 
     /// \brief Append a \c ParamVarDecl array.
     ///
     /// The parameter name is always added as well.
-    void AppendParameterList(const ArrayRef<ParmVarDecl*> parameters, const NameOnly nameOnly = NameOnly::No);
+    void AppendParameterList(const ArrayRef<ParmVarDecl*> parameters,
+                             const NameOnly               nameOnly            = NameOnly::No,
+                             const GenMissingParamName    genMissingParamName = GenMissingParamName::No);
 
     /// \brief Increase the current indention by \c SCOPE_INDENT
     void IncreaseIndent() { mDefaultIndent += SCOPE_INDENT; }

--- a/tests/usingConstructor2Test.cpp
+++ b/tests/usingConstructor2Test.cpp
@@ -1,0 +1,17 @@
+class Base {
+public:
+  Base(double) {}
+};
+
+class Derived : public Base{
+public:
+  using Base::Base;
+  
+  int someValue;
+};
+  
+  
+int main()
+{
+  Derived d(3.14);
+}

--- a/tests/usingConstructor2Test.expect
+++ b/tests/usingConstructor2Test.expect
@@ -1,0 +1,34 @@
+class Base
+{
+  
+  public: 
+  inline Base(double)
+  {
+  }
+  
+};
+
+
+
+class Derived : public Base
+{
+  
+  public: 
+  int someValue;
+  // inline Derived() = delete;
+  inline Derived(double __param0) noexcept(false)
+  : Base(__param0)
+  {
+  }
+  
+};
+
+
+  
+  
+int main()
+{
+  Derived d = Derived(3.1400000000000001);
+  return 0;
+}
+


### PR DESCRIPTION
In case a user did not name the parameter in a base classes constructor
the resulting transformation in C++ Insights looked like a call to the
default constructor. This patch creates a parameter name in that case.