### PR TITLE
Fixed #520: Avoiding crashing due to unsatisfied requirements.

### DIFF
--- a/tests/Issue520.cpp
+++ b/tests/Issue520.cpp
@@ -1,0 +1,35 @@
+// cmdline:-std=c++20
+
+template<typename Type, typename Archive>
+constexpr static auto simple()
+{
+  return requires(Type && item, Archive && archive)
+  {
+    serialize(archive, item);
+  };
+}
+
+template<typename Type, typename Archive>
+constexpr static auto nested()
+{
+  return requires(Type && item, Archive && archive)
+  {
+    requires serialize(archive, item);
+  };
+}
+
+template<typename Type>
+constexpr static auto type()
+{
+  return requires(Type && item)
+  {
+    typename Type::value;
+  };
+}
+
+
+int main()
+{
+  return simple<int, int>() || nested<int, int>() || type<int>();
+}
+

--- a/tests/Issue520.expect
+++ b/tests/Issue520.expect
@@ -1,0 +1,69 @@
+// cmdline:-std=c++20
+
+template<typename Type, typename Archive>
+static inline constexpr auto simple()
+{
+  return requires(Type && item, Archive && archive) {
+    serialize(archive, item);
+  };
+}
+
+
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+inline constexpr bool simple<int, int>()
+{
+  return requires(int && item, int && archive) {
+    requires false;
+  };
+}
+#endif
+
+
+template<typename Type, typename Archive>
+static inline constexpr auto nested()
+{
+  return requires(Type && item, Archive && archive) {
+    requires serialize(archive, item);
+  };
+}
+
+
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+inline constexpr bool nested<int, int>()
+{
+  return requires(int && item, int && archive) {
+    requires false;
+  };
+}
+#endif
+
+
+template<typename Type>
+static inline constexpr auto type()
+{
+  return requires(Type && item) {
+    typename Type::value;
+  };
+}
+
+
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+inline constexpr bool type<int>()
+{
+  return requires(int && item) {
+    requires false;
+  };
+}
+#endif
+
+
+
+int main()
+{
+  return static_cast<int>((simple<int, int>() || nested<int, int>()) || type<int>());
+}
+
+


### PR DESCRIPTION
A `requires` expression can be used as a return value in the body of a function, for example. In this case, the expression is there for an instantiation. If now a requirement fails, this instantation is not satisfied, but there is no printable expression anymore. In this case, C++ Insights simply creates `requires false` to keep the result.