### PR TITLE
Improved coroutine support.

### DIFF
--- a/tests/EduCoroutineAllocFailureTest.expect
+++ b/tests/EduCoroutineAllocFailureTest.expect
@@ -168,7 +168,8 @@ template<>
 generator<int> fun<int>()
 {
   /* Allocate the frame including the promise */
-  __fun_intFrame * __f = reinterpret_cast<__fun_intFrame *>(operator new(__builtin_coro_size(), std::nothrow));
+  /* Note: The actual parameter new is __builtin_coro_size */
+  __fun_intFrame * __f = reinterpret_cast<__fun_intFrame *>(operator new(sizeof(__fun_intFrame), std::nothrow));
   
   if(nullptr == __f) {
     return generator<int>::promise_type::get_return_object_on_allocation_failure();
@@ -247,7 +248,8 @@ void __fun_intDestroy(__fun_intFrame * __f)
   /* destroy all variables with dtors */
   __f->~__fun_intFrame();
   /* Deallocating the coroutine frame */
-  operator delete(__builtin_coro_free(static_cast<void *>(__f)));
+  /* Note: The actual argument to delete is __builtin_coro_frame with the promise as parameter */
+  operator delete(static_cast<void *>(__f));
 }
 
 #endif

--- a/tests/EduCoroutineBinaryExprTest.cerr
+++ b/tests/EduCoroutineBinaryExprTest.cerr
@@ -1,4 +1,0 @@
-.tmp.cpp:222:19: error: this builtin expect that __builtin_coro_id has been used earlier in this function
-  operator delete(__builtin_coro_free(static_cast<void *>(__f)));
-                  ^
-1 error generated.

--- a/tests/EduCoroutineBinaryExprTest.expect
+++ b/tests/EduCoroutineBinaryExprTest.expect
@@ -106,7 +106,8 @@ struct __seqFrame
 generator seq(int start)
 {
   /* Allocate the frame including the promise */
-  __seqFrame * __f = reinterpret_cast<__seqFrame *>(operator new(__builtin_coro_size()));
+  /* Note: The actual parameter new is __builtin_coro_size */
+  __seqFrame * __f = reinterpret_cast<__seqFrame *>(operator new(sizeof(__seqFrame)));
   __f->__suspend_index = 0;
   __f->__initial_await_suspend_called = false;
   __f->start = std::forward<int>(start);
@@ -219,7 +220,8 @@ void __seqDestroy(__seqFrame * __f)
   /* destroy all variables with dtors */
   __f->~__seqFrame();
   /* Deallocating the coroutine frame */
-  operator delete(__builtin_coro_free(static_cast<void *>(__f)));
+  /* Note: The actual argument to delete is __builtin_coro_frame with the promise as parameter */
+  operator delete(static_cast<void *>(__f));
 }
 
 

--- a/tests/EduCoroutineCaptureConstTest.cerr
+++ b/tests/EduCoroutineCaptureConstTest.cerr
@@ -1,10 +1,10 @@
-.tmp.cpp:108:14: error: cannot assign to non-static data member 'start' with const-qualified type 'const int &'
+.tmp.cpp:109:14: error: cannot assign to non-static data member 'start' with const-qualified type 'const int &'
   __f->start = std::forward<const int &>(start);
   ~~~~~~~~~~ ^
 .tmp.cpp:96:15: note: non-static data member 'start' declared const here
   const int & start;
   ~~~~~~~~~~~~^~~~~
-.tmp.cpp:152:12: error: no viable overloaded '='
+.tmp.cpp:153:12: error: no viable overloaded '='
     __f->s = {0, '\0'};
     ~~~~~~ ^ ~~~~~~~~~
 .tmp.cpp:89:10: note: candidate function (the implicit copy assignment operator) not viable: 'this' argument has type 'const __seqFrame::S', but method is not marked const

--- a/tests/EduCoroutineCaptureConstTest.expect
+++ b/tests/EduCoroutineCaptureConstTest.expect
@@ -102,7 +102,8 @@ struct __seqFrame
 generator seq(const int & start)
 {
   /* Allocate the frame including the promise */
-  __seqFrame * __f = reinterpret_cast<__seqFrame *>(operator new(__builtin_coro_size()));
+  /* Note: The actual parameter new is __builtin_coro_size */
+  __seqFrame * __f = reinterpret_cast<__seqFrame *>(operator new(sizeof(__seqFrame)));
   __f->__suspend_index = 0;
   __f->__initial_await_suspend_called = false;
   __f->start = std::forward<const int &>(start);
@@ -178,7 +179,8 @@ void __seqDestroy(__seqFrame * __f)
   /* destroy all variables with dtors */
   __f->~__seqFrame();
   /* Deallocating the coroutine frame */
-  operator delete(__builtin_coro_free(static_cast<void *>(__f)));
+  /* Note: The actual argument to delete is __builtin_coro_frame with the promise as parameter */
+  operator delete(static_cast<void *>(__f));
 }
 
 

--- a/tests/EduCoroutineCoAwaitOperatorTest.expect
+++ b/tests/EduCoroutineCoAwaitOperatorTest.expect
@@ -180,7 +180,8 @@ struct __gFrame
 my_future<int> g()
 {
   /* Allocate the frame including the promise */
-  __gFrame * __f = reinterpret_cast<__gFrame *>(operator new(__builtin_coro_size()));
+  /* Note: The actual parameter new is __builtin_coro_size */
+  __gFrame * __f = reinterpret_cast<__gFrame *>(operator new(sizeof(__gFrame)));
   __f->__suspend_index = 0;
   __f->__initial_await_suspend_called = false;
   
@@ -278,7 +279,8 @@ void __gDestroy(__gFrame * __f)
   /* destroy all variables with dtors */
   __f->~__gFrame();
   /* Deallocating the coroutine frame */
-  operator delete(__builtin_coro_free(static_cast<void *>(__f)));
+  /* Note: The actual argument to delete is __builtin_coro_frame with the promise as parameter */
+  operator delete(static_cast<void *>(__f));
 }
 
 

--- a/tests/EduCoroutineCoreturnWithCoawaitTest.cerr
+++ b/tests/EduCoroutineCoreturnWithCoawaitTest.cerr
@@ -1,46 +1,43 @@
-.tmp.cpp:196:19: error: this builtin expect that __builtin_coro_id has been used earlier in this function
-  operator delete(__builtin_coro_free(static_cast<void *>(__f)));
-                  ^
-.tmp.cpp:277:26: error: object of type 'generator' cannot be assigned because its copy assignment operator is implicitly deleted
+.tmp.cpp:280:26: error: object of type 'generator' cannot be assigned because its copy assignment operator is implicitly deleted
     __f->__suspend_56_24 = simpleReturn(__f->v);
                          ^
 .tmp.cpp:73:10: note: copy assignment operator is implicitly deleted because 'generator' has a user-declared move constructor
   inline generator(generator && rhs)
          ^
-.tmp.cpp:288:26: error: object of type 'generator' cannot be assigned because its copy assignment operator is implicitly deleted
+.tmp.cpp:291:26: error: object of type 'generator' cannot be assigned because its copy assignment operator is implicitly deleted
     __f->__suspend_56_51 = simpleReturn(__f->v + 1);
                          ^
 .tmp.cpp:73:10: note: copy assignment operator is implicitly deleted because 'generator' has a user-declared move constructor
   inline generator(generator && rhs)
          ^
-.tmp.cpp:410:26: error: object of type 'generator' cannot be assigned because its copy assignment operator is implicitly deleted
+.tmp.cpp:415:26: error: object of type 'generator' cannot be assigned because its copy assignment operator is implicitly deleted
     __f->__suspend_60_24 = simpleReturn(__f->v);
                          ^
 .tmp.cpp:73:10: note: copy assignment operator is implicitly deleted because 'generator' has a user-declared move constructor
   inline generator(generator && rhs)
          ^
-.tmp.cpp:421:26: error: object of type 'generator' cannot be assigned because its copy assignment operator is implicitly deleted
+.tmp.cpp:426:26: error: object of type 'generator' cannot be assigned because its copy assignment operator is implicitly deleted
     __f->__suspend_60_51 = simpleReturn(__f->v + 1);
                          ^
 .tmp.cpp:73:10: note: copy assignment operator is implicitly deleted because 'generator' has a user-declared move constructor
   inline generator(generator && rhs)
          ^
-.tmp.cpp:433:26: error: object of type 'generator' cannot be assigned because its copy assignment operator is implicitly deleted
+.tmp.cpp:438:26: error: object of type 'generator' cannot be assigned because its copy assignment operator is implicitly deleted
     __f->__suspend_60_80 = simpleReturn(__f->v + 2);
                          ^
 .tmp.cpp:73:10: note: copy assignment operator is implicitly deleted because 'generator' has a user-declared move constructor
   inline generator(generator && rhs)
          ^
-.tmp.cpp:552:26: error: object of type 'generator' cannot be assigned because its copy assignment operator is implicitly deleted
+.tmp.cpp:559:26: error: object of type 'generator' cannot be assigned because its copy assignment operator is implicitly deleted
     __f->__suspend_67_24 = simpleReturn(__f->v);
                          ^
 .tmp.cpp:73:10: note: copy assignment operator is implicitly deleted because 'generator' has a user-declared move constructor
   inline generator(generator && rhs)
          ^
-.tmp.cpp:563:26: error: object of type 'generator' cannot be assigned because its copy assignment operator is implicitly deleted
+.tmp.cpp:570:26: error: object of type 'generator' cannot be assigned because its copy assignment operator is implicitly deleted
     __f->__suspend_67_51 = simpleReturn(__f->v + 1);
                          ^
 .tmp.cpp:73:10: note: copy assignment operator is implicitly deleted because 'generator' has a user-declared move constructor
   inline generator(generator && rhs)
          ^
-8 errors generated.
+7 errors generated.

--- a/tests/EduCoroutineCoreturnWithCoawaitTest.expect
+++ b/tests/EduCoroutineCoreturnWithCoawaitTest.expect
@@ -113,7 +113,8 @@ struct __simpleReturnFrame
 generator simpleReturn(int v)
 {
   /* Allocate the frame including the promise */
-  __simpleReturnFrame * __f = reinterpret_cast<__simpleReturnFrame *>(operator new(__builtin_coro_size(), std::nothrow));
+  /* Note: The actual parameter new is __builtin_coro_size */
+  __simpleReturnFrame * __f = reinterpret_cast<__simpleReturnFrame *>(operator new(sizeof(__simpleReturnFrame), std::nothrow));
   
   if(nullptr == __f) {
     return generator::promise_type::get_return_object_on_allocation_failure();
@@ -193,7 +194,8 @@ void __simpleReturnDestroy(__simpleReturnFrame * __f)
   /* destroy all variables with dtors */
   __f->~__simpleReturnFrame();
   /* Deallocating the coroutine frame */
-  operator delete(__builtin_coro_free(static_cast<void *>(__f)));
+  /* Note: The actual argument to delete is __builtin_coro_frame with the promise as parameter */
+  operator delete(static_cast<void *>(__f));
 }
 
 
@@ -218,7 +220,8 @@ struct __additionAwaitReturnFrame
 generator additionAwaitReturn(int v)
 {
   /* Allocate the frame including the promise */
-  __additionAwaitReturnFrame * __f = reinterpret_cast<__additionAwaitReturnFrame *>(operator new(__builtin_coro_size(), std::nothrow));
+  /* Note: The actual parameter new is __builtin_coro_size */
+  __additionAwaitReturnFrame * __f = reinterpret_cast<__additionAwaitReturnFrame *>(operator new(sizeof(__additionAwaitReturnFrame), std::nothrow));
   
   if(nullptr == __f) {
     return generator::promise_type::get_return_object_on_allocation_failure();
@@ -324,7 +327,8 @@ void __additionAwaitReturnDestroy(__additionAwaitReturnFrame * __f)
   /* destroy all variables with dtors */
   __f->~__additionAwaitReturnFrame();
   /* Deallocating the coroutine frame */
-  operator delete(__builtin_coro_free(static_cast<void *>(__f)));
+  /* Note: The actual argument to delete is __builtin_coro_frame with the promise as parameter */
+  operator delete(static_cast<void *>(__f));
 }
 
 
@@ -350,7 +354,8 @@ struct __additionAwaitReturn2Frame
 generator additionAwaitReturn2(int v)
 {
   /* Allocate the frame including the promise */
-  __additionAwaitReturn2Frame * __f = reinterpret_cast<__additionAwaitReturn2Frame *>(operator new(__builtin_coro_size(), std::nothrow));
+  /* Note: The actual parameter new is __builtin_coro_size */
+  __additionAwaitReturn2Frame * __f = reinterpret_cast<__additionAwaitReturn2Frame *>(operator new(sizeof(__additionAwaitReturn2Frame), std::nothrow));
   
   if(nullptr == __f) {
     return generator::promise_type::get_return_object_on_allocation_failure();
@@ -469,7 +474,8 @@ void __additionAwaitReturn2Destroy(__additionAwaitReturn2Frame * __f)
   /* destroy all variables with dtors */
   __f->~__additionAwaitReturn2Frame();
   /* Deallocating the coroutine frame */
-  operator delete(__builtin_coro_free(static_cast<void *>(__f)));
+  /* Note: The actual argument to delete is __builtin_coro_frame with the promise as parameter */
+  operator delete(static_cast<void *>(__f));
 }
 
 
@@ -493,7 +499,8 @@ struct __additionAwaitReturnWithIntFrame
 generator additionAwaitReturnWithInt(int v)
 {
   /* Allocate the frame including the promise */
-  __additionAwaitReturnWithIntFrame * __f = reinterpret_cast<__additionAwaitReturnWithIntFrame *>(operator new(__builtin_coro_size(), std::nothrow));
+  /* Note: The actual parameter new is __builtin_coro_size */
+  __additionAwaitReturnWithIntFrame * __f = reinterpret_cast<__additionAwaitReturnWithIntFrame *>(operator new(sizeof(__additionAwaitReturnWithIntFrame), std::nothrow));
   
   if(nullptr == __f) {
     return generator::promise_type::get_return_object_on_allocation_failure();
@@ -600,7 +607,8 @@ void __additionAwaitReturnWithIntDestroy(__additionAwaitReturnWithIntFrame * __f
   /* destroy all variables with dtors */
   __f->~__additionAwaitReturnWithIntFrame();
   /* Deallocating the coroutine frame */
-  operator delete(__builtin_coro_free(static_cast<void *>(__f)));
+  /* Note: The actual argument to delete is __builtin_coro_frame with the promise as parameter */
+  operator delete(static_cast<void *>(__f));
 }
 
 

--- a/tests/EduCoroutineCustomYieldTypeTest.cerr
+++ b/tests/EduCoroutineCustomYieldTypeTest.cerr
@@ -1,4 +1,0 @@
-.tmp.cpp:273:19: error: this builtin expect that __builtin_coro_id has been used earlier in this function
-  operator delete(__builtin_coro_free(static_cast<void *>(__f)));
-                  ^
-1 error generated.

--- a/tests/EduCoroutineCustomYieldTypeTest.expect
+++ b/tests/EduCoroutineCustomYieldTypeTest.expect
@@ -175,7 +175,8 @@ struct __seqFrame
 generator seq(int start)
 {
   /* Allocate the frame including the promise */
-  __seqFrame * __f = reinterpret_cast<__seqFrame *>(operator new(__builtin_coro_size(), std::nothrow));
+  /* Note: The actual parameter new is __builtin_coro_size */
+  __seqFrame * __f = reinterpret_cast<__seqFrame *>(operator new(sizeof(__seqFrame), std::nothrow));
   
   if(nullptr == __f) {
     return generator::promise_type::get_return_object_on_allocation_failure();
@@ -270,7 +271,8 @@ void __seqDestroy(__seqFrame * __f)
   /* destroy all variables with dtors */
   __f->~__seqFrame();
   /* Deallocating the coroutine frame */
-  operator delete(__builtin_coro_free(static_cast<void *>(__f)));
+  /* Note: The actual argument to delete is __builtin_coro_frame with the promise as parameter */
+  operator delete(static_cast<void *>(__f));
 }
 
 

--- a/tests/EduCoroutineSimpleTest.cerr
+++ b/tests/EduCoroutineSimpleTest.cerr
@@ -1,4 +1,0 @@
-.tmp.cpp:168:19: error: this builtin expect that __builtin_coro_id has been used earlier in this function
-  operator delete(__builtin_coro_free(static_cast<void *>(__f)));
-                  ^
-1 error generated.

--- a/tests/EduCoroutineSimpleTest.expect
+++ b/tests/EduCoroutineSimpleTest.expect
@@ -91,7 +91,8 @@ struct __funFrame
 generator fun()
 {
   /* Allocate the frame including the promise */
-  __funFrame * __f = reinterpret_cast<__funFrame *>(operator new(__builtin_coro_size()));
+  /* Note: The actual parameter new is __builtin_coro_size */
+  __funFrame * __f = reinterpret_cast<__funFrame *>(operator new(sizeof(__funFrame)));
   __f->__suspend_index = 0;
   __f->__initial_await_suspend_called = false;
   
@@ -165,7 +166,8 @@ void __funDestroy(__funFrame * __f)
   /* destroy all variables with dtors */
   __f->~__funFrame();
   /* Deallocating the coroutine frame */
-  operator delete(__builtin_coro_free(static_cast<void *>(__f)));
+  /* Note: The actual argument to delete is __builtin_coro_frame with the promise as parameter */
+  operator delete(static_cast<void *>(__f));
 }
 
 

--- a/tests/EduCoroutineSuspendNeverBoolTest.expect
+++ b/tests/EduCoroutineSuspendNeverBoolTest.expect
@@ -179,7 +179,8 @@ template<>
 generator<int> fun<int>()
 {
   /* Allocate the frame including the promise */
-  __fun_intFrame * __f = reinterpret_cast<__fun_intFrame *>(operator new(__builtin_coro_size()));
+  /* Note: The actual parameter new is __builtin_coro_size */
+  __fun_intFrame * __f = reinterpret_cast<__fun_intFrame *>(operator new(sizeof(__fun_intFrame)));
   __f->__suspend_index = 0;
   __f->__initial_await_suspend_called = false;
   
@@ -274,7 +275,8 @@ void __fun_intDestroy(__fun_intFrame * __f)
   /* destroy all variables with dtors */
   __f->~__fun_intFrame();
   /* Deallocating the coroutine frame */
-  operator delete(__builtin_coro_free(static_cast<void *>(__f)));
+  /* Note: The actual argument to delete is __builtin_coro_frame with the promise as parameter */
+  operator delete(static_cast<void *>(__f));
 }
 
 #endif

--- a/tests/EduCoroutineSuspendNeverTest.expect
+++ b/tests/EduCoroutineSuspendNeverTest.expect
@@ -161,7 +161,8 @@ template<>
 generator<int> fun<int>()
 {
   /* Allocate the frame including the promise */
-  __fun_intFrame * __f = reinterpret_cast<__fun_intFrame *>(operator new(__builtin_coro_size()));
+  /* Note: The actual parameter new is __builtin_coro_size */
+  __fun_intFrame * __f = reinterpret_cast<__fun_intFrame *>(operator new(sizeof(__fun_intFrame)));
   __f->__suspend_index = 0;
   __f->__initial_await_suspend_called = false;
   
@@ -248,7 +249,8 @@ void __fun_intDestroy(__fun_intFrame * __f)
   /* destroy all variables with dtors */
   __f->~__fun_intFrame();
   /* Deallocating the coroutine frame */
-  operator delete(__builtin_coro_free(static_cast<void *>(__f)));
+  /* Note: The actual argument to delete is __builtin_coro_frame with the promise as parameter */
+  operator delete(static_cast<void *>(__f));
 }
 
 #endif

--- a/tests/EduCoroutineTemplateGeneratorTest.expect
+++ b/tests/EduCoroutineTemplateGeneratorTest.expect
@@ -158,7 +158,8 @@ template<>
 generator<int> fun<int>()
 {
   /* Allocate the frame including the promise */
-  __fun_intFrame * __f = reinterpret_cast<__fun_intFrame *>(operator new(__builtin_coro_size()));
+  /* Note: The actual parameter new is __builtin_coro_size */
+  __fun_intFrame * __f = reinterpret_cast<__fun_intFrame *>(operator new(sizeof(__fun_intFrame)));
   __f->__suspend_index = 0;
   __f->__initial_await_suspend_called = false;
   
@@ -232,7 +233,8 @@ void __fun_intDestroy(__fun_intFrame * __f)
   /* destroy all variables with dtors */
   __f->~__fun_intFrame();
   /* Deallocating the coroutine frame */
-  operator delete(__builtin_coro_free(static_cast<void *>(__f)));
+  /* Note: The actual argument to delete is __builtin_coro_frame with the promise as parameter */
+  operator delete(static_cast<void *>(__f));
 }
 
 #endif

--- a/tests/EduCoroutineVoidTest.expect
+++ b/tests/EduCoroutineVoidTest.expect
@@ -164,7 +164,8 @@ template<>
 generator<int> seq<int>()
 {
   /* Allocate the frame including the promise */
-  __seq_intFrame * __f = reinterpret_cast<__seq_intFrame *>(operator new(__builtin_coro_size()));
+  /* Note: The actual parameter new is __builtin_coro_size */
+  __seq_intFrame * __f = reinterpret_cast<__seq_intFrame *>(operator new(sizeof(__seq_intFrame)));
   __f->__suspend_index = 0;
   __f->__initial_await_suspend_called = false;
   
@@ -251,7 +252,8 @@ void __seq_intDestroy(__seq_intFrame * __f)
   /* destroy all variables with dtors */
   __f->~__seq_intFrame();
   /* Deallocating the coroutine frame */
-  operator delete(__builtin_coro_free(static_cast<void *>(__f)));
+  /* Note: The actual argument to delete is __builtin_coro_frame with the promise as parameter */
+  operator delete(static_cast<void *>(__f));
 }
 
 #endif

--- a/tests/EduCoroutineWithDtorTest.expect
+++ b/tests/EduCoroutineWithDtorTest.expect
@@ -177,7 +177,8 @@ template<>
 generator<Test> fun<Test>()
 {
   /* Allocate the frame including the promise */
-  __fun_TestFrame * __f = reinterpret_cast<__fun_TestFrame *>(operator new(__builtin_coro_size()));
+  /* Note: The actual parameter new is __builtin_coro_size */
+  __fun_TestFrame * __f = reinterpret_cast<__fun_TestFrame *>(operator new(sizeof(__fun_TestFrame)));
   __f->__suspend_index = 0;
   __f->__initial_await_suspend_called = false;
   
@@ -251,7 +252,8 @@ void __fun_TestDestroy(__fun_TestFrame * __f)
   /* destroy all variables with dtors */
   __f->~__fun_TestFrame();
   /* Deallocating the coroutine frame */
-  operator delete(__builtin_coro_free(static_cast<void *>(__f)));
+  /* Note: The actual argument to delete is __builtin_coro_frame with the promise as parameter */
+  operator delete(static_cast<void *>(__f));
 }
 
 #endif

--- a/tests/EduCoroutineWithExceptionHandlerTest.expect
+++ b/tests/EduCoroutineWithExceptionHandlerTest.expect
@@ -176,7 +176,8 @@ template<>
 generator<int> fun<int>()
 {
   /* Allocate the frame including the promise */
-  __fun_intFrame * __f = reinterpret_cast<__fun_intFrame *>(operator new(__builtin_coro_size()));
+  /* Note: The actual parameter new is __builtin_coro_size */
+  __fun_intFrame * __f = reinterpret_cast<__fun_intFrame *>(operator new(sizeof(__fun_intFrame)));
   __f->__suspend_index = 0;
   __f->__initial_await_suspend_called = false;
   
@@ -250,7 +251,8 @@ void __fun_intDestroy(__fun_intFrame * __f)
   /* destroy all variables with dtors */
   __f->~__fun_intFrame();
   /* Deallocating the coroutine frame */
-  operator delete(__builtin_coro_free(static_cast<void *>(__f)));
+  /* Note: The actual argument to delete is __builtin_coro_frame with the promise as parameter */
+  operator delete(static_cast<void *>(__f));
 }
 
 #endif

--- a/tests/EduCoroutineWithLambdaTest.expect
+++ b/tests/EduCoroutineWithLambdaTest.expect
@@ -109,7 +109,8 @@ void SyncAwait<std::suspend_always>(std::suspend_always && a)
 inline generator operator()() const
     {
       /* Allocate the frame including the promise */
-      __operator_44_43Frame * __f = reinterpret_cast<__operator_44_43Frame *>(operator new(__builtin_coro_size()));
+      /* Note: The actual parameter new is __builtin_coro_size */
+      __operator_44_43Frame * __f = reinterpret_cast<__operator_44_43Frame *>(operator new(sizeof(__operator_44_43Frame)));
       __f->__suspend_index = 0;
       __f->__initial_await_suspend_called = false;
       
@@ -193,7 +194,8 @@ inline generator operator()() const
       /* destroy all variables with dtors */
       __f->~__operator_44_43Frame();
       /* Deallocating the coroutine frame */
-      operator delete(__builtin_coro_free(static_cast<void *>(__f)));
+      /* Note: The actual argument to delete is __builtin_coro_frame with the promise as parameter */
+      operator delete(static_cast<void *>(__f));
     }
     
     

--- a/tests/Issue536.cerr
+++ b/tests/Issue536.cerr
@@ -1,4 +1,0 @@
-.tmp.cpp:175:19: error: this builtin expect that __builtin_coro_id has been used earlier in this function
-  operator delete(__builtin_coro_free(static_cast<void *>(__f)));
-                  ^
-1 error generated.

--- a/tests/Issue536.expect
+++ b/tests/Issue536.expect
@@ -95,7 +95,8 @@ struct __coroFrame
 my_resumable coro(int a, char b, double c)
 {
   /* Allocate the frame including the promise */
-  __coroFrame * __f = reinterpret_cast<__coroFrame *>(operator new(__builtin_coro_size()));
+  /* Note: The actual parameter new is __builtin_coro_size */
+  __coroFrame * __f = reinterpret_cast<__coroFrame *>(operator new(sizeof(__coroFrame)));
   __f->__suspend_index = 0;
   __f->__initial_await_suspend_called = false;
   __f->a = std::forward<int>(a);
@@ -172,7 +173,8 @@ void __coroDestroy(__coroFrame * __f)
   /* destroy all variables with dtors */
   __f->~__coroFrame();
   /* Deallocating the coroutine frame */
-  operator delete(__builtin_coro_free(static_cast<void *>(__f)));
+  /* Note: The actual argument to delete is __builtin_coro_frame with the promise as parameter */
+  operator delete(static_cast<void *>(__f));
 }
 
 

--- a/tests/Issue536_2.expect
+++ b/tests/Issue536_2.expect
@@ -86,7 +86,8 @@ struct ClassWithCoro
 inline my_resumable coro(int x) const
   {
     /* Allocate the frame including the promise */
-    __coroFrame * __f = reinterpret_cast<__coroFrame *>(operator new(__builtin_coro_size()));
+    /* Note: The actual parameter new is __builtin_coro_size */
+    __coroFrame * __f = reinterpret_cast<__coroFrame *>(operator new(sizeof(__coroFrame)));
     __f->__suspend_index = 0;
     __f->__initial_await_suspend_called = false;
     __f->x = std::forward<int>(x);
@@ -162,7 +163,8 @@ inline my_resumable coro(int x) const
     /* destroy all variables with dtors */
     __f->~__coroFrame();
     /* Deallocating the coroutine frame */
-    operator delete(__builtin_coro_free(static_cast<void *>(__f)));
+    /* Note: The actual argument to delete is __builtin_coro_frame with the promise as parameter */
+    operator delete(static_cast<void *>(__f));
   }
   
   


### PR DESCRIPTION
Removed calls to `__builtin_coro_nnn` because they lead to crashes when executing the transformed code.