### PR TITLE
Fixed #509: `inline namespace` in global scope

### DIFF
--- a/InsightsHelpers.cpp
+++ b/InsightsHelpers.cpp
@@ -462,7 +462,7 @@ static std::string GetScope(const DeclContext*       declCtx,
             declCtx = declCtx->getParent();
         }
 
-        if(declCtx->isNamespace() or declCtx->getParent()->isTranslationUnit()) {
+        if(not declCtx->isTranslationUnit() and (declCtx->isNamespace() or declCtx->getParent()->isTranslationUnit())) {
             if(const auto* namedDecl = dyn_cast_or_null<NamedDecl>(declCtx)) {
                 name = GetQualifiedName(*namedDecl, removeCurrentScope);
                 name.append("::"sv);


### PR DESCRIPTION
Fixed #509: `inline namespace` in global scope

In function `GetScope` at `InsightsHelpers.cpp:455`, when the argument `declCtx` is a `inline namespace` in global scope, it becomes the global scope after running the while loop and `declCtx->getParent()` returns an empty pointer, which causes segmentation fault.