### PR TITLE
Fixed #425: Show the correct reference type for structured bindings.

### DIFF
--- a/tests/Issue131.expect
+++ b/tests/Issue131.expect
@@ -4,6 +4,6 @@ std::tuple<int, float> foo();
 
  
 std::tuple<int, float> __foo5 = foo();
-int a = std::get<0UL>(static_cast<std::tuple<int, float> &&>(__foo5));
-float b = std::get<1UL>(static_cast<std::tuple<int, float> &&>(__foo5));
+int && a = std::get<0UL>(static_cast<std::tuple<int, float> &&>(__foo5));
+float && b = std::get<1UL>(static_cast<std::tuple<int, float> &&>(__foo5));
 

--- a/tests/Issue20.expect
+++ b/tests/Issue20.expect
@@ -4,8 +4,8 @@ int main()
 {
   std::map<int, int> map = std::map<int, int, std::less<int>, std::allocator<std::pair<const int, int> > >{std::initializer_list<std::pair<const int, int> >{std::pair<const int, int>{1, 2}}, std::less<int>()};
   std::pair<const int, int> __operator6 = std::pair<const int, int>(map.begin().operator*());
-  const int key = std::get<0UL>(static_cast<std::pair<const int, int> &&>(__operator6));
-  int value = std::get<1UL>(static_cast<std::pair<const int, int> &&>(__operator6));
+  const int && key = std::get<0UL>(static_cast<std::pair<const int, int> &&>(__operator6));
+  int && value = std::get<1UL>(static_cast<std::pair<const int, int> &&>(__operator6));
   return 0;
 }
 

--- a/tests/Issue381.expect
+++ b/tests/Issue381.expect
@@ -4,8 +4,8 @@ int main()
 {
   std::tuple<int, int> tup = std::tuple<int, int>{2, 5};
   std::tuple<int, int> __tup6 = std::tuple<int, int>(tup);
-  int a = std::get<0UL>(static_cast<std::tuple<int, int> &&>(__tup6));
-  int b = std::get<1UL>(static_cast<std::tuple<int, int> &&>(__tup6));
+  int && a = std::get<0UL>(static_cast<std::tuple<int, int> &&>(__tup6));
+  int && b = std::get<1UL>(static_cast<std::tuple<int, int> &&>(__tup6));
   return 0;
 }
 

--- a/tests/Issue425.cpp
+++ b/tests/Issue425.cpp
@@ -1,0 +1,7 @@
+#include <utility>
+
+int main()
+{
+    std::pair<int, char> p;
+  	auto [a, b] = p;
+}

--- a/tests/Issue425.expect
+++ b/tests/Issue425.expect
@@ -1,0 +1,11 @@
+#include <utility>
+
+int main()
+{
+  std::pair<int, char> p = std::pair<int, char>();
+  std::pair<int, char> __p6 = std::pair<int, char>(p);
+  int && a = std::get<0UL>(static_cast<std::pair<int, char> &&>(__p6));
+  char && b = std::get<1UL>(static_cast<std::pair<int, char> &&>(__p6));
+  return 0;
+}
+

--- a/tests/StructuredBindingsHandler10Test.cpp
+++ b/tests/StructuredBindingsHandler10Test.cpp
@@ -1,0 +1,12 @@
+// Source: https://en.cppreference.com/w/cpp/language/structured_binding
+#include <tuple>
+
+float x{};
+char  y{};
+int   z{};
+ 
+std::tuple<float&,char&&,int> tpl(x,std::move(y),z);
+const auto& [a,b,c] = tpl;
+// a names a structured binding that refers to x; decltype(a) is float&
+// b names a structured binding that refers to y; decltype(b) is char&&
+// c names a structured binding that refers to the 3rd element of tpl; decltype(c) is const int

--- a/tests/StructuredBindingsHandler10Test.expect
+++ b/tests/StructuredBindingsHandler10Test.expect
@@ -1,0 +1,20 @@
+// Source: https://en.cppreference.com/w/cpp/language/structured_binding
+#include <tuple>
+
+float x = {};
+
+char y = {};
+
+int z = {};
+
+ 
+std::tuple<float &, char &&, int> tpl = std::tuple<float &, char &&, int>(x, std::move(y), z);
+
+const std::tuple<float &, char &&, int> & __tpl9 = tpl;
+float & a = std::get<0UL>(__tpl9);
+char & b = std::get<1UL>(__tpl9);
+const int & c = std::get<2UL>(__tpl9);
+
+// a names a structured binding that refers to x; decltype(a) is float&
+// b names a structured binding that refers to y; decltype(b) is char&&
+// c names a structured binding that refers to the 3rd element of tpl; decltype(c) is const int

--- a/tests/StructuredBindingsHandler3Test.expect
+++ b/tests/StructuredBindingsHandler3Test.expect
@@ -105,15 +105,15 @@ namespace constant
 {
   Q q = Q();
   Q __q17 = Q(q);
-  int a = get<0UL>(static_cast<Q &&>(__q17));
-  int b = get<1UL>(static_cast<Q &&>(__q17));
-  int c = get<2UL>(static_cast<Q &&>(__q17));
+  int && a = get<0UL>(static_cast<Q &&>(__q17));
+  int && b = get<1UL>(static_cast<Q &&>(__q17));
+  int && c = get<2UL>(static_cast<Q &&>(__q17));
   inline constexpr bool f()
   {
     Q __q19 = Q(q);
-    int a = get<0UL>(static_cast<Q &&>(__q19));
-    int b = get<1UL>(static_cast<Q &&>(__q19));
-    int c = get<2UL>(static_cast<Q &&>(__q19));
+    int && a = get<0UL>(static_cast<Q &&>(__q19));
+    int && b = get<1UL>(static_cast<Q &&>(__q19));
+    int && c = get<2UL>(static_cast<Q &&>(__q19));
     return ((a == 0) && (b == 1)) && (c == 4);
   }
   inline constexpr int g()
@@ -121,9 +121,9 @@ namespace constant
     int * p = nullptr;
     {
       Q __q26 = Q(q);
-      int a = get<0UL>(static_cast<Q &&>(__q26));
-      int b = get<1UL>(static_cast<Q &&>(__q26));
-      int c = get<2UL>(static_cast<Q &&>(__q26));
+      int && a = get<0UL>(static_cast<Q &&>(__q26));
+      int && b = get<1UL>(static_cast<Q &&>(__q26));
+      int && c = get<2UL>(static_cast<Q &&>(__q26));
       p = &c;
     };
     return *p;

--- a/tests/StructuredBindingsHandler5Test.expect
+++ b/tests/StructuredBindingsHandler5Test.expect
@@ -152,7 +152,7 @@ int main()
   Point p = Point{1, 2};
   Point & __p64 = p;
   double & x = __p64.get<0>();
-  double y = __p64.get<1>();
+  double && y = __p64.get<1>();
   printf("x:%lf y:%lf\n", p.GetX(), p.GetY());
   ++x;
   ++y;
@@ -161,7 +161,7 @@ int main()
   constexpr const Point p2 = Point{3, 4};
   const Point & __p273 = p2;
   const double & x2 = __p273.get<0>();
-  const double y2 = static_cast<const double>(__p273.get<1>());
+  const double && y2 = static_cast<const double>(__p273.get<1>());
   return 0;
 }
 

--- a/tests/StructuredBindingsHandler6Test.expect
+++ b/tests/StructuredBindingsHandler6Test.expect
@@ -115,8 +115,8 @@ int main()
 {
   Point p = Point{1, 2};
   Point __p58 = Point(p);
-  double x = static_cast<const Point &&>(__p58).get<0>();
-  double y = static_cast<const Point &&>(__p58).get<1>();
+  double && x = static_cast<const Point &&>(__p58).get<0>();
+  double && y = static_cast<const Point &&>(__p58).get<1>();
   printf("x:%lf y:%lf\n", p.GetX(), p.GetY());
   printf("x:%lf y:%lf\n", x, y);
   char ar[2] = {7, 8};
@@ -143,9 +143,9 @@ int main()
   char & c = std::get<1UL>(__muple80);
   double & d = std::get<2UL>(__muple80);
   std::tuple<int, char, double> __muple82 = std::tuple<int, char, double>(muple);
-  int ii = std::get<0UL>(static_cast<std::tuple<int, char, double> &&>(__muple82));
-  char cc = std::get<1UL>(static_cast<std::tuple<int, char, double> &&>(__muple82));
-  double dd = std::get<2UL>(static_cast<std::tuple<int, char, double> &&>(__muple82));
+  int && ii = std::get<0UL>(static_cast<std::tuple<int, char, double> &&>(__muple82));
+  char && cc = std::get<1UL>(static_cast<std::tuple<int, char, double> &&>(__muple82));
+  double && dd = std::get<2UL>(static_cast<std::tuple<int, char, double> &&>(__muple82));
   return 0;
 }
 

--- a/tests/StructuredBindingsHandler8Test.cpp
+++ b/tests/StructuredBindingsHandler8Test.cpp
@@ -1,0 +1,10 @@
+#include <tuple>
+
+auto tup = std::tuple<int, int>{2, 5};
+auto [a1, b1] = tup;
+
+
+int i = 5;
+auto tup2 = std::tuple<int, int&>{2, i};
+auto [a2, b2] = tup2;
+

--- a/tests/StructuredBindingsHandler8Test.expect
+++ b/tests/StructuredBindingsHandler8Test.expect
@@ -1,0 +1,19 @@
+#include <tuple>
+
+std::tuple<int, int> tup = std::tuple<int, int>{2, 5};
+
+std::tuple<int, int> __tup4 = std::tuple<int, int>(tup);
+int && a1 = std::get<0UL>(static_cast<std::tuple<int, int> &&>(__tup4));
+int && b1 = std::get<1UL>(static_cast<std::tuple<int, int> &&>(__tup4));
+
+
+
+int i = 5;
+
+std::tuple<int, int &> tup2 = std::tuple<int, int &>{2, i};
+
+std::tuple<int, int &> __tup29 = std::tuple<int, int &>(tup2);
+int && a2 = std::get<0UL>(static_cast<std::tuple<int, int &> &&>(__tup29));
+int & b2 = std::get<1UL>(static_cast<std::tuple<int, int &> &&>(__tup29));
+
+

--- a/tests/StructuredBindingsHandler9Test.expect
+++ b/tests/StructuredBindingsHandler9Test.expect
@@ -4,8 +4,8 @@ std::tuple<int, float> foo = std::tuple<int, float>();
 
  
 std::tuple<int, float> __foo5 = std::tuple<int, float>(foo);
-int a = std::get<0UL>(static_cast<std::tuple<int, float> &&>(__foo5));
-float b = std::get<1UL>(static_cast<std::tuple<int, float> &&>(__foo5));
+int && a = std::get<0UL>(static_cast<std::tuple<int, float> &&>(__foo5));
+float && b = std::get<1UL>(static_cast<std::tuple<int, float> &&>(__foo5));
 
 std::tuple<int, float> & __foo6 = foo;
 int & ra = std::get<0UL>(__foo6);

--- a/tests/TupeInRangeBasedForTest.expect
+++ b/tests/TupeInRangeBasedForTest.expect
@@ -28,8 +28,8 @@ int main()
     std::__wrap_iter<std::tuple<std::basic_string<char, std::char_traits<char>, std::allocator<char> >, int> *> __end1 = __range1.end();
     for(; std::operator!=(__begin1, __end1); __begin1.operator++()) {
       std::tuple<std::basic_string<char, std::char_traits<char>, std::allocator<char> >, int> __operator15 = std::tuple<std::basic_string<char, std::char_traits<char>, std::allocator<char> >, int>(__begin1.operator*());
-      std::basic_string<char, std::char_traits<char>, std::allocator<char> > s = std::get<0UL>(static_cast<std::tuple<std::basic_string<char, std::char_traits<char>, std::allocator<char> >, int> &&>(__operator15));
-      int n = std::get<1UL>(static_cast<std::tuple<std::basic_string<char, std::char_traits<char>, std::allocator<char> >, int> &&>(__operator15));
+      std::basic_string<char, std::char_traits<char>, std::allocator<char> > && s = std::get<0UL>(static_cast<std::tuple<std::basic_string<char, std::char_traits<char>, std::allocator<char> >, int> &&>(__operator15));
+      int && n = std::get<1UL>(static_cast<std::tuple<std::basic_string<char, std::char_traits<char>, std::allocator<char> >, int> &&>(__operator15));
       printf("c=%s, n=%d\n", s.c_str(), n);
     }
     

--- a/tests/dcl.struct.bind.Test.cpp
+++ b/tests/dcl.struct.bind.Test.cpp
@@ -1,0 +1,86 @@
+
+// p1
+// cv := denote the cv-qualifiers in the decl-specifier-seq
+// S  := consist of the storage-class-specifiers of the decl-specifier-seq (if any)
+//
+// 1) a variable with a unique name e is introduced. 
+//    If the assignment-expression in the initializer has array type A and no ref-qualifier is present, e is defined by:
+// 
+//    attribute-specifier-seq_{opt} S cv A e ;
+//
+//    otherwise e is defined as-if by:
+//
+//   attribute-specifier-seq_{opt} decl-specifier-seq ref-qualifier_{opt} e initializer ;
+//
+//   The type of the id-expression e is called E.
+//
+//   Note: E is never a reference type
+//
+//
+// -- tuple --
+// Let i be an index of type std::size_t corresponding to vi
+// either:
+//  e.get<i>()
+//  get<i>(e)
+//
+//  In either case, 
+//      - e is an lvalue if the type of the entity e is an lvalue reference and 
+//      - an xvalue otherwise. 
+//
+//  -> auto& [a ,b ] -> e := lvalue
+//  -> auto  [a ,b ] -> e := xvalue
+//
+//  T_i  := std::tuple_element<i, E>::type 
+//  U_i  := either
+//           - T_i&:  if the initializer is an lvalue,
+//           - T_i&&: an rvalue reference otherwise, 
+//
+//  variables are introduced with unique names r_i as follows:
+//
+//      S U_i r_i = initializer ;
+//
+//  Each vi is the name of an lvalue of type Ti that refers to the object bound to ri; the referenced type is Ti.
+//
+
+
+// The lvalue is a bit-field if that member is a bit-field. [Example:
+//      struct S { int x1 : 2; volatile double y1; };
+//      S f();
+//      const auto [ x, y ] = f();
+// The type of the id-expression x is “const int”, the type of the id-expression y is “const volatile double”. —end example]
+
+
+// For each identifier, a variable whose type is "reference to std::tuple_element<i, E>::type" is introduced: lvalue reference if its corresponding initializer is an lvalue, rvalue reference otherwise. The initializer for the i-th variable is
+// - e.get<i>(), if lookup for the identifier get in the scope of E by class member access lookup finds at least one declaration that is a function template whose first template parameter is a non-type parameter
+// - Otherwise, get<i>(e), where get is looked up by argument-dependent lookup only, ignoring non-ADL lookup. 
+// 
+// The initializer for the new variable is e.get<i> or get<i>(e). 
+// Here the overload of get that is called is a rvalue in case we use auto and an lvalue in case we use auto&
+
+
+
+#include <cassert>
+#include <tuple>
+
+// https://en.cppreference.com/w/cpp/language/structured_binding
+float x{};
+char  y{};
+int   z{};
+ 
+std::tuple<float&,char&&,int> tpl(x,std::move(y),z);
+//auto tpl = std::tuple{x,std::move(y),z};
+auto& [a,b,c] = tpl;
+// a names a structured binding that refers to x; decltype(a) is float&
+// b names a structured binding that refers to y; decltype(b) is char&&
+// c names a structured binding that refers to the 3rd element of tpl; decltype(c) is int
+
+int main() {
+    a = 4.5;
+    c = 5;
+
+//    assert(4.5 == x);
+//    assert(0 == z);
+
+//    std::cout << a << '\n';
+//    std::cout << z << '\n';
+}

--- a/tests/dcl.struct.bind.Test.expect
+++ b/tests/dcl.struct.bind.Test.expect
@@ -1,0 +1,91 @@
+
+// p1
+// cv := denote the cv-qualifiers in the decl-specifier-seq
+// S  := consist of the storage-class-specifiers of the decl-specifier-seq (if any)
+//
+// 1) a variable with a unique name e is introduced. 
+//    If the assignment-expression in the initializer has array type A and no ref-qualifier is present, e is defined by:
+// 
+//    attribute-specifier-seq_{opt} S cv A e ;
+//
+//    otherwise e is defined as-if by:
+//
+//   attribute-specifier-seq_{opt} decl-specifier-seq ref-qualifier_{opt} e initializer ;
+//
+//   The type of the id-expression e is called E.
+//
+//   Note: E is never a reference type
+//
+//
+// -- tuple --
+// Let i be an index of type std::size_t corresponding to vi
+// either:
+//  e.get<i>()
+//  get<i>(e)
+//
+//  In either case, 
+//      - e is an lvalue if the type of the entity e is an lvalue reference and 
+//      - an xvalue otherwise. 
+//
+//  -> auto& [a ,b ] -> e := lvalue
+//  -> auto  [a ,b ] -> e := xvalue
+//
+//  T_i  := std::tuple_element<i, E>::type 
+//  U_i  := either
+//           - T_i&:  if the initializer is an lvalue,
+//           - T_i&&: an rvalue reference otherwise, 
+//
+//  variables are introduced with unique names r_i as follows:
+//
+//      S U_i r_i = initializer ;
+//
+//  Each vi is the name of an lvalue of type Ti that refers to the object bound to ri; the referenced type is Ti.
+//
+
+
+// The lvalue is a bit-field if that member is a bit-field. [Example:
+//      struct S { int x1 : 2; volatile double y1; };
+//      S f();
+//      const auto [ x, y ] = f();
+// The type of the id-expression x is “const int”, the type of the id-expression y is “const volatile double”. —end example]
+
+
+// For each identifier, a variable whose type is "reference to std::tuple_element<i, E>::type" is introduced: lvalue reference if its corresponding initializer is an lvalue, rvalue reference otherwise. The initializer for the i-th variable is
+// - e.get<i>(), if lookup for the identifier get in the scope of E by class member access lookup finds at least one declaration that is a function template whose first template parameter is a non-type parameter
+// - Otherwise, get<i>(e), where get is looked up by argument-dependent lookup only, ignoring non-ADL lookup. 
+// 
+// The initializer for the new variable is e.get<i> or get<i>(e). 
+// Here the overload of get that is called is a rvalue in case we use auto and an lvalue in case we use auto&
+
+
+
+#include <cassert>
+#include <tuple>
+
+// https://en.cppreference.com/w/cpp/language/structured_binding
+float x = {};
+
+char y = {};
+
+int z = {};
+
+ 
+std::tuple<float &, char &&, int> tpl = std::tuple<float &, char &&, int>(x, std::move(y), z);
+
+//auto tpl = std::tuple{x,std::move(y),z};
+std::tuple<float &, char &&, int> & __tpl72 = tpl;
+float & a = std::get<0UL>(__tpl72);
+char & b = std::get<1UL>(__tpl72);
+int & c = std::get<2UL>(__tpl72);
+
+// a names a structured binding that refers to x; decltype(a) is float&
+// b names a structured binding that refers to y; decltype(b) is char&&
+// c names a structured binding that refers to the 3rd element of tpl; decltype(c) is int
+
+int main()
+{
+  a = static_cast<float>(4.5);
+  c = 5;
+  return 0;
+}
+


### PR DESCRIPTION
This patch changes the behavior of how the resulting reference type of a
binding is determined. Now, the code uses the holding variables
type information of a `BindingDecl`. This seems to be consistent with
what Clang does.

The reference kind of a binding is determined by the declaration of the
structured binding.

In [dcl.struct.bind] the standard says that the reference type for a
binding is an lvalue reference if the initializer is an lvalue and
otherwise a rvalue reference. The initializer here donates to the hidden
object, referenced as e. WE declare this implicitly by declaring the
structured binding.

We get an rvalue reference in case we declare the structured binding as
a non-reference like this:
```
auto [a, b, c]
```

We get an lvalue reference if the structured binding is declared as
this:

```
auto& [a, b, c]
```

In the rvalue case we could profit from move because the contents of the
implicitly created object can be moved out.

If we have a reference to the original object moving wouldn't be a good
ting to do, hence an lvalue reference.

`std::get` has overloads for both l- and rvalues and returns the
respective reference type for each overload.

This behavior is observable thanks to #381 which shows the implicit cast
of the hidden object to a rvalue.