### PR TITLE
Fixed #536: Call promise constructor if arguments match.

### DIFF
--- a/CodeGenerator.cpp
+++ b/CodeGenerator.cpp
@@ -611,6 +611,13 @@ void CodeGenerator::InsertArg(const MemberExpr* stmt)
             }
         }
 
+        // Special case. If this is a CXXConversionDecl it might be:
+        // a) a template so we need the template arguments from this type
+        // b) in a namespace and need want to preserve that one.
+        if(const auto* convDecl = dyn_cast_or_null<CXXConversionDecl>(meDecl)) {
+            return StrCat(kwOperatorSpace, GetName(convDecl->getConversionType()));
+        }
+
         return stmt->getMemberNameInfo().getName().getAsString();
     }();
 

--- a/tests/ConversionDeclTest.cpp
+++ b/tests/ConversionDeclTest.cpp
@@ -1,0 +1,16 @@
+namespace test {
+template<class T = void>
+struct coroutine_handle
+{
+    operator coroutine_handle<>() { return {}; }
+};
+}
+
+int main()
+{
+    test::coroutine_handle<int> a{};
+
+    test::coroutine_handle<> b = a;
+}
+
+

--- a/tests/ConversionDeclTest.expect
+++ b/tests/ConversionDeclTest.expect
@@ -1,0 +1,50 @@
+namespace test
+{
+  template<class T = void>
+  struct coroutine_handle
+  {
+    using retType_5_5 = coroutine_handle<void>;
+    inline operator retType_5_5 ()
+    {
+      return {};
+    }
+    
+  };
+  
+  /* First instantiated from: ConversionDeclTest.cpp:5 */
+  #ifdef INSIGHTS_USE_TEMPLATE
+  template<>
+  struct coroutine_handle<void>
+  {
+    using retType_5_5 = coroutine_handle<void>;
+    inline operator retType_5_5 ();
+    
+  };
+  
+  #endif
+  /* First instantiated from: ConversionDeclTest.cpp:11 */
+  #ifdef INSIGHTS_USE_TEMPLATE
+  template<>
+  struct coroutine_handle<int>
+  {
+    using retType_5_5 = coroutine_handle<void>;
+    inline operator retType_5_5 ()
+    {
+      return {};
+    }
+    
+  };
+  
+  #endif
+  
+}
+
+int main()
+{
+  test::coroutine_handle<int> a = {};
+  test::coroutine_handle<void> b = static_cast<test::coroutine_handle<void>>(a.operator test::coroutine_handle<void>());
+  return 0;
+}
+
+
+

--- a/tests/EduCoroutineAllocFailureTest.expect
+++ b/tests/EduCoroutineAllocFailureTest.expect
@@ -194,7 +194,7 @@ generator<int> fun<int>()
   __fun_intResume(__f);
   
   
-  return __promise.get_return_object();
+  return __f->__promise.get_return_object();
 }
 
 /* This function invoked by coroutine_handle<>::resume() */
@@ -211,7 +211,7 @@ void __fun_intResume(__fun_intFrame * __f)
     /* co_await EduCoroutineAllocFailureTest.cpp:40 */
     __f->__suspend_40_14 = __f->__promise.initial_suspend();
     if(!__f->__suspend_40_14.await_ready()) {
-      __f->__suspend_40_14.await_suspend(std::coroutine_handle<generator<int>::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
+      __f->__suspend_40_14.await_suspend(std::coroutine_handle<generator<int>::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
       __f->__suspend_index = 1;
       __f->__initial_await_suspend_called = true;
       return;
@@ -235,7 +235,7 @@ void __fun_intResume(__fun_intFrame * __f)
   /* co_await EduCoroutineAllocFailureTest.cpp:40 */
   __f->__suspend_40_14_1 = __f->__promise.final_suspend();
   if(!__f->__suspend_40_14_1.await_ready()) {
-    __f->__suspend_40_14_1.await_suspend(std::coroutine_handle<generator<int>::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
+    __f->__suspend_40_14_1.await_suspend(std::coroutine_handle<generator<int>::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
   } 
   
   ;

--- a/tests/EduCoroutineBinaryExprTest.cerr
+++ b/tests/EduCoroutineBinaryExprTest.cerr
@@ -1,19 +1,4 @@
-.tmp.cpp:131:10: error: use of undeclared identifier '__promise'
-  return __promise.get_return_object();
-         ^
-.tmp.cpp:151:138: error: unknown type name 'coroutine_handle'
-      __f->__suspend_35_11.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
-                                                                                                                                         ^
-.tmp.cpp:165:139: error: unknown type name 'coroutine_handle'
-        __f->__suspend_42_5.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
-                                                                                                                                          ^
-.tmp.cpp:176:140: error: unknown type name 'coroutine_handle'
-        __f->__suspend_43_12.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
-                                                                                                                                           ^
-.tmp.cpp:187:139: error: unknown type name 'coroutine_handle'
-        __f->__suspend_44_5.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
-                                                                                                                                          ^
-.tmp.cpp:210:138: error: unknown type name 'coroutine_handle'
-    __f->__suspend_35_11_1.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
-                                                                                                                                         ^
-6 errors generated.
+.tmp.cpp:222:19: error: this builtin expect that __builtin_coro_id has been used earlier in this function
+  operator delete(__builtin_coro_free(static_cast<void *>(__f)));
+                  ^
+1 error generated.

--- a/tests/EduCoroutineBinaryExprTest.expect
+++ b/tests/EduCoroutineBinaryExprTest.expect
@@ -128,7 +128,7 @@ generator seq(int start)
   __seqResume(__f);
   
   
-  return __promise.get_return_object();
+  return __f->__promise.get_return_object();
 }
 
 /* This function invoked by coroutine_handle<>::resume() */
@@ -148,7 +148,7 @@ void __seqResume(__seqFrame * __f)
     /* co_await EduCoroutineBinaryExprTest.cpp:35 */
     __f->__suspend_35_11 = __f->__promise.initial_suspend();
     if(!__f->__suspend_35_11.await_ready()) {
-      __f->__suspend_35_11.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
+      __f->__suspend_35_11.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
       __f->__suspend_index = 1;
       __f->__initial_await_suspend_called = true;
       return;
@@ -162,7 +162,7 @@ void __seqResume(__seqFrame * __f)
       /* co_yield EduCoroutineBinaryExprTest.cpp:42 */
       __f->__suspend_42_5 = __f->__promise.yield_value(__f->s.t);
       if(!__f->__suspend_42_5.await_ready()) {
-        __f->__suspend_42_5.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
+        __f->__suspend_42_5.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
         __f->__suspend_index = 2;
         return;
       } 
@@ -173,7 +173,7 @@ void __seqResume(__seqFrame * __f)
       /* co_yield EduCoroutineBinaryExprTest.cpp:43 */
       __f->__suspend_43_12 = __f->__promise.yield_value(__f->i);
       if(!__f->__suspend_43_12.await_ready()) {
-        __f->__suspend_43_12.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
+        __f->__suspend_43_12.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
         __f->__suspend_index = 3;
         return;
       } 
@@ -184,7 +184,7 @@ void __seqResume(__seqFrame * __f)
       /* co_yield EduCoroutineBinaryExprTest.cpp:44 */
       __f->__suspend_44_5 = __f->__promise.yield_value(__f->i + 1);
       if(!__f->__suspend_44_5.await_ready()) {
-        __f->__suspend_44_5.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
+        __f->__suspend_44_5.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
         __f->__suspend_index = 4;
         return;
       } 
@@ -207,7 +207,7 @@ void __seqResume(__seqFrame * __f)
   /* co_await EduCoroutineBinaryExprTest.cpp:35 */
   __f->__suspend_35_11_1 = __f->__promise.final_suspend();
   if(!__f->__suspend_35_11_1.await_ready()) {
-    __f->__suspend_35_11_1.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
+    __f->__suspend_35_11_1.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
   } 
   
   ;

--- a/tests/EduCoroutineCaptureConstTest.cerr
+++ b/tests/EduCoroutineCaptureConstTest.cerr
@@ -4,12 +4,6 @@
 .tmp.cpp:96:15: note: non-static data member 'start' declared const here
   const int & start;
   ~~~~~~~~~~~~^~~~~
-.tmp.cpp:127:10: error: use of undeclared identifier '__promise'
-  return __promise.get_return_object();
-         ^
-.tmp.cpp:144:138: error: unknown type name 'coroutine_handle'
-      __f->__suspend_35_11.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
-                                                                                                                                         ^
 .tmp.cpp:152:12: error: no viable overloaded '='
     __f->s = {0, '\0'};
     ~~~~~~ ^ ~~~~~~~~~
@@ -17,7 +11,4 @@
   struct S
          ^
 .tmp.cpp:89:10: note: candidate function (the implicit move assignment operator) not viable: 'this' argument has type 'const __seqFrame::S', but method is not marked const
-.tmp.cpp:169:138: error: unknown type name 'coroutine_handle'
-    __f->__suspend_35_11_1.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
-                                                                                                                                         ^
-5 errors generated.
+2 errors generated.

--- a/tests/EduCoroutineCaptureConstTest.expect
+++ b/tests/EduCoroutineCaptureConstTest.expect
@@ -124,7 +124,7 @@ generator seq(const int & start)
   __seqResume(__f);
   
   
-  return __promise.get_return_object();
+  return __f->__promise.get_return_object();
 }
 
 /* This function invoked by coroutine_handle<>::resume() */
@@ -141,7 +141,7 @@ void __seqResume(__seqFrame * __f)
     /* co_await EduCoroutineCaptureConstTest.cpp:35 */
     __f->__suspend_35_11 = __f->__promise.initial_suspend();
     if(!__f->__suspend_35_11.await_ready()) {
-      __f->__suspend_35_11.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
+      __f->__suspend_35_11.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
       __f->__suspend_index = 1;
       __f->__initial_await_suspend_called = true;
       return;
@@ -166,7 +166,7 @@ void __seqResume(__seqFrame * __f)
   /* co_await EduCoroutineCaptureConstTest.cpp:35 */
   __f->__suspend_35_11_1 = __f->__promise.final_suspend();
   if(!__f->__suspend_35_11_1.await_ready()) {
-    __f->__suspend_35_11_1.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
+    __f->__suspend_35_11_1.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
   } 
   
   ;

--- a/tests/EduCoroutineCoAwaitOperatorTest.cerr
+++ b/tests/EduCoroutineCoAwaitOperatorTest.cerr
@@ -1,19 +1,4 @@
 .tmp.cpp:174:3: error: unknown type name 'awaiter'
   awaiter __suspend_54_5;
   ^
-.tmp.cpp:204:10: error: use of undeclared identifier '__promise'
-  return __promise.get_return_object();
-         ^
-.tmp.cpp:223:143: error: unknown type name 'coroutine_handle'
-      __f->__suspend_51_16.await_suspend(std::coroutine_handle<my_future<int>::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
-                                                                                                                                              ^
-.tmp.cpp:236:142: error: unknown type name 'coroutine_handle'
-      __f->__suspend_54_5.await_suspend(std::coroutine_handle<my_future<int>::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
-                                                                                                                                             ^
-.tmp.cpp:248:143: error: unknown type name 'coroutine_handle'
-      __f->__suspend_56_14.await_suspend(std::coroutine_handle<my_future<int>::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
-                                                                                                                                              ^
-.tmp.cpp:269:143: error: unknown type name 'coroutine_handle'
-    __f->__suspend_51_16_1.await_suspend(std::coroutine_handle<my_future<int>::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
-                                                                                                                                              ^
-6 errors generated.
+1 error generated.

--- a/tests/EduCoroutineCoAwaitOperatorTest.expect
+++ b/tests/EduCoroutineCoAwaitOperatorTest.expect
@@ -201,7 +201,7 @@ my_future<int> g()
   __gResume(__f);
   
   
-  return __promise.get_return_object();
+  return __f->__promise.get_return_object();
 }
 
 /* This function invoked by coroutine_handle<>::resume() */
@@ -220,7 +220,7 @@ void __gResume(__gFrame * __f)
     /* co_await EduCoroutineCoAwaitOperatorTest.cpp:51 */
     __f->__suspend_51_16 = __f->__promise.initial_suspend();
     if(!__f->__suspend_51_16.await_ready()) {
-      __f->__suspend_51_16.await_suspend(std::coroutine_handle<my_future<int>::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
+      __f->__suspend_51_16.await_suspend(std::coroutine_handle<my_future<int>::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
       __f->__suspend_index = 1;
       __f->__initial_await_suspend_called = true;
       return;
@@ -233,7 +233,7 @@ void __gResume(__gFrame * __f)
     /* co_await EduCoroutineCoAwaitOperatorTest.cpp:54 */
     __f->__suspend_54_5 = operator co_await(std::operator""ms(10ULL));
     if(!__f->__suspend_54_5.await_ready()) {
-      __f->__suspend_54_5.await_suspend(std::coroutine_handle<my_future<int>::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
+      __f->__suspend_54_5.await_suspend(std::coroutine_handle<my_future<int>::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
       __f->__suspend_index = 2;
       return;
     } 
@@ -245,7 +245,7 @@ void __gResume(__gFrame * __f)
     /* co_await EduCoroutineCoAwaitOperatorTest.cpp:56 */
     __f->__suspend_56_14 = h();
     if(!__f->__suspend_56_14.await_ready()) {
-      __f->__suspend_56_14.await_suspend(std::coroutine_handle<my_future<int>::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
+      __f->__suspend_56_14.await_suspend(std::coroutine_handle<my_future<int>::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
       __f->__suspend_index = 3;
       return;
     } 
@@ -266,7 +266,7 @@ void __gResume(__gFrame * __f)
   /* co_await EduCoroutineCoAwaitOperatorTest.cpp:51 */
   __f->__suspend_51_16_1 = __f->__promise.final_suspend();
   if(!__f->__suspend_51_16_1.await_ready()) {
-    __f->__suspend_51_16_1.await_suspend(std::coroutine_handle<my_future<int>::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
+    __f->__suspend_51_16_1.await_suspend(std::coroutine_handle<my_future<int>::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
   } 
   
   ;

--- a/tests/EduCoroutineCoreturnWithCoawaitTest.cerr
+++ b/tests/EduCoroutineCoreturnWithCoawaitTest.cerr
@@ -1,18 +1,6 @@
-.tmp.cpp:143:10: error: use of undeclared identifier '__promise'
-  return __promise.get_return_object();
-         ^
-.tmp.cpp:160:138: error: unknown type name 'coroutine_handle'
-      __f->__suspend_50_11.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
-                                                                                                                                         ^
-.tmp.cpp:184:138: error: unknown type name 'coroutine_handle'
-    __f->__suspend_50_11_1.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
-                                                                                                                                         ^
-.tmp.cpp:248:10: error: use of undeclared identifier '__promise'
-  return __promise.get_return_object();
-         ^
-.tmp.cpp:267:138: error: unknown type name 'coroutine_handle'
-      __f->__suspend_55_11.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
-                                                                                                                                         ^
+.tmp.cpp:196:19: error: this builtin expect that __builtin_coro_id has been used earlier in this function
+  operator delete(__builtin_coro_free(static_cast<void *>(__f)));
+                  ^
 .tmp.cpp:277:26: error: object of type 'generator' cannot be assigned because its copy assignment operator is implicitly deleted
     __f->__suspend_56_24 = simpleReturn(__f->v);
                          ^
@@ -25,15 +13,6 @@
 .tmp.cpp:73:10: note: copy assignment operator is implicitly deleted because 'generator' has a user-declared move constructor
   inline generator(generator && rhs)
          ^
-.tmp.cpp:315:138: error: unknown type name 'coroutine_handle'
-    __f->__suspend_55_11_1.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
-                                                                                                                                         ^
-.tmp.cpp:380:10: error: use of undeclared identifier '__promise'
-  return __promise.get_return_object();
-         ^
-.tmp.cpp:400:138: error: unknown type name 'coroutine_handle'
-      __f->__suspend_59_11.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
-                                                                                                                                         ^
 .tmp.cpp:410:26: error: object of type 'generator' cannot be assigned because its copy assignment operator is implicitly deleted
     __f->__suspend_60_24 = simpleReturn(__f->v);
                          ^
@@ -52,15 +31,6 @@
 .tmp.cpp:73:10: note: copy assignment operator is implicitly deleted because 'generator' has a user-declared move constructor
   inline generator(generator && rhs)
          ^
-.tmp.cpp:460:138: error: unknown type name 'coroutine_handle'
-    __f->__suspend_59_11_1.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
-                                                                                                                                         ^
-.tmp.cpp:523:10: error: use of undeclared identifier '__promise'
-  return __promise.get_return_object();
-         ^
-.tmp.cpp:542:138: error: unknown type name 'coroutine_handle'
-      __f->__suspend_63_11.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
-                                                                                                                                         ^
 .tmp.cpp:552:26: error: object of type 'generator' cannot be assigned because its copy assignment operator is implicitly deleted
     __f->__suspend_67_24 = simpleReturn(__f->v);
                          ^
@@ -73,7 +43,4 @@
 .tmp.cpp:73:10: note: copy assignment operator is implicitly deleted because 'generator' has a user-declared move constructor
   inline generator(generator && rhs)
          ^
-.tmp.cpp:591:138: error: unknown type name 'coroutine_handle'
-    __f->__suspend_63_11_1.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
-                                                                                                                                         ^
-19 errors generated.
+8 errors generated.

--- a/tests/EduCoroutineCoreturnWithCoawaitTest.expect
+++ b/tests/EduCoroutineCoreturnWithCoawaitTest.expect
@@ -140,7 +140,7 @@ generator simpleReturn(int v)
   __simpleReturnResume(__f);
   
   
-  return __promise.get_return_object();
+  return __f->__promise.get_return_object();
 }
 
 /* This function invoked by coroutine_handle<>::resume() */
@@ -157,7 +157,7 @@ void __simpleReturnResume(__simpleReturnFrame * __f)
     /* co_await EduCoroutineCoreturnWithCoawaitTest.cpp:50 */
     __f->__suspend_50_11 = __f->__promise.initial_suspend();
     if(!__f->__suspend_50_11.await_ready()) {
-      __f->__suspend_50_11.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
+      __f->__suspend_50_11.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
       __f->__suspend_index = 1;
       __f->__initial_await_suspend_called = true;
       return;
@@ -181,7 +181,7 @@ void __simpleReturnResume(__simpleReturnFrame * __f)
   /* co_await EduCoroutineCoreturnWithCoawaitTest.cpp:50 */
   __f->__suspend_50_11_1 = __f->__promise.final_suspend();
   if(!__f->__suspend_50_11_1.await_ready()) {
-    __f->__suspend_50_11_1.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
+    __f->__suspend_50_11_1.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
   } 
   
   ;
@@ -245,7 +245,7 @@ generator additionAwaitReturn(int v)
   __additionAwaitReturnResume(__f);
   
   
-  return __promise.get_return_object();
+  return __f->__promise.get_return_object();
 }
 
 /* This function invoked by coroutine_handle<>::resume() */
@@ -264,7 +264,7 @@ void __additionAwaitReturnResume(__additionAwaitReturnFrame * __f)
     /* co_await EduCoroutineCoreturnWithCoawaitTest.cpp:55 */
     __f->__suspend_55_11 = __f->__promise.initial_suspend();
     if(!__f->__suspend_55_11.await_ready()) {
-      __f->__suspend_55_11.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
+      __f->__suspend_55_11.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
       __f->__suspend_index = 1;
       __f->__initial_await_suspend_called = true;
       return;
@@ -312,7 +312,7 @@ void __additionAwaitReturnResume(__additionAwaitReturnFrame * __f)
   /* co_await EduCoroutineCoreturnWithCoawaitTest.cpp:55 */
   __f->__suspend_55_11_1 = __f->__promise.final_suspend();
   if(!__f->__suspend_55_11_1.await_ready()) {
-    __f->__suspend_55_11_1.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
+    __f->__suspend_55_11_1.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
   } 
   
   ;
@@ -377,7 +377,7 @@ generator additionAwaitReturn2(int v)
   __additionAwaitReturn2Resume(__f);
   
   
-  return __promise.get_return_object();
+  return __f->__promise.get_return_object();
 }
 
 /* This function invoked by coroutine_handle<>::resume() */
@@ -397,7 +397,7 @@ void __additionAwaitReturn2Resume(__additionAwaitReturn2Frame * __f)
     /* co_await EduCoroutineCoreturnWithCoawaitTest.cpp:59 */
     __f->__suspend_59_11 = __f->__promise.initial_suspend();
     if(!__f->__suspend_59_11.await_ready()) {
-      __f->__suspend_59_11.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
+      __f->__suspend_59_11.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
       __f->__suspend_index = 1;
       __f->__initial_await_suspend_called = true;
       return;
@@ -457,7 +457,7 @@ void __additionAwaitReturn2Resume(__additionAwaitReturn2Frame * __f)
   /* co_await EduCoroutineCoreturnWithCoawaitTest.cpp:59 */
   __f->__suspend_59_11_1 = __f->__promise.final_suspend();
   if(!__f->__suspend_59_11_1.await_ready()) {
-    __f->__suspend_59_11_1.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
+    __f->__suspend_59_11_1.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
   } 
   
   ;
@@ -520,7 +520,7 @@ generator additionAwaitReturnWithInt(int v)
   __additionAwaitReturnWithIntResume(__f);
   
   
-  return __promise.get_return_object();
+  return __f->__promise.get_return_object();
 }
 
 /* This function invoked by coroutine_handle<>::resume() */
@@ -539,7 +539,7 @@ void __additionAwaitReturnWithIntResume(__additionAwaitReturnWithIntFrame * __f)
     /* co_await EduCoroutineCoreturnWithCoawaitTest.cpp:63 */
     __f->__suspend_63_11 = __f->__promise.initial_suspend();
     if(!__f->__suspend_63_11.await_ready()) {
-      __f->__suspend_63_11.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
+      __f->__suspend_63_11.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
       __f->__suspend_index = 1;
       __f->__initial_await_suspend_called = true;
       return;
@@ -588,7 +588,7 @@ void __additionAwaitReturnWithIntResume(__additionAwaitReturnWithIntFrame * __f)
   /* co_await EduCoroutineCoreturnWithCoawaitTest.cpp:63 */
   __f->__suspend_63_11_1 = __f->__promise.final_suspend();
   if(!__f->__suspend_63_11_1.await_ready()) {
-    __f->__suspend_63_11_1.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
+    __f->__suspend_63_11_1.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
   } 
   
   ;

--- a/tests/EduCoroutineCustomYieldTypeTest.cerr
+++ b/tests/EduCoroutineCustomYieldTypeTest.cerr
@@ -1,10 +1,4 @@
-.tmp.cpp:205:10: error: use of undeclared identifier '__promise'
-  return __promise.get_return_object();
-         ^
-.tmp.cpp:223:138: error: unknown type name 'coroutine_handle'
-      __f->__suspend_86_11.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
-                                                                                                                                         ^
-.tmp.cpp:261:138: error: unknown type name 'coroutine_handle'
-    __f->__suspend_86_11_1.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
-                                                                                                                                         ^
-3 errors generated.
+.tmp.cpp:273:19: error: this builtin expect that __builtin_coro_id has been used earlier in this function
+  operator delete(__builtin_coro_free(static_cast<void *>(__f)));
+                  ^
+1 error generated.

--- a/tests/EduCoroutineCustomYieldTypeTest.expect
+++ b/tests/EduCoroutineCustomYieldTypeTest.expect
@@ -202,7 +202,7 @@ generator seq(int start)
   __seqResume(__f);
   
   
-  return __promise.get_return_object();
+  return __f->__promise.get_return_object();
 }
 
 /* This function invoked by coroutine_handle<>::resume() */
@@ -220,7 +220,7 @@ void __seqResume(__seqFrame * __f)
     /* co_await EduCoroutineCustomYieldTypeTest.cpp:86 */
     __f->__suspend_86_11 = __f->__promise.initial_suspend();
     if(!__f->__suspend_86_11.await_ready()) {
-      __f->__suspend_86_11.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
+      __f->__suspend_86_11.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
       __f->__suspend_index = 1;
       __f->__initial_await_suspend_called = true;
       return;
@@ -258,7 +258,7 @@ void __seqResume(__seqFrame * __f)
   /* co_await EduCoroutineCustomYieldTypeTest.cpp:86 */
   __f->__suspend_86_11_1 = __f->__promise.final_suspend();
   if(!__f->__suspend_86_11_1.await_ready()) {
-    __f->__suspend_86_11_1.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
+    __f->__suspend_86_11_1.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
   } 
   
   ;

--- a/tests/EduCoroutineSimpleTest.cerr
+++ b/tests/EduCoroutineSimpleTest.cerr
@@ -1,10 +1,4 @@
-.tmp.cpp:115:10: error: use of undeclared identifier '__promise'
-  return __promise.get_return_object();
-         ^
-.tmp.cpp:132:138: error: unknown type name 'coroutine_handle'
-      __f->__suspend_34_11.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
-                                                                                                                                         ^
-.tmp.cpp:156:138: error: unknown type name 'coroutine_handle'
-    __f->__suspend_34_11_1.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
-                                                                                                                                         ^
-3 errors generated.
+.tmp.cpp:168:19: error: this builtin expect that __builtin_coro_id has been used earlier in this function
+  operator delete(__builtin_coro_free(static_cast<void *>(__f)));
+                  ^
+1 error generated.

--- a/tests/EduCoroutineSimpleTest.expect
+++ b/tests/EduCoroutineSimpleTest.expect
@@ -112,7 +112,7 @@ generator fun()
   __funResume(__f);
   
   
-  return __promise.get_return_object();
+  return __f->__promise.get_return_object();
 }
 
 /* This function invoked by coroutine_handle<>::resume() */
@@ -129,7 +129,7 @@ void __funResume(__funFrame * __f)
     /* co_await EduCoroutineSimpleTest.cpp:34 */
     __f->__suspend_34_11 = __f->__promise.initial_suspend();
     if(!__f->__suspend_34_11.await_ready()) {
-      __f->__suspend_34_11.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
+      __f->__suspend_34_11.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
       __f->__suspend_index = 1;
       __f->__initial_await_suspend_called = true;
       return;
@@ -153,7 +153,7 @@ void __funResume(__funFrame * __f)
   /* co_await EduCoroutineSimpleTest.cpp:34 */
   __f->__suspend_34_11_1 = __f->__promise.final_suspend();
   if(!__f->__suspend_34_11_1.await_ready()) {
-    __f->__suspend_34_11_1.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
+    __f->__suspend_34_11_1.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
   } 
   
   ;

--- a/tests/EduCoroutineSuspendNeverBoolTest.expect
+++ b/tests/EduCoroutineSuspendNeverBoolTest.expect
@@ -200,7 +200,7 @@ generator<int> fun<int>()
   __fun_intResume(__f);
   
   
-  return __promise.get_return_object();
+  return __f->__promise.get_return_object();
 }
 
 /* This function invoked by coroutine_handle<>::resume() */
@@ -218,7 +218,7 @@ void __fun_intResume(__fun_intFrame * __f)
     /* co_await EduCoroutineSuspendNeverBoolTest.cpp:41 */
     __f->__suspend_41_14 = __f->__promise.initial_suspend();
     if(!__f->__suspend_41_14.await_ready()) {
-      if(__f->__suspend_41_14.await_suspend(std::coroutine_handle<generator<int>::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle())) {
+      if(__f->__suspend_41_14.await_suspend(std::coroutine_handle<generator<int>::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>())) {
         __f->__suspend_index = 1;
         __f->__initial_await_suspend_called = true;
         return;
@@ -235,7 +235,7 @@ void __fun_intResume(__fun_intFrame * __f)
       /* co_yield EduCoroutineSuspendNeverBoolTest.cpp:43 */
       __f->__suspend_43_5 = __f->__promise.yield_value(2);
       if(!__f->__suspend_43_5.await_ready()) {
-        if(__f->__suspend_43_5.await_suspend(std::coroutine_handle<generator<int>::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle())) {
+        if(__f->__suspend_43_5.await_suspend(std::coroutine_handle<generator<int>::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>())) {
           __f->__suspend_index = 2;
           return;
         } 
@@ -260,7 +260,7 @@ void __fun_intResume(__fun_intFrame * __f)
   /* co_await EduCoroutineSuspendNeverBoolTest.cpp:41 */
   __f->__suspend_41_14_1 = __f->__promise.final_suspend();
   if(!__f->__suspend_41_14_1.await_ready()) {
-    if(__f->__suspend_41_14_1.await_suspend(std::coroutine_handle<generator<int>::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle())) {
+    if(__f->__suspend_41_14_1.await_suspend(std::coroutine_handle<generator<int>::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>())) {
     } 
     
   } 

--- a/tests/EduCoroutineSuspendNeverTest.expect
+++ b/tests/EduCoroutineSuspendNeverTest.expect
@@ -182,7 +182,7 @@ generator<int> fun<int>()
   __fun_intResume(__f);
   
   
-  return __promise.get_return_object();
+  return __f->__promise.get_return_object();
 }
 
 /* This function invoked by coroutine_handle<>::resume() */
@@ -200,7 +200,7 @@ void __fun_intResume(__fun_intFrame * __f)
     /* co_await EduCoroutineSuspendNeverTest.cpp:34 */
     __f->__suspend_34_14 = __f->__promise.initial_suspend();
     if(!__f->__suspend_34_14.await_ready()) {
-      __f->__suspend_34_14.await_suspend(std::coroutine_handle<generator<int>::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
+      __f->__suspend_34_14.await_suspend(std::coroutine_handle<generator<int>::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
       __f->__suspend_index = 1;
       __f->__initial_await_suspend_called = true;
       return;
@@ -213,7 +213,7 @@ void __fun_intResume(__fun_intFrame * __f)
       /* co_yield EduCoroutineSuspendNeverTest.cpp:36 */
       __f->__suspend_36_5 = __f->__promise.yield_value(2);
       if(!__f->__suspend_36_5.await_ready()) {
-        __f->__suspend_36_5.await_suspend(std::coroutine_handle<generator<int>::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
+        __f->__suspend_36_5.await_suspend(std::coroutine_handle<generator<int>::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
         __f->__suspend_index = 2;
         return;
       } 
@@ -236,7 +236,7 @@ void __fun_intResume(__fun_intFrame * __f)
   /* co_await EduCoroutineSuspendNeverTest.cpp:34 */
   __f->__suspend_34_14_1 = __f->__promise.final_suspend();
   if(!__f->__suspend_34_14_1.await_ready()) {
-    __f->__suspend_34_14_1.await_suspend(std::coroutine_handle<generator<int>::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
+    __f->__suspend_34_14_1.await_suspend(std::coroutine_handle<generator<int>::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
   } 
   
   ;

--- a/tests/EduCoroutineTemplateGeneratorTest.expect
+++ b/tests/EduCoroutineTemplateGeneratorTest.expect
@@ -179,7 +179,7 @@ generator<int> fun<int>()
   __fun_intResume(__f);
   
   
-  return __promise.get_return_object();
+  return __f->__promise.get_return_object();
 }
 
 /* This function invoked by coroutine_handle<>::resume() */
@@ -196,7 +196,7 @@ void __fun_intResume(__fun_intFrame * __f)
     /* co_await EduCoroutineTemplateGeneratorTest.cpp:34 */
     __f->__suspend_34_14 = __f->__promise.initial_suspend();
     if(!__f->__suspend_34_14.await_ready()) {
-      __f->__suspend_34_14.await_suspend(std::coroutine_handle<generator<int>::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
+      __f->__suspend_34_14.await_suspend(std::coroutine_handle<generator<int>::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
       __f->__suspend_index = 1;
       __f->__initial_await_suspend_called = true;
       return;
@@ -220,7 +220,7 @@ void __fun_intResume(__fun_intFrame * __f)
   /* co_await EduCoroutineTemplateGeneratorTest.cpp:34 */
   __f->__suspend_34_14_1 = __f->__promise.final_suspend();
   if(!__f->__suspend_34_14_1.await_ready()) {
-    __f->__suspend_34_14_1.await_suspend(std::coroutine_handle<generator<int>::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
+    __f->__suspend_34_14_1.await_suspend(std::coroutine_handle<generator<int>::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
   } 
   
   ;

--- a/tests/EduCoroutineVoidTest.expect
+++ b/tests/EduCoroutineVoidTest.expect
@@ -185,7 +185,7 @@ generator<int> seq<int>()
   __seq_intResume(__f);
   
   
-  return __promise.get_return_object();
+  return __f->__promise.get_return_object();
 }
 
 /* This function invoked by coroutine_handle<>::resume() */
@@ -203,7 +203,7 @@ void __seq_intResume(__seq_intFrame * __f)
     /* co_await EduCoroutineVoidTest.cpp:34 */
     __f->__suspend_34_14 = __f->__promise.initial_suspend();
     if(!__f->__suspend_34_14.await_ready()) {
-      __f->__suspend_34_14.await_suspend(std::coroutine_handle<generator<int>::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
+      __f->__suspend_34_14.await_suspend(std::coroutine_handle<generator<int>::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
       __f->__suspend_index = 1;
       __f->__initial_await_suspend_called = true;
       return;
@@ -216,7 +216,7 @@ void __seq_intResume(__seq_intFrame * __f)
       /* co_yield EduCoroutineVoidTest.cpp:36 */
       __f->__suspend_36_5 = __f->__promise.yield_value(__f->i);
       if(!__f->__suspend_36_5.await_ready()) {
-        __f->__suspend_36_5.await_suspend(std::coroutine_handle<generator<int>::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
+        __f->__suspend_36_5.await_suspend(std::coroutine_handle<generator<int>::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
         __f->__suspend_index = 2;
         return;
       } 
@@ -239,7 +239,7 @@ void __seq_intResume(__seq_intFrame * __f)
   /* co_await EduCoroutineVoidTest.cpp:34 */
   __f->__suspend_34_14_1 = __f->__promise.final_suspend();
   if(!__f->__suspend_34_14_1.await_ready()) {
-    __f->__suspend_34_14_1.await_suspend(std::coroutine_handle<generator<int>::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
+    __f->__suspend_34_14_1.await_suspend(std::coroutine_handle<generator<int>::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
   } 
   
   ;

--- a/tests/EduCoroutineWithDtorTest.expect
+++ b/tests/EduCoroutineWithDtorTest.expect
@@ -198,7 +198,7 @@ generator<Test> fun<Test>()
   __fun_TestResume(__f);
   
   
-  return __promise.get_return_object();
+  return __f->__promise.get_return_object();
 }
 
 /* This function invoked by coroutine_handle<>::resume() */
@@ -215,7 +215,7 @@ void __fun_TestResume(__fun_TestFrame * __f)
     /* co_await EduCoroutineWithDtorTest.cpp:43 */
     __f->__suspend_43_14 = __f->__promise.initial_suspend();
     if(!__f->__suspend_43_14.await_ready()) {
-      __f->__suspend_43_14.await_suspend(std::coroutine_handle<generator<Test>::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
+      __f->__suspend_43_14.await_suspend(std::coroutine_handle<generator<Test>::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
       __f->__suspend_index = 1;
       __f->__initial_await_suspend_called = true;
       return;
@@ -239,7 +239,7 @@ void __fun_TestResume(__fun_TestFrame * __f)
   /* co_await EduCoroutineWithDtorTest.cpp:43 */
   __f->__suspend_43_14_1 = __f->__promise.final_suspend();
   if(!__f->__suspend_43_14_1.await_ready()) {
-    __f->__suspend_43_14_1.await_suspend(std::coroutine_handle<generator<Test>::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
+    __f->__suspend_43_14_1.await_suspend(std::coroutine_handle<generator<Test>::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
   } 
   
   ;

--- a/tests/EduCoroutineWithExceptionHandlerTest.expect
+++ b/tests/EduCoroutineWithExceptionHandlerTest.expect
@@ -197,7 +197,7 @@ generator<int> fun<int>()
   __fun_intResume(__f);
   
   
-  return __promise.get_return_object();
+  return __f->__promise.get_return_object();
 }
 
 /* This function invoked by coroutine_handle<>::resume() */
@@ -214,7 +214,7 @@ void __fun_intResume(__fun_intFrame * __f)
     /* co_await EduCoroutineWithExceptionHandlerTest.cpp:41 */
     __f->__suspend_41_14 = __f->__promise.initial_suspend();
     if(!__f->__suspend_41_14.await_ready()) {
-      __f->__suspend_41_14.await_suspend(std::coroutine_handle<generator<int>::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
+      __f->__suspend_41_14.await_suspend(std::coroutine_handle<generator<int>::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
       __f->__suspend_index = 1;
       __f->__initial_await_suspend_called = true;
       return;
@@ -238,7 +238,7 @@ void __fun_intResume(__fun_intFrame * __f)
   /* co_await EduCoroutineWithExceptionHandlerTest.cpp:41 */
   __f->__suspend_41_14_1 = __f->__promise.final_suspend();
   if(!__f->__suspend_41_14_1.await_ready()) {
-    __f->__suspend_41_14_1.await_suspend(std::coroutine_handle<generator<int>::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
+    __f->__suspend_41_14_1.await_suspend(std::coroutine_handle<generator<int>::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
   } 
   
   ;

--- a/tests/EduCoroutineWithLambdaTest.expect
+++ b/tests/EduCoroutineWithLambdaTest.expect
@@ -130,7 +130,7 @@ inline generator operator()() const
       __operator_44_43Resume(__f);
       
       
-      return __promise.get_return_object();
+      return __f->__promise.get_return_object();
     }
     
     /* This function invoked by coroutine_handle<>::resume() */
@@ -148,7 +148,7 @@ inline generator operator()() const
         /* co_await EduCoroutineWithLambdaTest.cpp:44 */
         __f->__suspend_44_24 = __f->__promise.initial_suspend();
         if(!__f->__suspend_44_24.await_ready()) {
-          __f->__suspend_44_24.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
+          __f->__suspend_44_24.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
           __f->__suspend_index = 1;
           __f->__initial_await_suspend_called = true;
           return;
@@ -160,7 +160,7 @@ inline generator operator()() const
         /* co_await EduCoroutineWithLambdaTest.cpp:44 */
         __f->__suspend_44_54 = a;
         if(!__f->__suspend_44_54.await_ready()) {
-          __f->__suspend_44_54.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
+          __f->__suspend_44_54.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
           __f->__suspend_index = 2;
           return;
         } 
@@ -181,7 +181,7 @@ inline generator operator()() const
       /* co_await EduCoroutineWithLambdaTest.cpp:44 */
       __f->__suspend_44_24_1 = __f->__promise.final_suspend();
       if(!__f->__suspend_44_24_1.await_ready()) {
-        __f->__suspend_44_24_1.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator coroutine_handle());
+        __f->__suspend_44_24_1.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
       } 
       
       ;

--- a/tests/Issue536.cerr
+++ b/tests/Issue536.cerr
@@ -1,0 +1,4 @@
+.tmp.cpp:175:19: error: this builtin expect that __builtin_coro_id has been used earlier in this function
+  operator delete(__builtin_coro_free(static_cast<void *>(__f)));
+                  ^
+1 error generated.

--- a/tests/Issue536.cpp
+++ b/tests/Issue536.cpp
@@ -1,0 +1,39 @@
+// cmdline:-std=c++20
+// cmdlineinsights:-edu-show-coroutine-transformation
+
+#include <coroutine>
+#include <utility>
+
+struct my_resumable {
+    struct promise_type {
+    promise_type() = default;
+    promise_type(int& a, char& b, double& c) { }
+
+    my_resumable get_return_object() {
+        auto h = my_resumable::handle_type::from_promise(*this);
+        return my_resumable(h);
+    }
+
+    std::suspend_never initial_suspend() { return {}; }
+    std::suspend_always final_suspend() noexcept { return {}; }
+    void return_void() {}
+
+    void unhandled_exception() {}
+};
+
+
+    using handle_type = std::coroutine_handle<promise_type>;
+    my_resumable() = default;
+    my_resumable(handle_type h) : m_handle(h) {}
+    ~my_resumable() { if (m_handle) m_handle.destroy(); }
+    my_resumable(my_resumable&& other) noexcept : m_handle(std::exchange(other.m_handle, nullptr)) {}
+    my_resumable& operator=(my_resumable&& other) noexcept {
+        m_handle = std::exchange(other.m_handle, nullptr);
+        return *this;
+    }
+    handle_type m_handle;
+};
+
+my_resumable coro(int a, char b, double c) {
+    co_return;
+}

--- a/tests/Issue536.expect
+++ b/tests/Issue536.expect
@@ -1,0 +1,178 @@
+/*************************************************************************************
+ * NOTE: The coroutine transformation you've enabled is a hand coded transformation! *
+ *       Most of it is _not_ present in the AST. What you see is an approximation.   *
+ *************************************************************************************/
+#include <new> // for thread-safe static's placement new
+#include <stdint.h> // for uint64_t under Linux/GCC
+// cmdline:-std=c++20
+// cmdlineinsights:-edu-show-coroutine-transformation
+
+#include <coroutine>
+#include <utility>
+
+struct my_resumable
+{
+  struct promise_type
+  {
+    inline constexpr promise_type() /* noexcept */ = default;
+    inline promise_type(int & a, char & b, double & c)
+    {
+    }
+    
+    inline my_resumable get_return_object()
+    {
+      std::coroutine_handle<promise_type> h = std::coroutine_handle<promise_type>::from_promise(*this);
+      return my_resumable(my_resumable(std::coroutine_handle<promise_type>(h)));
+    }
+    
+    inline std::suspend_never initial_suspend()
+    {
+      return {};
+    }
+    
+    inline std::suspend_always final_suspend() noexcept
+    {
+      return {};
+    }
+    
+    inline void return_void()
+    {
+    }
+    
+    inline void unhandled_exception()
+    {
+    }
+    
+  };
+  
+  using handle_type = std::coroutine_handle<promise_type>;
+  inline constexpr my_resumable() /* noexcept */ = default;
+  inline my_resumable(std::coroutine_handle<promise_type> h)
+  : m_handle{std::coroutine_handle<promise_type>(h)}
+  {
+  }
+  
+  inline ~my_resumable() noexcept
+  {
+    if(static_cast<bool>(this->m_handle.operator bool())) {
+      this->m_handle.destroy();
+    } 
+    
+  }
+  
+  inline my_resumable(my_resumable && other) noexcept
+  : m_handle{std::exchange(other.m_handle, nullptr)}
+  {
+  }
+  
+  inline my_resumable & operator=(my_resumable && other) noexcept
+  {
+    this->m_handle.operator=(std::exchange(other.m_handle, nullptr));
+    return *this;
+  }
+  
+  std::coroutine_handle<promise_type> m_handle;
+  // inline constexpr my_resumable(const my_resumable &) /* noexcept */ = delete;
+  // inline my_resumable & operator=(const my_resumable &) /* noexcept */ = delete;
+};
+
+
+
+struct __coroFrame
+{
+  void (*resume_fn)(__coroFrame *);
+  void (*destroy_fn)(__coroFrame *);
+  std::__coroutine_traits_sfinae<my_resumable>::promise_type __promise;
+  int __suspend_index;
+  bool __initial_await_suspend_called;
+  int a;
+  char b;
+  double c;
+  std::suspend_never __suspend_37_14;
+  std::suspend_always __suspend_37_14_1;
+};
+
+my_resumable coro(int a, char b, double c)
+{
+  /* Allocate the frame including the promise */
+  __coroFrame * __f = reinterpret_cast<__coroFrame *>(operator new(__builtin_coro_size()));
+  __f->__suspend_index = 0;
+  __f->__initial_await_suspend_called = false;
+  __f->a = std::forward<int>(a);
+  __f->b = std::forward<char>(b);
+  __f->c = std::forward<double>(c);
+  
+  /* Construct the promise. */
+  new (&__f->__promise)std::__coroutine_traits_sfinae<my_resumable>::promise_type{__f->a, __f->b, __f->c};
+  
+  /* Forward declare the resume and destroy function. */
+  void __coroResume(__coroFrame * __f);
+  void __coroDestroy(__coroFrame * __f);
+  
+  /* Assign the resume and destroy function pointers. */
+  __f->resume_fn = &__coroResume;
+  __f->destroy_fn = &__coroDestroy;
+  
+  /* Call the made up function with the coroutine body for initial suspend.
+     This function will be called subsequently by coroutine_handle<>::resume()
+     which calls __builtin_coro_resume(__handle_) */
+  __coroResume(__f);
+  
+  
+  return __f->__promise.get_return_object();
+}
+
+/* This function invoked by coroutine_handle<>::resume() */
+void __coroResume(__coroFrame * __f)
+{
+  try 
+  {
+    /* Create a switch to get to the correct resume point */
+    switch(__f->__suspend_index) {
+      case 0: break;
+      case 1: goto __resume_coro_1;
+    }
+    
+    /* co_await Issue536.cpp:37 */
+    __f->__suspend_37_14 = __f->__promise.initial_suspend();
+    if(!__f->__suspend_37_14.await_ready()) {
+      __f->__suspend_37_14.await_suspend(std::coroutine_handle<my_resumable::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
+      __f->__suspend_index = 1;
+      __f->__initial_await_suspend_called = true;
+      return;
+    } 
+    
+    __resume_coro_1:
+    __f->__suspend_37_14.await_resume();
+    /* co_return Issue536.cpp:38 */
+    __f->__promise.return_void();
+    goto __final_suspend;
+  } catch(...) {
+    if(!__f->__initial_await_suspend_called) {
+      throw ;
+    } 
+    
+    __f->__promise.unhandled_exception();
+  }
+  
+  __final_suspend:
+  
+  /* co_await Issue536.cpp:37 */
+  __f->__suspend_37_14_1 = __f->__promise.final_suspend();
+  if(!__f->__suspend_37_14_1.await_ready()) {
+    __f->__suspend_37_14_1.await_suspend(std::coroutine_handle<my_resumable::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
+  } 
+  
+  ;
+}
+
+/* This function invoked by coroutine_handle<>::destroy() */
+void __coroDestroy(__coroFrame * __f)
+{
+  /* destroy all variables with dtors */
+  __f->~__coroFrame();
+  /* Deallocating the coroutine frame */
+  operator delete(__builtin_coro_free(static_cast<void *>(__f)));
+}
+
+

--- a/tests/Issue536_2.cpp
+++ b/tests/Issue536_2.cpp
@@ -1,0 +1,32 @@
+// cmdline:-std=c++20
+// cmdlineinsights:-edu-show-coroutine-transformation
+
+#include <coroutine>
+#include <utility>
+
+struct ClassWithCoro;
+
+struct my_resumable {
+  struct promise_type {
+    promise_type(const ClassWithCoro& q1, int& q2) {}
+    my_resumable get_return_object() {
+      return my_resumable(my_resumable::handle_type::from_promise(*this));
+    }
+    std::suspend_never initial_suspend() { return {}; }
+    std::suspend_always final_suspend() noexcept { return {}; }
+    void return_void() {}
+    void unhandled_exception() {}
+  };
+  
+  using handle_type = std::coroutine_handle<promise_type>;
+  my_resumable(handle_type h) : m_handle(h) {}
+  ~my_resumable() { if (m_handle) m_handle.destroy(); }
+  my_resumable(my_resumable&& other) = delete;
+  handle_type m_handle;
+};
+
+struct ClassWithCoro {
+  my_resumable coro(int x) const {
+    co_return;
+  }
+};

--- a/tests/Issue536_2.expect
+++ b/tests/Issue536_2.expect
@@ -1,0 +1,171 @@
+/*************************************************************************************
+ * NOTE: The coroutine transformation you've enabled is a hand coded transformation! *
+ *       Most of it is _not_ present in the AST. What you see is an approximation.   *
+ *************************************************************************************/
+#include <new> // for thread-safe static's placement new
+#include <stdint.h> // for uint64_t under Linux/GCC
+// cmdline:-std=c++20
+// cmdlineinsights:-edu-show-coroutine-transformation
+
+#include <coroutine>
+#include <utility>
+
+struct ClassWithCoro;
+
+
+struct my_resumable
+{
+  struct promise_type
+  {
+    inline promise_type(const ClassWithCoro & q1, int & q2)
+    {
+    }
+    
+    inline my_resumable get_return_object()
+    {
+      return my_resumable(my_resumable(std::coroutine_handle<promise_type>::from_promise(*this)));
+    }
+    
+    inline std::suspend_never initial_suspend()
+    {
+      return {};
+    }
+    
+    inline std::suspend_always final_suspend() noexcept
+    {
+      return {};
+    }
+    
+    inline void return_void()
+    {
+    }
+    
+    inline void unhandled_exception()
+    {
+    }
+    
+  };
+  
+  using handle_type = std::coroutine_handle<promise_type>;
+  inline my_resumable(std::coroutine_handle<promise_type> h)
+  : m_handle{std::coroutine_handle<promise_type>(h)}
+  {
+  }
+  
+  inline ~my_resumable() noexcept
+  {
+    if(static_cast<bool>(this->m_handle.operator bool())) {
+      this->m_handle.destroy();
+    } 
+    
+  }
+  
+  // inline my_resumable(my_resumable && other) = delete;
+  std::coroutine_handle<promise_type> m_handle;
+  // inline constexpr my_resumable(const my_resumable &) /* noexcept */ = delete;
+  // inline my_resumable & operator=(const my_resumable &) /* noexcept */ = delete;
+};
+
+
+
+struct ClassWithCoro
+{
+  struct __coroFrame
+{
+  void (*resume_fn)(__coroFrame *);
+  void (*destroy_fn)(__coroFrame *);
+  std::__coroutine_traits_sfinae<my_resumable>::promise_type __promise;
+  int __suspend_index;
+  bool __initial_await_suspend_called;
+  const ClassWithCoro * __this;
+  int x;
+  std::suspend_never __suspend_29_16;
+  std::suspend_always __suspend_29_16_1;
+};
+
+inline my_resumable coro(int x) const
+  {
+    /* Allocate the frame including the promise */
+    __coroFrame * __f = reinterpret_cast<__coroFrame *>(operator new(__builtin_coro_size()));
+    __f->__suspend_index = 0;
+    __f->__initial_await_suspend_called = false;
+    __f->x = std::forward<int>(x);
+    __f->__this = this;
+    
+    /* Construct the promise. */
+    new (&__f->__promise)std::__coroutine_traits_sfinae<my_resumable>::promise_type{*__f->__this, __f->x};
+    
+    /* Forward declare the resume and destroy function. */
+    void __coroResume(__coroFrame * __f);
+    void __coroDestroy(__coroFrame * __f);
+    
+    /* Assign the resume and destroy function pointers. */
+    __f->resume_fn = &__coroResume;
+    __f->destroy_fn = &__coroDestroy;
+    
+    /* Call the made up function with the coroutine body for initial suspend.
+     This function will be called subsequently by coroutine_handle<>::resume()
+     which calls __builtin_coro_resume(__handle_) */
+    __coroResume(__f);
+    
+    
+    return __f->__promise.get_return_object();
+  }
+  
+  /* This function invoked by coroutine_handle<>::resume() */
+  void __coroResume(__coroFrame * __f)
+  {
+    try 
+    {
+      /* Create a switch to get to the correct resume point */
+      switch(__f->__suspend_index) {
+        case 0: break;
+        case 1: goto __resume_coro_1;
+      }
+      
+      /* co_await Issue536_2.cpp:29 */
+      __f->__suspend_29_16 = __f->__promise.initial_suspend();
+      if(!__f->__suspend_29_16.await_ready()) {
+        __f->__suspend_29_16.await_suspend(std::coroutine_handle<my_resumable::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
+        __f->__suspend_index = 1;
+        __f->__initial_await_suspend_called = true;
+        return;
+      } 
+      
+      __resume_coro_1:
+      __f->__suspend_29_16.await_resume();
+      /* co_return Issue536_2.cpp:30 */
+      __f->__promise.return_void();
+      goto __final_suspend;
+    } catch(...) {
+      if(!__f->__initial_await_suspend_called) {
+        throw ;
+      } 
+      
+      __f->__promise.unhandled_exception();
+    }
+    
+    __final_suspend:
+    
+    /* co_await Issue536_2.cpp:29 */
+    __f->__suspend_29_16_1 = __f->__promise.final_suspend();
+    if(!__f->__suspend_29_16_1.await_ready()) {
+      __f->__suspend_29_16_1.await_suspend(std::coroutine_handle<my_resumable::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
+    } 
+    
+    ;
+  }
+  
+  /* This function invoked by coroutine_handle<>::destroy() */
+  void __coroDestroy(__coroFrame * __f)
+  {
+    /* destroy all variables with dtors */
+    __f->~__coroFrame();
+    /* Deallocating the coroutine frame */
+    operator delete(__builtin_coro_free(static_cast<void *>(__f)));
+  }
+  
+  
+};
+
+

--- a/tests/StringViewNamespaceTest.cerr
+++ b/tests/StringViewNamespaceTest.cerr
@@ -1,4 +1,0 @@
-.tmp.cpp:8:147: error: unknown type name 'basic_string_view'
-  std::basic_string_view<char, std::char_traits<char> > strView = static_cast<std::basic_string_view<char, std::char_traits<char> >>(str.operator basic_string_view());
-                                                                                                                                                  ^
-1 error generated.

--- a/tests/StringViewNamespaceTest.expect
+++ b/tests/StringViewNamespaceTest.expect
@@ -5,7 +5,7 @@
 int main()
 {
   std::basic_string<char, std::char_traits<char>, std::allocator<char> > str = std::basic_string<char, std::char_traits<char>, std::allocator<char> >("Some string");
-  std::basic_string_view<char, std::char_traits<char> > strView = static_cast<std::basic_string_view<char, std::char_traits<char> >>(str.operator basic_string_view());
+  std::basic_string_view<char, std::char_traits<char> > strView = static_cast<std::basic_string_view<char, std::char_traits<char> >>(str.operator std::basic_string_view<char, std::char_traits<char> >());
   std::operator<<(std::operator<<(std::cout, "strView  : "), std::basic_string_view<char, std::char_traits<char> >(strView)).operator<<(std::endl);
   return 0;
 }


### PR DESCRIPTION
Along with the mentioned fix, this patch fixes two other issues:

1) The return statement in the coroutine setup function was missing the
   `__f`. This error was introduced with the update to Clang 15.
2) The template parameters were missing in the case of a `CXXConversionDecl`
   where the conversion type was a template.