### PR TITLE
Fixed #454: Added missing support for noexcept transformation.

### DIFF
--- a/CodeGenerator.h
+++ b/CodeGenerator.h
@@ -267,6 +267,7 @@ protected:
 
     STRONG_BOOL(SkipBody);
     void InsertCXXMethodDecl(const CXXMethodDecl* stmt, SkipBody skipBody);
+    void InsertMethodBody(const FunctionDecl* stmt);
 
     /// \brief Generalized function to insert either a \c CXXConstructExpr or \c CXXUnresolvedConstructExpr
     template<typename T>

--- a/tests/Issue454.cpp
+++ b/tests/Issue454.cpp
@@ -1,0 +1,16 @@
+// cmdlineinsights:-edu-show-noexcept
+
+struct Data
+{
+  int i;
+  double d;
+  double func() const noexcept{
+	// should't also this show a try ... catch block? 
+    return d*i;
+  }
+};
+
+
+int func() noexcept {
+  return 4*6;
+}

--- a/tests/Issue454.expect
+++ b/tests/Issue454.expect
@@ -1,0 +1,30 @@
+#include <exception> // for noexcept transformation
+// cmdlineinsights:-edu-show-noexcept
+
+struct Data
+{
+  int i;
+  double d;
+  inline double func() const noexcept
+  {
+    try {
+      return this->d * static_cast<double>(this->i);
+    } catch(...) {
+      std::terminate();
+    }
+  }
+  
+};
+
+
+
+
+int func() noexcept
+{
+  try {
+    return 4 * 6;
+  } catch(...) {
+    std::terminate();
+  }
+}
+


### PR DESCRIPTION
The first implementation left member functions untransformed. This patch
adds support for them.