### PR TITLE
Fixed `noexcept` in destructors.

### DIFF
--- a/InsightsHelpers.cpp
+++ b/InsightsHelpers.cpp
@@ -1367,6 +1367,9 @@ const std::string GetNoExcept(const FunctionDecl& decl)
         }
 
         return ret;
+    } else if(func and isUnresolvedExceptionSpec(func->getExceptionSpecType())) {
+        // For special members the exception specification is unevaluated as long as the special member is unused.
+        return StrCat(" "sv, kwCommentStart, kwSpaceNoexcept, kwSpaceCCommentEnd);
     }
 
     return {};

--- a/tests/CharLiteralTest.expect
+++ b/tests/CharLiteralTest.expect
@@ -36,7 +36,7 @@ struct Foo<int>
     return this->raw;
   }
   
-  inline constexpr Foo<int> & operator=(const Foo<int> & rhs) = default;
+  inline constexpr Foo<int> & operator=(const Foo<int> & rhs) /* noexcept */ = default;
   inline Foo<int> & operator=(int v);
   
   inline void operator=(int v) volatile;
@@ -53,13 +53,13 @@ struct Foo<char>
 {
   char raw;
   inline Foo() noexcept = default;
-  inline constexpr Foo(const Foo<char> & v) = default;
+  inline constexpr Foo(const Foo<char> & v) /* noexcept */ = default;
   inline constexpr Foo(char v);
   
   using retType_12_5 = char;
   inline constexpr operator retType_12_5 () const;
   
-  inline constexpr Foo<char> & operator=(const Foo<char> & rhs) = default;
+  inline constexpr Foo<char> & operator=(const Foo<char> & rhs) /* noexcept */ = default;
   inline Foo<char> & operator=(char v)
   {
     this->raw = v;

--- a/tests/Class2Test.expect
+++ b/tests/Class2Test.expect
@@ -60,7 +60,7 @@ class Test
 struct S
 {
   Test count;
-  // inline constexpr S(S &&) = delete;
+  // inline constexpr S(S &&) /* noexcept */ = delete;
   // inline S() noexcept(false) = default;
 };
 

--- a/tests/CoroutinesCoReturnPlusTest.expect
+++ b/tests/CoroutinesCoReturnPlusTest.expect
@@ -86,7 +86,7 @@ struct generator
   
   std::experimental::coroutine_handle<promise_type> p;
   public: 
-  // inline generator & operator=(const generator &) = delete;
+  // inline generator & operator=(const generator &) /* noexcept */ = delete;
 };
 
 

--- a/tests/EduCoroutineAllocFailureTest.expect
+++ b/tests/EduCoroutineAllocFailureTest.expect
@@ -114,8 +114,8 @@ struct generator<int>
   
   std::experimental::coroutine_handle<promise_type> p;
   public: 
-  // inline constexpr generator(const generator<int> &) = delete;
-  // inline generator<int> & operator=(const generator<int> &) = delete;
+  // inline constexpr generator(const generator<int> &) /* noexcept */ = delete;
+  // inline generator<int> & operator=(const generator<int> &) /* noexcept */ = delete;
 };
 
 #endif

--- a/tests/EduCoroutineBinaryExprTest.expect
+++ b/tests/EduCoroutineBinaryExprTest.expect
@@ -80,8 +80,8 @@ struct generator
   
   std::experimental::coroutine_handle<promise_type> p;
   public: 
-  // inline constexpr generator(const generator &) = delete;
-  // inline generator & operator=(const generator &) = delete;
+  // inline constexpr generator(const generator &) /* noexcept */ = delete;
+  // inline generator & operator=(const generator &) /* noexcept */ = delete;
 };
 
 

--- a/tests/EduCoroutineCaptureConstTest.expect
+++ b/tests/EduCoroutineCaptureConstTest.expect
@@ -80,8 +80,8 @@ struct generator
   
   std::experimental::coroutine_handle<promise_type> p;
   public: 
-  // inline constexpr generator(const generator &) = delete;
-  // inline generator & operator=(const generator &) = delete;
+  // inline constexpr generator(const generator &) /* noexcept */ = delete;
+  // inline generator & operator=(const generator &) /* noexcept */ = delete;
 };
 
 

--- a/tests/EduCoroutineCoreturnWithCoawaitTest.expect
+++ b/tests/EduCoroutineCoreturnWithCoawaitTest.expect
@@ -101,8 +101,8 @@ struct generator
   
   std::experimental::coroutine_handle<promise_type> p;
   public: 
-  // inline constexpr generator(const generator &) = delete;
-  // inline generator & operator=(const generator &) = delete;
+  // inline constexpr generator(const generator &) /* noexcept */ = delete;
+  // inline generator & operator=(const generator &) /* noexcept */ = delete;
 };
 
 

--- a/tests/EduCoroutineCustomYieldTypeTest.expect
+++ b/tests/EduCoroutineCustomYieldTypeTest.expect
@@ -135,8 +135,8 @@ struct generator
   
   std::experimental::coroutine_handle<promise_type> p;
   public: 
-  // inline constexpr generator(const generator &) = delete;
-  // inline generator & operator=(const generator &) = delete;
+  // inline constexpr generator(const generator &) /* noexcept */ = delete;
+  // inline generator & operator=(const generator &) /* noexcept */ = delete;
 };
 
 

--- a/tests/EduCoroutineSimpleTest.expect
+++ b/tests/EduCoroutineSimpleTest.expect
@@ -83,8 +83,8 @@ struct generator
   
   std::experimental::coroutine_handle<promise_type> p;
   public: 
-  // inline constexpr generator(const generator &) = delete;
-  // inline generator & operator=(const generator &) = delete;
+  // inline constexpr generator(const generator &) /* noexcept */ = delete;
+  // inline generator & operator=(const generator &) /* noexcept */ = delete;
 };
 
 

--- a/tests/EduCoroutineSuspendNeverBoolTest.expect
+++ b/tests/EduCoroutineSuspendNeverBoolTest.expect
@@ -122,8 +122,8 @@ struct generator<int>
   
   std::experimental::coroutine_handle<promise_type> p;
   public: 
-  // inline constexpr generator(const generator<int> &) = delete;
-  // inline generator<int> & operator=(const generator<int> &) = delete;
+  // inline constexpr generator(const generator<int> &) /* noexcept */ = delete;
+  // inline generator<int> & operator=(const generator<int> &) /* noexcept */ = delete;
 };
 
 #endif

--- a/tests/EduCoroutineSuspendNeverTest.expect
+++ b/tests/EduCoroutineSuspendNeverTest.expect
@@ -105,8 +105,8 @@ struct generator<int>
   
   std::experimental::coroutine_handle<promise_type> p;
   public: 
-  // inline constexpr generator(const generator<int> &) = delete;
-  // inline generator<int> & operator=(const generator<int> &) = delete;
+  // inline constexpr generator(const generator<int> &) /* noexcept */ = delete;
+  // inline generator<int> & operator=(const generator<int> &) /* noexcept */ = delete;
 };
 
 #endif

--- a/tests/EduCoroutineTemplateGeneratorTest.expect
+++ b/tests/EduCoroutineTemplateGeneratorTest.expect
@@ -104,8 +104,8 @@ struct generator<int>
   
   std::experimental::coroutine_handle<promise_type> p;
   public: 
-  // inline constexpr generator(const generator<int> &) = delete;
-  // inline generator<int> & operator=(const generator<int> &) = delete;
+  // inline constexpr generator(const generator<int> &) /* noexcept */ = delete;
+  // inline generator<int> & operator=(const generator<int> &) /* noexcept */ = delete;
 };
 
 #endif

--- a/tests/EduCoroutineVoidTest.expect
+++ b/tests/EduCoroutineVoidTest.expect
@@ -106,8 +106,8 @@ struct generator<int>
   
   std::experimental::coroutine_handle<promise_type> p;
   public: 
-  // inline constexpr generator(const generator<int> &) = delete;
-  // inline generator<int> & operator=(const generator<int> &) = delete;
+  // inline constexpr generator(const generator<int> &) /* noexcept */ = delete;
+  // inline generator<int> & operator=(const generator<int> &) /* noexcept */ = delete;
 };
 
 #endif

--- a/tests/EduCoroutineWithDtorTest.expect
+++ b/tests/EduCoroutineWithDtorTest.expect
@@ -122,8 +122,8 @@ struct generator<Test>
   
   std::experimental::coroutine_handle<promise_type> p;
   public: 
-  // inline constexpr generator(const generator<Test> &) = delete;
-  // inline generator<Test> & operator=(const generator<Test> &) = delete;
+  // inline constexpr generator(const generator<Test> &) /* noexcept */ = delete;
+  // inline generator<Test> & operator=(const generator<Test> &) /* noexcept */ = delete;
 };
 
 #endif

--- a/tests/EduCoroutineWithExceptionHandlerTest.expect
+++ b/tests/EduCoroutineWithExceptionHandlerTest.expect
@@ -122,8 +122,8 @@ struct generator<int>
   
   std::experimental::coroutine_handle<promise_type> p;
   public: 
-  // inline constexpr generator(const generator<int> &) = delete;
-  // inline generator<int> & operator=(const generator<int> &) = delete;
+  // inline constexpr generator(const generator<int> &) /* noexcept */ = delete;
+  // inline generator<int> & operator=(const generator<int> &) /* noexcept */ = delete;
 };
 
 #endif

--- a/tests/EduCoroutineWithLambdaTest.expect
+++ b/tests/EduCoroutineWithLambdaTest.expect
@@ -82,8 +82,8 @@ struct generator
   
   std::experimental::coroutine_handle<promise_type> p;
   public: 
-  // inline constexpr generator(const generator &) = delete;
-  // inline generator & operator=(const generator &) = delete;
+  // inline constexpr generator(const generator &) /* noexcept */ = delete;
+  // inline generator & operator=(const generator &) /* noexcept */ = delete;
 };
 
 

--- a/tests/Issue188_2.expect
+++ b/tests/Issue188_2.expect
@@ -22,7 +22,7 @@ namespace mstd
     
     inline constexpr _Head_base(const long & __h);
     
-    inline constexpr _Head_base(const _Head_base<2, long, false> &) = default;
+    inline constexpr _Head_base(const _Head_base<2, long, false> &) /* noexcept */ = default;
     long _M_head_impl;
   };
   
@@ -39,7 +39,7 @@ namespace mstd
     
     inline constexpr _Head_base(const short & __h);
     
-    inline constexpr _Head_base(const _Head_base<1, short, false> &) = default;
+    inline constexpr _Head_base(const _Head_base<1, short, false> &) /* noexcept */ = default;
     short _M_head_impl;
   };
   

--- a/tests/Issue2.expect
+++ b/tests/Issue2.expect
@@ -37,8 +37,8 @@ int main()
     Movable x;
     int c;
     public: 
-    // inline __lambda_20_16(const __lambda_20_16 &) = delete;
-    // inline __lambda_20_16 & operator=(const __lambda_20_16 &) = delete;
+    // inline __lambda_20_16(const __lambda_20_16 &) /* noexcept */ = delete;
+    // inline __lambda_20_16 & operator=(const __lambda_20_16 &) /* noexcept */ = delete;
     __lambda_20_16(Movable && _x, int & _c)
     : x{std::move(_x)}
     , c{_c}

--- a/tests/Issue205.expect
+++ b/tests/Issue205.expect
@@ -22,7 +22,7 @@ class EventContainer
     private: 
     EventContainer * __this;
     public: 
-    // inline /*constexpr */ __lambda_6_43 & operator=(const __lambda_6_43 &) = delete;
+    // inline /*constexpr */ __lambda_6_43 & operator=(const __lambda_6_43 &) /* noexcept */ = delete;
     // inline /*constexpr */ __lambda_6_43(const __lambda_6_43 &) noexcept = default;
     // inline /*constexpr */ __lambda_6_43(__lambda_6_43 &&) noexcept = default;
     __lambda_6_43(EventContainer * _this)

--- a/tests/Issue205_2.expect
+++ b/tests/Issue205_2.expect
@@ -20,7 +20,7 @@ class EventContainer
     private: 
     EventContainer * __this;
     public: 
-    // inline /*constexpr */ __lambda_6_43 & operator=(const __lambda_6_43 &) = delete;
+    // inline /*constexpr */ __lambda_6_43 & operator=(const __lambda_6_43 &) /* noexcept */ = delete;
     // inline /*constexpr */ __lambda_6_43(const __lambda_6_43 &) noexcept = default;
     // inline /*constexpr */ __lambda_6_43(__lambda_6_43 &&) noexcept = default;
     __lambda_6_43(EventContainer * _this)

--- a/tests/Issue233.expect
+++ b/tests/Issue233.expect
@@ -1,8 +1,8 @@
 struct C
 {
   int & i;
-  inline C() = delete;
-  inline constexpr C(const C &) = default;
+  inline C() /* noexcept */ = delete;
+  inline constexpr C(const C &) /* noexcept */ = default;
 };
 
 

--- a/tests/Issue258.expect
+++ b/tests/Issue258.expect
@@ -16,8 +16,8 @@ int main()
     private: 
     std::unique_ptr<int, std::default_delete<int> > x;
     public: 
-    // inline /*constexpr */ __lambda_7_19(const __lambda_7_19 &) = delete;
-    // inline __lambda_7_19 & operator=(const __lambda_7_19 &) = delete;
+    // inline /*constexpr */ __lambda_7_19(const __lambda_7_19 &) /* noexcept */ = delete;
+    // inline __lambda_7_19 & operator=(const __lambda_7_19 &) /* noexcept */ = delete;
     __lambda_7_19(std::unique_ptr<int, std::default_delete<int> > && _x)
     : x{std::move(_x)}
     {}

--- a/tests/Issue258_2.expect
+++ b/tests/Issue258_2.expect
@@ -13,7 +13,7 @@ class NonMoveable
   // inline NonMoveable(const NonMoveable &) = delete;
   // inline NonMoveable & operator=(const NonMoveable &) = delete;
   inline constexpr NonMoveable(NonMoveable &&) noexcept = default;
-  inline NonMoveable & operator=(NonMoveable &&) = default;
+  inline NonMoveable & operator=(NonMoveable &&) /* noexcept */ = default;
   inline int Get() const
   {
     return this->mX;
@@ -38,8 +38,8 @@ int main()
     private: 
     NonMoveable x;
     public: 
-    // inline __lambda_22_19(const __lambda_22_19 &) = delete;
-    // inline __lambda_22_19 & operator=(const __lambda_22_19 &) = delete;
+    // inline __lambda_22_19(const __lambda_22_19 &) /* noexcept */ = delete;
+    // inline __lambda_22_19 & operator=(const __lambda_22_19 &) /* noexcept */ = delete;
     __lambda_22_19(NonMoveable && _x)
     : x{static_cast<NonMoveable &&>(_x)}
     {}

--- a/tests/Issue288.expect
+++ b/tests/Issue288.expect
@@ -82,7 +82,7 @@ namespace expressions
       __lambda_27_16 ex1;
       __lambda_32_16 ex2;
       public: 
-      // inline /*constexpr */ __lambda_20_10 & operator=(const __lambda_20_10 &) = delete;
+      // inline /*constexpr */ __lambda_20_10 & operator=(const __lambda_20_10 &) /* noexcept */ = delete;
       __lambda_20_10(__lambda_27_16 && _ex1, __lambda_32_16 && _ex2)
       : ex1{std::move(_ex1)}
       , ex2{std::move(_ex2)}
@@ -117,7 +117,7 @@ namespace expressions
     
     public: 
     // inline /*constexpr */ __lambda_27_16(__lambda_27_16 &&) noexcept = default;
-    // inline /*constexpr */ __lambda_27_16 & operator=(const __lambda_27_16 &) = delete;
+    // inline /*constexpr */ __lambda_27_16 & operator=(const __lambda_27_16 &) /* noexcept */ = delete;
     
   };
   
@@ -145,7 +145,7 @@ namespace expressions
     
     public: 
     // inline /*constexpr */ __lambda_32_16(__lambda_32_16 &&) noexcept = default;
-    // inline /*constexpr */ __lambda_32_16 & operator=(const __lambda_32_16 &) = delete;
+    // inline /*constexpr */ __lambda_32_16 & operator=(const __lambda_32_16 &) /* noexcept */ = delete;
     
   };
   

--- a/tests/Issue347.expect
+++ b/tests/Issue347.expect
@@ -14,7 +14,7 @@ int main()
     private: 
     std::basic_string<char, std::char_traits<char>, std::allocator<char> > str;
     public: 
-    // inline __lambda_5_12 & operator=(const __lambda_5_12 &) = delete;
+    // inline __lambda_5_12 & operator=(const __lambda_5_12 &) /* noexcept */ = delete;
     __lambda_5_12(const std::basic_string<char, std::char_traits<char>, std::allocator<char> > & _str)
     : str{_str}
     {}

--- a/tests/Issue347_2.expect
+++ b/tests/Issue347_2.expect
@@ -14,7 +14,7 @@ int main()
     private: 
     const std::basic_string<char, std::char_traits<char>, std::allocator<char> > str;
     public: 
-    // inline __lambda_5_12 & operator=(const __lambda_5_12 &) = delete;
+    // inline __lambda_5_12 & operator=(const __lambda_5_12 &) /* noexcept */ = delete;
     __lambda_5_12(const std::basic_string<char, std::char_traits<char>, std::allocator<char> > & _str)
     : str{_str}
     {}

--- a/tests/Issue402.expect
+++ b/tests/Issue402.expect
@@ -28,14 +28,14 @@ int main()
       }
       
       public: 
-      // inline /*constexpr */ __lambda_2_8 & operator=(const __lambda_2_8 &) = delete;
+      // inline /*constexpr */ __lambda_2_8 & operator=(const __lambda_2_8 &) /* noexcept */ = delete;
       
     };
     
     private: 
     __lambda_2_8 var;
     public: 
-    // inline /*constexpr */ __lambda_2_3 & operator=(const __lambda_2_3 &) = delete;
+    // inline /*constexpr */ __lambda_2_3 & operator=(const __lambda_2_3 &) /* noexcept */ = delete;
     __lambda_2_3(const __lambda_2_8 & _var)
     : var{_var}
     {}

--- a/tests/Issue64.expect
+++ b/tests/Issue64.expect
@@ -14,7 +14,7 @@ void func(const std::basic_string<char, std::char_traits<char>, std::allocator<c
     private: 
     const std::basic_string<char, std::char_traits<char>, std::allocator<char> > arg;
     public: 
-    // inline __lambda_5_11 & operator=(const __lambda_5_11 &) = delete;
+    // inline __lambda_5_11 & operator=(const __lambda_5_11 &) /* noexcept */ = delete;
     __lambda_5_11(const std::basic_string<char, std::char_traits<char>, std::allocator<char> > & _arg)
     : arg{_arg}
     {}

--- a/tests/Issue92.expect
+++ b/tests/Issue92.expect
@@ -184,8 +184,8 @@ struct generator<unsigned int>
   
   std::experimental::coroutine_handle<promise_type> p;
   public: 
-  // inline constexpr generator(const generator<unsigned int> &) = delete;
-  // inline generator<unsigned int> & operator=(const generator<unsigned int> &) = delete;
+  // inline constexpr generator(const generator<unsigned int> &) /* noexcept */ = delete;
+  // inline generator<unsigned int> & operator=(const generator<unsigned int> &) /* noexcept */ = delete;
 };
 
 #endif

--- a/tests/LambdaAndInClassInitializerTest.expect
+++ b/tests/LambdaAndInClassInitializerTest.expect
@@ -17,7 +17,7 @@ class function<void ()>
 {
   
   public: 
-  inline constexpr function() = default;
+  inline constexpr function() /* noexcept */ = default;
   template<typename T>
   inline function(T && f);
   

--- a/tests/NoexceptDtorTest.cpp
+++ b/tests/NoexceptDtorTest.cpp
@@ -1,0 +1,33 @@
+struct A {
+	~A() {}
+};
+
+struct C { 
+  int i; 
+
+  // remains unevaluated as int doesn't require a dtor  
+  ~C() = default;
+};
+
+
+struct D { 
+  A a{};
+  
+  // unevaluated as not instantiated
+  ~D() = default;
+};
+
+
+struct E { 
+  A a{};
+  
+  // implicitly noexcept
+  ~E() = default;
+};
+
+int main()
+{ 
+  C c{};
+  E e{}; 
+}
+

--- a/tests/NoexceptDtorTest.expect
+++ b/tests/NoexceptDtorTest.expect
@@ -1,0 +1,44 @@
+struct A
+{
+  inline ~A() noexcept
+  {
+  }
+  
+};
+
+
+
+struct C
+{
+  int i;
+  inline ~C() /* noexcept */ = default;
+};
+
+
+
+
+struct D
+{
+  A a{};
+  inline ~D() /* noexcept */ = default;
+};
+
+
+
+
+struct E
+{
+  A a{};
+  inline ~E() noexcept = default;
+};
+
+
+
+int main()
+{
+  C c = {0};
+  E e = {{}};
+  return 0;
+}
+
+

--- a/tests/SpecialMemberTest.expect
+++ b/tests/SpecialMemberTest.expect
@@ -5,7 +5,7 @@ class C
 {
   
   public: 
-  inline C() = delete;
+  inline C() /* noexcept */ = delete;
   
   private: 
   const int i;
@@ -17,13 +17,13 @@ class D
 {
   
   public: 
-  inline constexpr D() = default;
+  inline constexpr D() /* noexcept */ = default;
   
   private: 
   std::unique_ptr<int, std::default_delete<int> > p;
   public: 
-  // inline constexpr D(const D &) = delete;
-  // inline D & operator=(const D &) = delete;
+  // inline constexpr D(const D &) /* noexcept */ = delete;
+  // inline D & operator=(const D &) /* noexcept */ = delete;
 };
 
 

--- a/tests/VisitorTest.expect
+++ b/tests/VisitorTest.expect
@@ -11,8 +11,8 @@ struct visitor<__lambda_8_7, __lambda_9_7> : public __lambda_8_7, public __lambd
   using __lambda_9_7::operator();
   // inline /*constexpr */ void ::operator()(const char * value) const;
   
-  // inline constexpr visitor<__lambda_8_7, __lambda_9_7> & operator=(const visitor<__lambda_8_7, __lambda_9_7> &) = delete;
-  // inline constexpr visitor<__lambda_8_7, __lambda_9_7> & operator=(visitor<__lambda_8_7, __lambda_9_7> &&) = delete;
+  // inline constexpr visitor<__lambda_8_7, __lambda_9_7> & operator=(const visitor<__lambda_8_7, __lambda_9_7> &) /* noexcept */ = delete;
+  // inline constexpr visitor<__lambda_8_7, __lambda_9_7> & operator=(visitor<__lambda_8_7, __lambda_9_7> &&) /* noexcept */ = delete;
 };
 
 #endif
@@ -37,7 +37,7 @@ int main()
     {
     }
     
-    // inline /*constexpr */ __lambda_8_7 & operator=(const __lambda_8_7 &) = delete;
+    // inline /*constexpr */ __lambda_8_7 & operator=(const __lambda_8_7 &) /* noexcept */ = delete;
     // inline /*constexpr */ __lambda_8_7(__lambda_8_7 &&) noexcept = default;
     
   };
@@ -50,7 +50,7 @@ int main()
     {
     }
     
-    // inline /*constexpr */ __lambda_9_7 & operator=(const __lambda_9_7 &) = delete;
+    // inline /*constexpr */ __lambda_9_7 & operator=(const __lambda_9_7 &) /* noexcept */ = delete;
     // inline /*constexpr */ __lambda_9_7(__lambda_9_7 &&) noexcept = default;
     
   };

--- a/tests/runTest.py
+++ b/tests/runTest.py
@@ -120,8 +120,7 @@ def main():
     defaultCppStd = '-std=%s'% (args['std'])
 
     if 0 == len(remainingArgs):
-        cppFiles = [f for f in os.listdir(mypath) if (os.path.isfile(os.path.join(mypath, f)) and f.endswith('.cpp') and
-            f.startswith('EduCo') )]
+        cppFiles = [f for f in os.listdir(mypath) if (os.path.isfile(os.path.join(mypath, f)) and f.endswith('.cpp'))]
     else:
         cppFiles = remainingArgs
 

--- a/tests/usingConstructor2Test.expect
+++ b/tests/usingConstructor2Test.expect
@@ -15,7 +15,7 @@ class Derived : public Base
   
   public: 
   int someValue;
-  // inline Derived() = delete;
+  // inline Derived() /* noexcept */ = delete;
   inline Derived(double __param0) noexcept(false)
   : Base(__param0)
   {

--- a/tests/usingConstructorTest.expect
+++ b/tests/usingConstructorTest.expect
@@ -19,7 +19,7 @@ class Bar : public Foo
   
   public: 
   int mX;
-  // inline Bar() = delete;
+  // inline Bar() /* noexcept */ = delete;
   inline Bar(double amount) noexcept(false)
   : Foo(amount)
   {
@@ -40,7 +40,7 @@ class Bla : public Foo
   private: 
   int mX;
   public: 
-  // inline Bla() = delete;
+  // inline Bla() /* noexcept */ = delete;
   inline Bla(int x, int y) noexcept(false)
   : Foo(x, y)
   {


### PR DESCRIPTION
Destructors are always implicitly inline if not declared 
otherwise. See [except.spec] p8 and [class.dtor] p6. However,
it can be that Clang does not evaluate the exception
specification of a destructor (or any other functions) if
that function is not used.

This patch adds a `noexcept` comment in this case.