### PR TITLE
Fixed #518: Support for `co_await` in a `VarDecl` and more.

### DIFF
--- a/CodeGenerator.cpp
+++ b/CodeGenerator.cpp
@@ -2136,7 +2136,15 @@ void CodeGenerator::InsertArg(const CXXOperatorCallExpr* stmt)
     if(isCXXMethod) {
         const OverloadedOperatorKind opKind = stmt->getOperator();
 
-        mOutputFormatHelper.Append("."sv, kwOperator, getOperatorSpelling(opKind), "("sv);
+        const std::string_view operatorKw{[&] {
+            if(OO_Coawait == opKind) {
+                return kwOperatorSpace;
+            }
+
+            return kwOperator;
+        }()};
+
+        mOutputFormatHelper.Append("."sv, operatorKw, getOperatorSpelling(opKind), "("sv);
     }
 
     // consume all remaining arguments
@@ -2705,7 +2713,8 @@ void CodeGenerator::InsertArg(const FieldDecl* stmt)
         // - get next field
         // - if this fields offset + size is equal to the next fields offset we are good,
         // - if not we insert padding bytes
-        // - in case there is no next field this is the last field, check this field's offset + size against the records
+        // - in case there is no next field this is the last field, check this field's offset + size against the
+        // records
         //   size. If unequal padding is needed
 
         const auto expectedOffset = fieldOffset + effectiveFieldSize;

--- a/CodeGenerator.h
+++ b/CodeGenerator.h
@@ -470,16 +470,17 @@ protected:
 
 struct CoroutineASTData
 {
-    CXXRecordDecl* mFrameType{};
-    FieldDecl*     mResumeFnField{};
-    FieldDecl*     mDestroyFnField{};
-    FieldDecl*     mPromiseField{};
-    FieldDecl*     mSuspendIndexField{};
-    FieldDecl*     mInitialAwaitResumeCalledField{};
-    MemberExpr*    mInitialAwaitResumeCalledAccess{};
-    DeclRefExpr*   mFrameAccessDeclRef{};
-    MemberExpr*    mSuspendIndexAccess{};
-    bool           mDoInsertInDtor{};
+    CXXRecordDecl*                  mFrameType{};
+    FieldDecl*                      mResumeFnField{};
+    FieldDecl*                      mDestroyFnField{};
+    FieldDecl*                      mPromiseField{};
+    FieldDecl*                      mSuspendIndexField{};
+    FieldDecl*                      mInitialAwaitResumeCalledField{};
+    MemberExpr*                     mInitialAwaitResumeCalledAccess{};
+    DeclRefExpr*                    mFrameAccessDeclRef{};
+    MemberExpr*                     mSuspendIndexAccess{};
+    bool                            mDoInsertInDtor{};
+    std::vector<const CXXThisExpr*> mThisExprs{};
 };
 
 ///
@@ -512,11 +513,8 @@ public:
 
     void InsertArg(const ImplicitCastExpr* stmt) override;
     void InsertArg(const CallExpr* stmt) override;
-    void InsertArg(const CStyleCastExpr* stmt) override;
     void InsertArg(const CXXRecordDecl* stmt) override;
-    void InsertArg(const CXXThisExpr* stmt) override;
     void InsertArg(const OpaqueValueExpr* stmt) override;
-    void InsertArg(const BinaryOperator* stmt) override;
 
     void InsertArg(const CoroutineBodyStmt* stmt) override;
     void InsertArg(const CoroutineSuspendExpr* stmt) override;
@@ -547,8 +545,6 @@ private:
     bool                              mInsertVarDecl{true};
     bool                              mSupressCasts{};
     bool                              mSupressRecordDecls{};
-    bool                              mNameOnly{};
-    bool                              mCorosOnly{};
     std::string                       mFrameName{};
     std::string                       mFSMName{};
     CoroutineASTData                  mASTData{};

--- a/InsightsHelpers.cpp
+++ b/InsightsHelpers.cpp
@@ -863,10 +863,7 @@ public:
     {
     }
 
-    std::string& GetString()
-    {
-        return mData.GetString();
-    }
+    std::string& GetString() { return mData.GetString(); }
 
     bool GetTypeString()
     {
@@ -1243,38 +1240,10 @@ static std::string GetTemplateParameterPackArgumentName(std::string_view name, c
 }
 //-----------------------------------------------------------------------------
 
-static llvm::DenseMap<const ValueDecl*, std::string_view> varNamePrefix{};
-static bool                                               skipNamePrefix{};
-
-void AddToVarNamePrefixMap(const VarDecl* vd, std::string_view name)
-{
-    // The name currently is _only_ CORO_FRAME_ACCESS. Known at compile-time
-    varNamePrefix.insert(std::make_pair(vd, name));
-}
-
-void ClearVarNamePrefix()
-{
-    varNamePrefix.clear();
-}
-
-void SkipNamePrefix(bool b)
-{
-    skipNamePrefix = b;
-}
-
-static std::string_view GetPrefixIfAvailable(const ValueDecl* decl)
-{
-    if(Contains(varNamePrefix, decl) and not skipNamePrefix) {
-        return varNamePrefix[decl];
-    }
-
-    return {};
-}
-
 std::string GetName(const DeclRefExpr& declRefExpr)
 {
     const auto* declRefDecl = declRefExpr.getDecl();
-    std::string name{GetPrefixIfAvailable(declRefDecl)};
+    std::string name{};
     const auto* declCtx = declRefDecl->getDeclContext();
     const bool  needsNamespace{NeedsNamespace(*declRefDecl, UseLexicalParent::No)};
 
@@ -1364,8 +1333,7 @@ std::string GetName(const VarDecl& VD)
         return {BuildInternalVarName(baseVarName, decompositionDeclStmt->getBeginLoc(), GetSM(*decompositionDeclStmt))};
     }
 
-    std::string name{GetPrefixIfAvailable(&VD)};
-    name += VD.getNameAsString();
+    std::string name{VD.getNameAsString()};
 
     return ScopeHandler::RemoveCurrentScope(GetTemplateParameterPackArgumentName(name, &VD));
 }

--- a/tests/EduCoroutineBinaryExprTest.cpp
+++ b/tests/EduCoroutineBinaryExprTest.cpp
@@ -41,6 +41,7 @@ generator seq(int start) {
 
     co_yield s.t;
     (void)(co_yield i);
+    static_cast<void>(co_yield i);
     co_yield i+1;
   }
 }

--- a/tests/EduCoroutineBinaryExprTest.expect
+++ b/tests/EduCoroutineBinaryExprTest.expect
@@ -85,6 +85,8 @@ struct __seqFrame
   std::__coroutine_traits_sfinae<generator>::promise_type __promise;
   int __suspend_index;
   bool __initial_await_suspend_called;
+  int start;
+  int i;
   
   struct S
   {
@@ -93,13 +95,12 @@ struct __seqFrame
   };
   
   public: 
-  int start;
-  int i;
   S s;
   std::suspend_always __suspend_35_11;
   std::suspend_always __suspend_42_5;
   std::suspend_always __suspend_43_12;
-  std::suspend_always __suspend_44_5;
+  std::suspend_always __suspend_44_23;
+  std::suspend_always __suspend_45_5;
   std::suspend_always __suspend_35_11_1;
 };
 
@@ -144,6 +145,7 @@ void __seqResume(__seqFrame * __f)
       case 2: goto __resume_seq_2;
       case 3: goto __resume_seq_3;
       case 4: goto __resume_seq_4;
+      case 5: goto __resume_seq_5;
     }
     
     /* co_await EduCoroutineBinaryExprTest.cpp:35 */
@@ -157,7 +159,7 @@ void __seqResume(__seqFrame * __f)
     
     __resume_seq_1:
     __f->__suspend_35_11.await_resume();
-    for( __f->i = __f->start; ; ++__f->i) {
+    for(__f->i = __f->start; ; ++__f->i) {
       __f->s = {0, '\0'};
       
       /* co_yield EduCoroutineBinaryExprTest.cpp:42 */
@@ -183,15 +185,26 @@ void __seqResume(__seqFrame * __f)
       __f->__suspend_43_12.await_resume();
       
       /* co_yield EduCoroutineBinaryExprTest.cpp:44 */
-      __f->__suspend_44_5 = __f->__promise.yield_value(__f->i + 1);
-      if(!__f->__suspend_44_5.await_ready()) {
-        __f->__suspend_44_5.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
+      __f->__suspend_44_23 = __f->__promise.yield_value(__f->i);
+      if(!__f->__suspend_44_23.await_ready()) {
+        __f->__suspend_44_23.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
         __f->__suspend_index = 4;
         return;
       } 
       
       __resume_seq_4:
-      __f->__suspend_44_5.await_resume();
+      __f->__suspend_44_23.await_resume();
+      
+      /* co_yield EduCoroutineBinaryExprTest.cpp:45 */
+      __f->__suspend_45_5 = __f->__promise.yield_value(__f->i + 1);
+      if(!__f->__suspend_45_5.await_ready()) {
+        __f->__suspend_45_5.await_suspend(std::coroutine_handle<generator::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
+        __f->__suspend_index = 5;
+        return;
+      } 
+      
+      __resume_seq_5:
+      __f->__suspend_45_5.await_resume();
     }
     
     goto __final_suspend;

--- a/tests/EduCoroutineCaptureConstTest.cerr
+++ b/tests/EduCoroutineCaptureConstTest.cerr
@@ -1,14 +1,14 @@
 .tmp.cpp:109:14: error: cannot assign to non-static data member 'start' with const-qualified type 'const int &'
   __f->start = std::forward<const int &>(start);
   ~~~~~~~~~~ ^
-.tmp.cpp:96:15: note: non-static data member 'start' declared const here
+.tmp.cpp:88:15: note: non-static data member 'start' declared const here
   const int & start;
   ~~~~~~~~~~~~^~~~~
 .tmp.cpp:153:12: error: no viable overloaded '='
     __f->s = {0, '\0'};
     ~~~~~~ ^ ~~~~~~~~~
-.tmp.cpp:89:10: note: candidate function (the implicit copy assignment operator) not viable: 'this' argument has type 'const __seqFrame::S', but method is not marked const
+.tmp.cpp:90:10: note: candidate function (the implicit copy assignment operator) not viable: 'this' argument has type 'const __seqFrame::S', but method is not marked const
   struct S
          ^
-.tmp.cpp:89:10: note: candidate function (the implicit move assignment operator) not viable: 'this' argument has type 'const __seqFrame::S', but method is not marked const
+.tmp.cpp:90:10: note: candidate function (the implicit move assignment operator) not viable: 'this' argument has type 'const __seqFrame::S', but method is not marked const
 2 errors generated.

--- a/tests/EduCoroutineCaptureConstTest.expect
+++ b/tests/EduCoroutineCaptureConstTest.expect
@@ -85,6 +85,7 @@ struct __seqFrame
   std::__coroutine_traits_sfinae<generator>::promise_type __promise;
   int __suspend_index;
   bool __initial_await_suspend_called;
+  const int & start;
   
   struct S
   {
@@ -93,7 +94,6 @@ struct __seqFrame
   };
   
   public: 
-  const int & start;
   const S s;
   std::suspend_always __suspend_35_11;
   std::suspend_always __suspend_35_11_1;

--- a/tests/EduCoroutineCaptureThisTest.cpp
+++ b/tests/EduCoroutineCaptureThisTest.cpp
@@ -1,0 +1,36 @@
+// cmdline:-std=c++20
+// cmdlineinsights:-edu-show-coroutine-transformation
+
+#include <coroutine>
+#include <utility>
+
+struct ClassWithCoro;
+
+struct my_resumable {
+  struct promise_type {
+    promise_type(ClassWithCoro& q1, int& q2) {}
+    my_resumable get_return_object() {
+      return my_resumable(my_resumable::handle_type::from_promise(*this));
+    }
+    std::suspend_never initial_suspend() { return {}; }
+    std::suspend_always final_suspend() noexcept { return {}; }
+    void return_value(int) {}
+    void unhandled_exception() {}
+  };
+  
+  using handle_type = std::coroutine_handle<promise_type>;
+  my_resumable(handle_type h) : m_handle(h) {}
+  ~my_resumable() { if (m_handle) m_handle.destroy(); }
+  my_resumable(my_resumable&& other) = delete;
+  handle_type m_handle;
+};
+
+struct ClassWithCoro {
+  int y{6};
+
+  my_resumable coro(int x) {
+    ++y;
+    co_return x + y;
+  }
+};
+

--- a/tests/EduCoroutineCaptureThisTest.expect
+++ b/tests/EduCoroutineCaptureThisTest.expect
@@ -17,7 +17,7 @@ struct my_resumable
 {
   struct promise_type
   {
-    inline promise_type(const ClassWithCoro & q1, int & q2)
+    inline promise_type(ClassWithCoro & q1, int & q2)
     {
     }
     
@@ -36,7 +36,7 @@ struct my_resumable
       return {};
     }
     
-    inline void return_void()
+    inline void return_value(int)
     {
     }
     
@@ -70,6 +70,7 @@ struct my_resumable
 
 struct ClassWithCoro
 {
+  int y{6};
   struct __coroFrame
 {
   void (*resume_fn)(__coroFrame *);
@@ -78,12 +79,12 @@ struct ClassWithCoro
   int __suspend_index;
   bool __initial_await_suspend_called;
   int x;
-  const ClassWithCoro * __this;
-  std::suspend_never __suspend_29_16;
-  std::suspend_always __suspend_29_16_1;
+  ClassWithCoro * __this;
+  std::suspend_never __suspend_31_16;
+  std::suspend_always __suspend_31_16_1;
 };
 
-inline my_resumable coro(int x) const
+inline my_resumable coro(int x)
   {
     /* Allocate the frame including the promise */
     /* Note: The actual parameter new is __builtin_coro_size */
@@ -124,19 +125,20 @@ inline my_resumable coro(int x) const
         case 1: goto __resume_coro_1;
       }
       
-      /* co_await Issue536_2.cpp:29 */
-      __f->__suspend_29_16 = __f->__promise.initial_suspend();
-      if(!__f->__suspend_29_16.await_ready()) {
-        __f->__suspend_29_16.await_suspend(std::coroutine_handle<my_resumable::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
+      /* co_await EduCoroutineCaptureThisTest.cpp:31 */
+      __f->__suspend_31_16 = __f->__promise.initial_suspend();
+      if(!__f->__suspend_31_16.await_ready()) {
+        __f->__suspend_31_16.await_suspend(std::coroutine_handle<my_resumable::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
         __f->__suspend_index = 1;
         __f->__initial_await_suspend_called = true;
         return;
       } 
       
       __resume_coro_1:
-      __f->__suspend_29_16.await_resume();
-      /* co_return Issue536_2.cpp:30 */
-      __f->__promise.return_void();
+      __f->__suspend_31_16.await_resume();
+      ++__f->__this->y;
+      /* co_return EduCoroutineCaptureThisTest.cpp:33 */
+      __f->__promise.return_value(__f->x + __f->__this->y);
       goto __final_suspend;
     } catch(...) {
       if(!__f->__initial_await_suspend_called) {
@@ -148,10 +150,10 @@ inline my_resumable coro(int x) const
     
     __final_suspend:
     
-    /* co_await Issue536_2.cpp:29 */
-    __f->__suspend_29_16_1 = __f->__promise.final_suspend();
-    if(!__f->__suspend_29_16_1.await_ready()) {
-      __f->__suspend_29_16_1.await_suspend(std::coroutine_handle<my_resumable::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
+    /* co_await EduCoroutineCaptureThisTest.cpp:31 */
+    __f->__suspend_31_16_1 = __f->__promise.final_suspend();
+    if(!__f->__suspend_31_16_1.await_ready()) {
+      __f->__suspend_31_16_1.await_suspend(std::coroutine_handle<my_resumable::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
     } 
     
     ;
@@ -169,5 +171,6 @@ inline my_resumable coro(int x) const
   
   
 };
+
 
 

--- a/tests/EduCoroutineCoAwaitOperatorTest.cerr
+++ b/tests/EduCoroutineCoAwaitOperatorTest.cerr
@@ -1,4 +1,7 @@
 .tmp.cpp:174:3: error: unknown type name 'awaiter'
   awaiter __suspend_54_5;
   ^
-1 error generated.
+.tmp.cpp:256:10: warning: expression result unused [-Wunused-value]
+    __f->__suspend_56_14_res;
+    ~~~  ^~~~~~~~~~~~~~~~~~~
+1 warning and 1 error generated.

--- a/tests/EduCoroutineCoAwaitOperatorTest.expect
+++ b/tests/EduCoroutineCoAwaitOperatorTest.expect
@@ -253,6 +253,7 @@ void __gResume(__gFrame * __f)
     
     __resume_g_3:
     __f->__suspend_56_14_res = __f->__suspend_56_14.await_resume();
+    __f->__suspend_56_14_res;
     goto __final_suspend;
   } catch(...) {
     if(!__f->__initial_await_suspend_called) {

--- a/tests/EduCoroutineCoreturnWithCoawaitTest.cerr
+++ b/tests/EduCoroutineCoreturnWithCoawaitTest.cerr
@@ -10,31 +10,31 @@
 .tmp.cpp:73:10: note: copy assignment operator is implicitly deleted because 'generator' has a user-declared move constructor
   inline generator(generator && rhs)
          ^
-.tmp.cpp:415:26: error: object of type 'generator' cannot be assigned because its copy assignment operator is implicitly deleted
+.tmp.cpp:413:26: error: object of type 'generator' cannot be assigned because its copy assignment operator is implicitly deleted
     __f->__suspend_60_24 = simpleReturn(__f->v);
                          ^
 .tmp.cpp:73:10: note: copy assignment operator is implicitly deleted because 'generator' has a user-declared move constructor
   inline generator(generator && rhs)
          ^
-.tmp.cpp:426:26: error: object of type 'generator' cannot be assigned because its copy assignment operator is implicitly deleted
+.tmp.cpp:424:26: error: object of type 'generator' cannot be assigned because its copy assignment operator is implicitly deleted
     __f->__suspend_60_51 = simpleReturn(__f->v + 1);
                          ^
 .tmp.cpp:73:10: note: copy assignment operator is implicitly deleted because 'generator' has a user-declared move constructor
   inline generator(generator && rhs)
          ^
-.tmp.cpp:438:26: error: object of type 'generator' cannot be assigned because its copy assignment operator is implicitly deleted
+.tmp.cpp:435:26: error: object of type 'generator' cannot be assigned because its copy assignment operator is implicitly deleted
     __f->__suspend_60_80 = simpleReturn(__f->v + 2);
                          ^
 .tmp.cpp:73:10: note: copy assignment operator is implicitly deleted because 'generator' has a user-declared move constructor
   inline generator(generator && rhs)
          ^
-.tmp.cpp:559:26: error: object of type 'generator' cannot be assigned because its copy assignment operator is implicitly deleted
+.tmp.cpp:554:26: error: object of type 'generator' cannot be assigned because its copy assignment operator is implicitly deleted
     __f->__suspend_67_24 = simpleReturn(__f->v);
                          ^
 .tmp.cpp:73:10: note: copy assignment operator is implicitly deleted because 'generator' has a user-declared move constructor
   inline generator(generator && rhs)
          ^
-.tmp.cpp:570:26: error: object of type 'generator' cannot be assigned because its copy assignment operator is implicitly deleted
+.tmp.cpp:565:26: error: object of type 'generator' cannot be assigned because its copy assignment operator is implicitly deleted
     __f->__suspend_67_51 = simpleReturn(__f->v + 1);
                          ^
 .tmp.cpp:73:10: note: copy assignment operator is implicitly deleted because 'generator' has a user-declared move constructor

--- a/tests/EduCoroutineCoreturnWithCoawaitTest.expect
+++ b/tests/EduCoroutineCoreturnWithCoawaitTest.expect
@@ -297,8 +297,6 @@ void __additionAwaitReturnResume(__additionAwaitReturnFrame * __f)
     
     __resume_additionAwaitReturn_3:
     __f->__suspend_56_51_res = __f->__suspend_56_51.await_resume();
-    ;
-    
     /* co_return EduCoroutineCoreturnWithCoawaitTest.cpp:56 */
     __f->__promise.return_value(__f->__suspend_56_24_res + __f->__suspend_56_51_res);
     goto __final_suspend;
@@ -432,7 +430,6 @@ void __additionAwaitReturn2Resume(__additionAwaitReturn2Frame * __f)
     
     __resume_additionAwaitReturn2_3:
     __f->__suspend_60_51_res = __f->__suspend_60_51.await_resume();
-    ;
     
     /* co_await EduCoroutineCoreturnWithCoawaitTest.cpp:60 */
     __f->__suspend_60_80 = simpleReturn(__f->v + 2);
@@ -444,8 +441,6 @@ void __additionAwaitReturn2Resume(__additionAwaitReturn2Frame * __f)
     
     __resume_additionAwaitReturn2_4:
     __f->__suspend_60_80_res = __f->__suspend_60_80.await_resume();
-    ;
-    
     /* co_return EduCoroutineCoreturnWithCoawaitTest.cpp:60 */
     __f->__promise.return_value((__f->__suspend_60_24_res + __f->__suspend_60_51_res) + __f->__suspend_60_80_res);
     goto __final_suspend;
@@ -576,9 +571,6 @@ void __additionAwaitReturnWithIntResume(__additionAwaitReturnWithIntFrame * __f)
     
     __resume_additionAwaitReturnWithInt_3:
     __f->__suspend_67_51_res = __f->__suspend_67_51.await_resume();
-    ;
-    ;
-    
     /* co_return EduCoroutineCoreturnWithCoawaitTest.cpp:67 */
     __f->__promise.return_value((__f->__suspend_67_24_res + __f->__suspend_67_51_res) + 47);
     goto __final_suspend;

--- a/tests/EduCoroutineCustomYieldTypeTest.expect
+++ b/tests/EduCoroutineCustomYieldTypeTest.expect
@@ -229,7 +229,7 @@ void __seqResume(__seqFrame * __f)
     
     __resume_seq_1:
     __f->__suspend_86_11.await_resume();
-    for( __f->i = __f->start; ; ++__f->i) {
+    for(__f->i = __f->start; ; ++__f->i) {
       
       /* co_await EduCoroutineCustomYieldTypeTest.cpp:88 */
       __f->__suspend_88_14 = auto_await_suspend{};

--- a/tests/EduCoroutineExprTest.cpp
+++ b/tests/EduCoroutineExprTest.cpp
@@ -1,0 +1,166 @@
+// cmdline:-std=c++20
+// cmdlineinsights:-edu-show-coroutine-transformation
+
+#include <coroutine>
+#include <cstdint>
+#include <exception>
+#include <iostream>
+#include <iostream>
+#include <utility>
+
+template<class T>
+struct task
+{
+    struct promise_type
+    {
+        auto get_return_object()
+        {
+            return task(std::coroutine_handle<promise_type>::from_promise(*this));
+        }
+        std::suspend_always initial_suspend() { return {}; }
+        struct final_awaiter
+        {
+            bool await_ready() noexcept { return false; }
+            void await_resume() noexcept {}
+            std::coroutine_handle<>
+            await_suspend(std::coroutine_handle<promise_type> h) noexcept
+            {
+                // final_awaiter::await_suspend is called when the execution of the
+                // current coroutine (referred to by 'h') is about to finish.
+                // If the current coroutine was resumed by another coroutine via
+                // co_await get_task(), a handle to that coroutine has been stored
+                // as h.promise().previous. In that case, return the handle to resume
+                // the previous coroutine.
+                // Otherwise, return noop_coroutine(), whose resumption does nothing.
+
+                if (auto previous = h.promise().previous; previous)
+                    return previous;
+                else
+                    return std::noop_coroutine();
+            }
+        };
+        final_awaiter final_suspend() noexcept { return {}; }
+        void unhandled_exception() { throw; }
+        void return_value(T value) { result = std::move(value); }
+
+        T result;
+        std::coroutine_handle<> previous;
+    };
+
+    task(std::coroutine_handle<promise_type> h) : coro(h) {}
+    task(task&& t) = default;
+    task& operator=(task&& t) = default;
+    ~task() { coro.destroy(); }
+
+    struct awaiter
+    {
+        bool await_ready() { return false; }
+        T await_resume() { return std::move(coro.promise().result); }
+        auto await_suspend(std::coroutine_handle<> h)
+        {
+            coro.promise().previous = h;
+            return coro;
+        }
+        std::coroutine_handle<promise_type> coro;
+    };
+    awaiter operator co_await() { return awaiter{coro}; }
+    T operator()()
+    {
+        coro.resume();
+        return std::move(coro.promise().result);
+    }
+
+private:
+    std::coroutine_handle<promise_type> coro;
+};
+
+task<int> get_random()
+{
+    std::cout << "in get_random()\n";
+    co_return 4;
+}
+
+int Funa(int);
+
+task<int> testVarDeclAndConditional()
+{
+    task<int> v = get_random();
+    task<int> u = get_random();
+    
+    int xres = (co_await v + co_await u);
+
+    auto t = co_await v ? co_await v+1 : co_await v+2;
+
+    co_return xres + co_await v;
+}
+task<int> testIfStmt()
+{
+    task<int> v = get_random();
+    task<int> u = get_random();
+
+    if(co_await v + co_await u)
+    {
+        Funa(Funa(co_await v));
+    } else {
+        auto w = co_await v;
+    }
+
+    co_return 0;
+}
+
+task<int> testCallExpr()
+{
+    task<int> v = get_random();
+
+    Funa(co_await v);
+
+    co_return 0;
+}
+
+task<int> testSwitch()
+{
+    task<int> v = get_random();
+
+    switch(co_await v) {
+        default: break;
+    }
+
+    co_return 0;
+}
+
+task<int> testWhile()
+{
+    task<int> v = get_random();
+
+    while(co_await v) {
+        int y{};
+    }
+
+    co_return 0;
+}
+
+task<int> testDoWhile()
+{
+    task<int> v = get_random();
+
+    do {
+        int yy{};
+    } while(co_await v);
+
+
+    co_return 0;
+}
+
+task<int> testForLoop()
+{
+    task<int> v = get_random();
+
+    // More difficult as the condition and increment happen on each iteration
+    for(co_await v; 0 != co_await v; co_await v)
+    {
+        co_await v + 6;
+    }
+
+    co_return 0;
+}
+

--- a/tests/EduCoroutineExprTest.expect
+++ b/tests/EduCoroutineExprTest.expect
@@ -1,0 +1,1301 @@
+/*************************************************************************************
+ * NOTE: The coroutine transformation you've enabled is a hand coded transformation! *
+ *       Most of it is _not_ present in the AST. What you see is an approximation.   *
+ *************************************************************************************/
+// cmdline:-std=c++20
+// cmdlineinsights:-edu-show-coroutine-transformation
+
+#include <coroutine>
+#include <cstdint>
+#include <exception>
+#include <iostream>
+#include <iostream>
+#include <utility>
+
+template<class T>
+struct task
+{
+  struct promise_type
+  {
+    inline auto get_return_object()
+    {
+      return task<T>(std::coroutine_handle<promise_type>::from_promise(*this));
+    }
+    
+    inline std::suspend_always initial_suspend()
+    {
+      return {};
+    }
+    
+    struct final_awaiter
+    {
+      inline bool await_ready() noexcept
+      {
+        return false;
+      }
+      
+      inline void await_resume() noexcept
+      {
+      }
+      
+      inline std::coroutine_handle<void> await_suspend(std::coroutine_handle<promise_type> h) noexcept
+      {
+        {
+          auto previous = h.promise().previous;
+          if(previous) {
+            return previous;
+          } else {
+            return static_cast<std::coroutine_handle<void>>(std::noop_coroutine().operator std::coroutine_handle<void>());
+          } 
+          
+        }
+        
+      }
+      
+    };
+    
+    inline final_awaiter final_suspend() noexcept
+    {
+      return {};
+    }
+    
+    inline void unhandled_exception()
+    {
+      throw ;
+    }
+    
+    inline void return_value(T value)
+    {
+      this->result = std::move(value);
+    }
+    
+    T result;
+    std::coroutine_handle<void> previous;
+  };
+  
+  inline task(std::coroutine_handle<promise_type> h)
+  : coro{h}
+  {
+  }
+  
+  inline task(task<T> && t) = default;
+  inline task<T> & operator=(task<T> && t) = default;
+  inline ~task()
+  {
+    this->coro.destroy();
+  }
+  
+  struct awaiter
+  {
+    inline bool await_ready()
+    {
+      return false;
+    }
+    
+    inline T await_resume()
+    {
+      return std::move(this->coro.promise().result);
+    }
+    
+    inline auto await_suspend(std::coroutine_handle<void> h)
+    {
+      this->coro.promise().previous = h;
+      return this->coro;
+    }
+    
+    std::coroutine_handle<promise_type> coro;
+  };
+  
+  inline awaiter operator co_await()
+  {
+    return awaiter{{this->coro}};
+  }
+  
+  inline T operator()()
+  {
+    this->coro.resume();
+    return std::move(this->coro.promise().result);
+  }
+  
+  
+  private: 
+  std::coroutine_handle<promise_type> coro;
+};
+
+/* First instantiated from: EduCoroutineExprTest.cpp:77 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+struct task<int>
+{
+  struct promise_type
+  {
+    inline task<int> get_return_object()
+    {
+      return task<int>(task<int>(std::coroutine_handle<promise_type>::from_promise(*this)));
+    }
+    
+    inline std::suspend_always initial_suspend()
+    {
+      return {};
+    }
+    
+    struct final_awaiter
+    {
+      inline bool await_ready() noexcept
+      {
+        return false;
+      }
+      
+      inline void await_resume() noexcept
+      {
+      }
+      
+      inline std::coroutine_handle<void> await_suspend(std::coroutine_handle<task<int>::promise_type> h) noexcept
+      {
+        {
+          std::coroutine_handle<void> previous = std::coroutine_handle<void>(h.promise().previous);
+          if(static_cast<bool>(previous.operator bool())) {
+            return std::coroutine_handle<void>(static_cast<std::coroutine_handle<void> &&>(previous));
+          } else {
+            return static_cast<std::coroutine_handle<void>>(std::noop_coroutine().operator std::coroutine_handle<void>());
+          } 
+          
+        }
+        
+      }
+      
+    };
+    
+    inline final_awaiter final_suspend() noexcept
+    {
+      return {};
+    }
+    
+    inline void unhandled_exception()
+    {
+      throw ;
+    }
+    
+    inline void return_value(int value)
+    {
+      this->result = std::move(value);
+    }
+    
+    int result;
+    std::coroutine_handle<void> previous;
+    // inline constexpr promise_type() noexcept = default;
+  };
+  
+  inline task(std::coroutine_handle<promise_type> h)
+  : coro{std::coroutine_handle<promise_type>(h)}
+  {
+  }
+  
+  inline constexpr task(task<int> && t) /* noexcept */ = default;
+  inline task<int> & operator=(task<int> && t) /* noexcept */ = default;
+  inline ~task() noexcept
+  {
+    this->coro.destroy();
+  }
+  
+  struct awaiter
+  {
+    inline bool await_ready()
+    {
+      return false;
+    }
+    
+    inline int await_resume()
+    {
+      return std::move(this->coro.promise().result);
+    }
+    
+    inline std::coroutine_handle<promise_type> await_suspend(std::coroutine_handle<void> h)
+    {
+      this->coro.promise().previous.operator=(h);
+      return std::coroutine_handle<promise_type>(this->coro);
+    }
+    
+    std::coroutine_handle<promise_type> coro;
+  };
+  
+  inline awaiter operator co_await()
+  {
+    return awaiter{std::coroutine_handle<promise_type>(this->coro)};
+  }
+  
+  inline int operator()();
+  
+  
+  private: 
+  std::coroutine_handle<promise_type> coro;
+  public: 
+  // inline constexpr task(const task<int> &) /* noexcept */ = delete;
+  // inline task<int> & operator=(const task<int> &) /* noexcept */ = delete;
+};
+
+#endif
+
+
+struct __get_randomFrame
+{
+  void (*resume_fn)(__get_randomFrame *);
+  void (*destroy_fn)(__get_randomFrame *);
+  std::__coroutine_traits_sfinae<task<int> >::promise_type __promise;
+  int __suspend_index;
+  bool __initial_await_suspend_called;
+  std::suspend_always __suspend_77_11;
+  task<int>::promise_type::final_awaiter __suspend_77_11_1;
+};
+
+task<int> get_random()
+{
+  /* Allocate the frame including the promise */
+  /* Note: The actual parameter new is __builtin_coro_size */
+  __get_randomFrame * __f = reinterpret_cast<__get_randomFrame *>(operator new(sizeof(__get_randomFrame)));
+  __f->__suspend_index = 0;
+  __f->__initial_await_suspend_called = false;
+  
+  /* Construct the promise. */
+  new (&__f->__promise)std::__coroutine_traits_sfinae<task<int> >::promise_type{};
+  
+  /* Forward declare the resume and destroy function. */
+  void __get_randomResume(__get_randomFrame * __f);
+  void __get_randomDestroy(__get_randomFrame * __f);
+  
+  /* Assign the resume and destroy function pointers. */
+  __f->resume_fn = &__get_randomResume;
+  __f->destroy_fn = &__get_randomDestroy;
+  
+  /* Call the made up function with the coroutine body for initial suspend.
+     This function will be called subsequently by coroutine_handle<>::resume()
+     which calls __builtin_coro_resume(__handle_) */
+  __get_randomResume(__f);
+  
+  
+  return __f->__promise.get_return_object();
+}
+
+/* This function invoked by coroutine_handle<>::resume() */
+void __get_randomResume(__get_randomFrame * __f)
+{
+  try 
+  {
+    /* Create a switch to get to the correct resume point */
+    switch(__f->__suspend_index) {
+      case 0: break;
+      case 1: goto __resume_get_random_1;
+    }
+    
+    /* co_await EduCoroutineExprTest.cpp:77 */
+    __f->__suspend_77_11 = __f->__promise.initial_suspend();
+    if(!__f->__suspend_77_11.await_ready()) {
+      __f->__suspend_77_11.await_suspend(std::coroutine_handle<task<int>::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
+      __f->__suspend_index = 1;
+      __f->__initial_await_suspend_called = true;
+      return;
+    } 
+    
+    __resume_get_random_1:
+    __f->__suspend_77_11.await_resume();
+    std::operator<<(std::cout, "in get_random()\n");
+    /* co_return EduCoroutineExprTest.cpp:80 */
+    __f->__promise.return_value(4);
+    goto __final_suspend;
+  } catch(...) {
+    if(!__f->__initial_await_suspend_called) {
+      throw ;
+    } 
+    
+    __f->__promise.unhandled_exception();
+  }
+  
+  __final_suspend:
+  
+  /* co_await EduCoroutineExprTest.cpp:77 */
+  __f->__suspend_77_11_1 = __f->__promise.final_suspend();
+  if(!__f->__suspend_77_11_1.await_ready()) {
+    __builtin_coro_resume(__f->__suspend_77_11_1.await_suspend(std::coroutine_handle<task<int>::promise_type>::from_address(static_cast<void *>(__f))).address());
+  } 
+  
+  ;
+}
+
+/* This function invoked by coroutine_handle<>::destroy() */
+void __get_randomDestroy(__get_randomFrame * __f)
+{
+  /* destroy all variables with dtors */
+  __f->~__get_randomFrame();
+  /* Deallocating the coroutine frame */
+  /* Note: The actual argument to delete is __builtin_coro_frame with the promise as parameter */
+  operator delete(static_cast<void *>(__f));
+}
+
+
+
+int Funa(int);
+
+
+struct __testVarDeclAndConditionalFrame
+{
+  void (*resume_fn)(__testVarDeclAndConditionalFrame *);
+  void (*destroy_fn)(__testVarDeclAndConditionalFrame *);
+  std::__coroutine_traits_sfinae<task<int> >::promise_type __promise;
+  int __suspend_index;
+  bool __initial_await_suspend_called;
+  task<int> v;
+  task<int> u;
+  int xres;
+  int t;
+  std::suspend_always __suspend_85_11;
+  task<int>::awaiter __suspend_90_17;
+  int __suspend_90_17_res;
+  task<int>::awaiter __suspend_90_30;
+  int __suspend_90_30_res;
+  task<int>::awaiter __suspend_92_14;
+  int __suspend_92_14_res;
+  task<int>::awaiter __suspend_92_27;
+  int __suspend_92_27_res;
+  task<int>::awaiter __suspend_92_42;
+  int __suspend_92_42_res;
+  task<int>::awaiter __suspend_94_22;
+  int __suspend_94_22_res;
+  task<int>::promise_type::final_awaiter __suspend_85_11_1;
+};
+
+task<int> testVarDeclAndConditional()
+{
+  /* Allocate the frame including the promise */
+  /* Note: The actual parameter new is __builtin_coro_size */
+  __testVarDeclAndConditionalFrame * __f = reinterpret_cast<__testVarDeclAndConditionalFrame *>(operator new(sizeof(__testVarDeclAndConditionalFrame)));
+  __f->__suspend_index = 0;
+  __f->__initial_await_suspend_called = false;
+  
+  /* Construct the promise. */
+  new (&__f->__promise)std::__coroutine_traits_sfinae<task<int> >::promise_type{};
+  
+  /* Forward declare the resume and destroy function. */
+  void __testVarDeclAndConditionalResume(__testVarDeclAndConditionalFrame * __f);
+  void __testVarDeclAndConditionalDestroy(__testVarDeclAndConditionalFrame * __f);
+  
+  /* Assign the resume and destroy function pointers. */
+  __f->resume_fn = &__testVarDeclAndConditionalResume;
+  __f->destroy_fn = &__testVarDeclAndConditionalDestroy;
+  
+  /* Call the made up function with the coroutine body for initial suspend.
+     This function will be called subsequently by coroutine_handle<>::resume()
+     which calls __builtin_coro_resume(__handle_) */
+  __testVarDeclAndConditionalResume(__f);
+  
+  
+  return __f->__promise.get_return_object();
+}
+
+/* This function invoked by coroutine_handle<>::resume() */
+void __testVarDeclAndConditionalResume(__testVarDeclAndConditionalFrame * __f)
+{
+  try 
+  {
+    /* Create a switch to get to the correct resume point */
+    switch(__f->__suspend_index) {
+      case 0: break;
+      case 1: goto __resume_testVarDeclAndConditional_1;
+      case 2: goto __resume_testVarDeclAndConditional_2;
+      case 3: goto __resume_testVarDeclAndConditional_3;
+      case 4: goto __resume_testVarDeclAndConditional_4;
+      case 5: goto __resume_testVarDeclAndConditional_5;
+      case 6: goto __resume_testVarDeclAndConditional_6;
+      case 7: goto __resume_testVarDeclAndConditional_7;
+    }
+    
+    /* co_await EduCoroutineExprTest.cpp:85 */
+    __f->__suspend_85_11 = __f->__promise.initial_suspend();
+    if(!__f->__suspend_85_11.await_ready()) {
+      __f->__suspend_85_11.await_suspend(std::coroutine_handle<task<int>::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
+      __f->__suspend_index = 1;
+      __f->__initial_await_suspend_called = true;
+      return;
+    } 
+    
+    __resume_testVarDeclAndConditional_1:
+    __f->__suspend_85_11.await_resume();
+    __f->v = get_random();
+    __f->u = get_random();
+    
+    /* co_await EduCoroutineExprTest.cpp:90 */
+    __f->__suspend_90_17 = __f->v.operator co_await();
+    if(!__f->__suspend_90_17.await_ready()) {
+      __builtin_coro_resume(__f->__suspend_90_17.await_suspend(std::coroutine_handle<task<int>::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>()).address());
+      __f->__suspend_index = 2;
+      return;
+    } 
+    
+    __resume_testVarDeclAndConditional_2:
+    __f->__suspend_90_17_res = __f->__suspend_90_17.await_resume();
+    
+    /* co_await EduCoroutineExprTest.cpp:90 */
+    __f->__suspend_90_30 = __f->u.operator co_await();
+    if(!__f->__suspend_90_30.await_ready()) {
+      __builtin_coro_resume(__f->__suspend_90_30.await_suspend(std::coroutine_handle<task<int>::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>()).address());
+      __f->__suspend_index = 3;
+      return;
+    } 
+    
+    __resume_testVarDeclAndConditional_3:
+    __f->__suspend_90_30_res = __f->__suspend_90_30.await_resume();
+    __f->xres = (__f->__suspend_90_17_res + __f->__suspend_90_30_res);
+    
+    /* co_await EduCoroutineExprTest.cpp:92 */
+    __f->__suspend_92_14 = __f->v.operator co_await();
+    if(!__f->__suspend_92_14.await_ready()) {
+      __builtin_coro_resume(__f->__suspend_92_14.await_suspend(std::coroutine_handle<task<int>::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>()).address());
+      __f->__suspend_index = 4;
+      return;
+    } 
+    
+    __resume_testVarDeclAndConditional_4:
+    __f->__suspend_92_14_res = __f->__suspend_92_14.await_resume();
+    
+    /* co_await EduCoroutineExprTest.cpp:92 */
+    __f->__suspend_92_27 = __f->v.operator co_await();
+    if(!__f->__suspend_92_27.await_ready()) {
+      __builtin_coro_resume(__f->__suspend_92_27.await_suspend(std::coroutine_handle<task<int>::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>()).address());
+      __f->__suspend_index = 5;
+      return;
+    } 
+    
+    __resume_testVarDeclAndConditional_5:
+    __f->__suspend_92_27_res = __f->__suspend_92_27.await_resume();
+    
+    /* co_await EduCoroutineExprTest.cpp:92 */
+    __f->__suspend_92_42 = __f->v.operator co_await();
+    if(!__f->__suspend_92_42.await_ready()) {
+      __builtin_coro_resume(__f->__suspend_92_42.await_suspend(std::coroutine_handle<task<int>::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>()).address());
+      __f->__suspend_index = 6;
+      return;
+    } 
+    
+    __resume_testVarDeclAndConditional_6:
+    __f->__suspend_92_42_res = __f->__suspend_92_42.await_resume();
+    __f->t = __f->__suspend_92_14_res ? __f->__suspend_92_27_res + 1 : __f->__suspend_92_42_res + 2;
+    
+    /* co_await EduCoroutineExprTest.cpp:94 */
+    __f->__suspend_94_22 = __f->v.operator co_await();
+    if(!__f->__suspend_94_22.await_ready()) {
+      __builtin_coro_resume(__f->__suspend_94_22.await_suspend(std::coroutine_handle<task<int>::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>()).address());
+      __f->__suspend_index = 7;
+      return;
+    } 
+    
+    __resume_testVarDeclAndConditional_7:
+    __f->__suspend_94_22_res = __f->__suspend_94_22.await_resume();
+    /* co_return EduCoroutineExprTest.cpp:94 */
+    __f->__promise.return_value(__f->xres + __f->__suspend_94_22_res);
+    goto __final_suspend;
+  } catch(...) {
+    if(!__f->__initial_await_suspend_called) {
+      throw ;
+    } 
+    
+    __f->__promise.unhandled_exception();
+  }
+  
+  __final_suspend:
+  
+  /* co_await EduCoroutineExprTest.cpp:85 */
+  __f->__suspend_85_11_1 = __f->__promise.final_suspend();
+  if(!__f->__suspend_85_11_1.await_ready()) {
+    __builtin_coro_resume(__f->__suspend_85_11_1.await_suspend(std::coroutine_handle<task<int>::promise_type>::from_address(static_cast<void *>(__f))).address());
+  } 
+  
+  ;
+}
+
+/* This function invoked by coroutine_handle<>::destroy() */
+void __testVarDeclAndConditionalDestroy(__testVarDeclAndConditionalFrame * __f)
+{
+  /* destroy all variables with dtors */
+  __f->~__testVarDeclAndConditionalFrame();
+  /* Deallocating the coroutine frame */
+  /* Note: The actual argument to delete is __builtin_coro_frame with the promise as parameter */
+  operator delete(static_cast<void *>(__f));
+}
+
+
+struct __testIfStmtFrame
+{
+  void (*resume_fn)(__testIfStmtFrame *);
+  void (*destroy_fn)(__testIfStmtFrame *);
+  std::__coroutine_traits_sfinae<task<int> >::promise_type __promise;
+  int __suspend_index;
+  bool __initial_await_suspend_called;
+  task<int> v;
+  task<int> u;
+  int w;
+  std::suspend_always __suspend_96_11;
+  task<int>::awaiter __suspend_101_8;
+  int __suspend_101_8_res;
+  task<int>::awaiter __suspend_101_21;
+  int __suspend_101_21_res;
+  task<int>::awaiter __suspend_103_19;
+  int __suspend_103_19_res;
+  task<int>::awaiter __suspend_105_18;
+  int __suspend_105_18_res;
+  task<int>::promise_type::final_awaiter __suspend_96_11_1;
+};
+
+task<int> testIfStmt()
+{
+  /* Allocate the frame including the promise */
+  /* Note: The actual parameter new is __builtin_coro_size */
+  __testIfStmtFrame * __f = reinterpret_cast<__testIfStmtFrame *>(operator new(sizeof(__testIfStmtFrame)));
+  __f->__suspend_index = 0;
+  __f->__initial_await_suspend_called = false;
+  
+  /* Construct the promise. */
+  new (&__f->__promise)std::__coroutine_traits_sfinae<task<int> >::promise_type{};
+  
+  /* Forward declare the resume and destroy function. */
+  void __testIfStmtResume(__testIfStmtFrame * __f);
+  void __testIfStmtDestroy(__testIfStmtFrame * __f);
+  
+  /* Assign the resume and destroy function pointers. */
+  __f->resume_fn = &__testIfStmtResume;
+  __f->destroy_fn = &__testIfStmtDestroy;
+  
+  /* Call the made up function with the coroutine body for initial suspend.
+     This function will be called subsequently by coroutine_handle<>::resume()
+     which calls __builtin_coro_resume(__handle_) */
+  __testIfStmtResume(__f);
+  
+  
+  return __f->__promise.get_return_object();
+}
+
+/* This function invoked by coroutine_handle<>::resume() */
+void __testIfStmtResume(__testIfStmtFrame * __f)
+{
+  try 
+  {
+    /* Create a switch to get to the correct resume point */
+    switch(__f->__suspend_index) {
+      case 0: break;
+      case 1: goto __resume_testIfStmt_1;
+      case 2: goto __resume_testIfStmt_2;
+      case 3: goto __resume_testIfStmt_3;
+      case 4: goto __resume_testIfStmt_4;
+      case 5: goto __resume_testIfStmt_5;
+    }
+    
+    /* co_await EduCoroutineExprTest.cpp:96 */
+    __f->__suspend_96_11 = __f->__promise.initial_suspend();
+    if(!__f->__suspend_96_11.await_ready()) {
+      __f->__suspend_96_11.await_suspend(std::coroutine_handle<task<int>::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
+      __f->__suspend_index = 1;
+      __f->__initial_await_suspend_called = true;
+      return;
+    } 
+    
+    __resume_testIfStmt_1:
+    __f->__suspend_96_11.await_resume();
+    __f->v = get_random();
+    __f->u = get_random();
+    
+    /* co_await EduCoroutineExprTest.cpp:101 */
+    __f->__suspend_101_8 = __f->v.operator co_await();
+    if(!__f->__suspend_101_8.await_ready()) {
+      __builtin_coro_resume(__f->__suspend_101_8.await_suspend(std::coroutine_handle<task<int>::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>()).address());
+      __f->__suspend_index = 2;
+      return;
+    } 
+    
+    __resume_testIfStmt_2:
+    __f->__suspend_101_8_res = __f->__suspend_101_8.await_resume();
+    
+    /* co_await EduCoroutineExprTest.cpp:101 */
+    __f->__suspend_101_21 = __f->u.operator co_await();
+    if(!__f->__suspend_101_21.await_ready()) {
+      __builtin_coro_resume(__f->__suspend_101_21.await_suspend(std::coroutine_handle<task<int>::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>()).address());
+      __f->__suspend_index = 3;
+      return;
+    } 
+    
+    __resume_testIfStmt_3:
+    __f->__suspend_101_21_res = __f->__suspend_101_21.await_resume();
+    if(__f->__suspend_101_8_res + __f->__suspend_101_21_res) {
+      
+      /* co_await EduCoroutineExprTest.cpp:103 */
+      __f->__suspend_103_19 = __f->v.operator co_await();
+      if(!__f->__suspend_103_19.await_ready()) {
+        __builtin_coro_resume(__f->__suspend_103_19.await_suspend(std::coroutine_handle<task<int>::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>()).address());
+        __f->__suspend_index = 4;
+        return;
+      } 
+      
+      __resume_testIfStmt_4:
+      __f->__suspend_103_19_res = __f->__suspend_103_19.await_resume();
+      Funa(Funa(__f->__suspend_103_19_res));
+    } else {
+      
+      /* co_await EduCoroutineExprTest.cpp:105 */
+      __f->__suspend_105_18 = __f->v.operator co_await();
+      if(!__f->__suspend_105_18.await_ready()) {
+        __builtin_coro_resume(__f->__suspend_105_18.await_suspend(std::coroutine_handle<task<int>::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>()).address());
+        __f->__suspend_index = 5;
+        return;
+      } 
+      
+      __resume_testIfStmt_5:
+      __f->__suspend_105_18_res = __f->__suspend_105_18.await_resume();
+      __f->w = __f->__suspend_105_18_res;
+    } 
+    
+    /* co_return EduCoroutineExprTest.cpp:108 */
+    __f->__promise.return_value(0);
+    goto __final_suspend;
+  } catch(...) {
+    if(!__f->__initial_await_suspend_called) {
+      throw ;
+    } 
+    
+    __f->__promise.unhandled_exception();
+  }
+  
+  __final_suspend:
+  
+  /* co_await EduCoroutineExprTest.cpp:96 */
+  __f->__suspend_96_11_1 = __f->__promise.final_suspend();
+  if(!__f->__suspend_96_11_1.await_ready()) {
+    __builtin_coro_resume(__f->__suspend_96_11_1.await_suspend(std::coroutine_handle<task<int>::promise_type>::from_address(static_cast<void *>(__f))).address());
+  } 
+  
+  ;
+}
+
+/* This function invoked by coroutine_handle<>::destroy() */
+void __testIfStmtDestroy(__testIfStmtFrame * __f)
+{
+  /* destroy all variables with dtors */
+  __f->~__testIfStmtFrame();
+  /* Deallocating the coroutine frame */
+  /* Note: The actual argument to delete is __builtin_coro_frame with the promise as parameter */
+  operator delete(static_cast<void *>(__f));
+}
+
+
+
+struct __testCallExprFrame
+{
+  void (*resume_fn)(__testCallExprFrame *);
+  void (*destroy_fn)(__testCallExprFrame *);
+  std::__coroutine_traits_sfinae<task<int> >::promise_type __promise;
+  int __suspend_index;
+  bool __initial_await_suspend_called;
+  task<int> v;
+  std::suspend_always __suspend_111_11;
+  task<int>::awaiter __suspend_115_10;
+  int __suspend_115_10_res;
+  task<int>::promise_type::final_awaiter __suspend_111_11_1;
+};
+
+task<int> testCallExpr()
+{
+  /* Allocate the frame including the promise */
+  /* Note: The actual parameter new is __builtin_coro_size */
+  __testCallExprFrame * __f = reinterpret_cast<__testCallExprFrame *>(operator new(sizeof(__testCallExprFrame)));
+  __f->__suspend_index = 0;
+  __f->__initial_await_suspend_called = false;
+  
+  /* Construct the promise. */
+  new (&__f->__promise)std::__coroutine_traits_sfinae<task<int> >::promise_type{};
+  
+  /* Forward declare the resume and destroy function. */
+  void __testCallExprResume(__testCallExprFrame * __f);
+  void __testCallExprDestroy(__testCallExprFrame * __f);
+  
+  /* Assign the resume and destroy function pointers. */
+  __f->resume_fn = &__testCallExprResume;
+  __f->destroy_fn = &__testCallExprDestroy;
+  
+  /* Call the made up function with the coroutine body for initial suspend.
+     This function will be called subsequently by coroutine_handle<>::resume()
+     which calls __builtin_coro_resume(__handle_) */
+  __testCallExprResume(__f);
+  
+  
+  return __f->__promise.get_return_object();
+}
+
+/* This function invoked by coroutine_handle<>::resume() */
+void __testCallExprResume(__testCallExprFrame * __f)
+{
+  try 
+  {
+    /* Create a switch to get to the correct resume point */
+    switch(__f->__suspend_index) {
+      case 0: break;
+      case 1: goto __resume_testCallExpr_1;
+      case 2: goto __resume_testCallExpr_2;
+    }
+    
+    /* co_await EduCoroutineExprTest.cpp:111 */
+    __f->__suspend_111_11 = __f->__promise.initial_suspend();
+    if(!__f->__suspend_111_11.await_ready()) {
+      __f->__suspend_111_11.await_suspend(std::coroutine_handle<task<int>::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
+      __f->__suspend_index = 1;
+      __f->__initial_await_suspend_called = true;
+      return;
+    } 
+    
+    __resume_testCallExpr_1:
+    __f->__suspend_111_11.await_resume();
+    __f->v = get_random();
+    
+    /* co_await EduCoroutineExprTest.cpp:115 */
+    __f->__suspend_115_10 = __f->v.operator co_await();
+    if(!__f->__suspend_115_10.await_ready()) {
+      __builtin_coro_resume(__f->__suspend_115_10.await_suspend(std::coroutine_handle<task<int>::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>()).address());
+      __f->__suspend_index = 2;
+      return;
+    } 
+    
+    __resume_testCallExpr_2:
+    __f->__suspend_115_10_res = __f->__suspend_115_10.await_resume();
+    Funa(__f->__suspend_115_10_res);
+    /* co_return EduCoroutineExprTest.cpp:117 */
+    __f->__promise.return_value(0);
+    goto __final_suspend;
+  } catch(...) {
+    if(!__f->__initial_await_suspend_called) {
+      throw ;
+    } 
+    
+    __f->__promise.unhandled_exception();
+  }
+  
+  __final_suspend:
+  
+  /* co_await EduCoroutineExprTest.cpp:111 */
+  __f->__suspend_111_11_1 = __f->__promise.final_suspend();
+  if(!__f->__suspend_111_11_1.await_ready()) {
+    __builtin_coro_resume(__f->__suspend_111_11_1.await_suspend(std::coroutine_handle<task<int>::promise_type>::from_address(static_cast<void *>(__f))).address());
+  } 
+  
+  ;
+}
+
+/* This function invoked by coroutine_handle<>::destroy() */
+void __testCallExprDestroy(__testCallExprFrame * __f)
+{
+  /* destroy all variables with dtors */
+  __f->~__testCallExprFrame();
+  /* Deallocating the coroutine frame */
+  /* Note: The actual argument to delete is __builtin_coro_frame with the promise as parameter */
+  operator delete(static_cast<void *>(__f));
+}
+
+
+
+struct __testSwitchFrame
+{
+  void (*resume_fn)(__testSwitchFrame *);
+  void (*destroy_fn)(__testSwitchFrame *);
+  std::__coroutine_traits_sfinae<task<int> >::promise_type __promise;
+  int __suspend_index;
+  bool __initial_await_suspend_called;
+  task<int> v;
+  std::suspend_always __suspend_120_11;
+  task<int>::awaiter __suspend_124_12;
+  int __suspend_124_12_res;
+  task<int>::promise_type::final_awaiter __suspend_120_11_1;
+};
+
+task<int> testSwitch()
+{
+  /* Allocate the frame including the promise */
+  /* Note: The actual parameter new is __builtin_coro_size */
+  __testSwitchFrame * __f = reinterpret_cast<__testSwitchFrame *>(operator new(sizeof(__testSwitchFrame)));
+  __f->__suspend_index = 0;
+  __f->__initial_await_suspend_called = false;
+  
+  /* Construct the promise. */
+  new (&__f->__promise)std::__coroutine_traits_sfinae<task<int> >::promise_type{};
+  
+  /* Forward declare the resume and destroy function. */
+  void __testSwitchResume(__testSwitchFrame * __f);
+  void __testSwitchDestroy(__testSwitchFrame * __f);
+  
+  /* Assign the resume and destroy function pointers. */
+  __f->resume_fn = &__testSwitchResume;
+  __f->destroy_fn = &__testSwitchDestroy;
+  
+  /* Call the made up function with the coroutine body for initial suspend.
+     This function will be called subsequently by coroutine_handle<>::resume()
+     which calls __builtin_coro_resume(__handle_) */
+  __testSwitchResume(__f);
+  
+  
+  return __f->__promise.get_return_object();
+}
+
+/* This function invoked by coroutine_handle<>::resume() */
+void __testSwitchResume(__testSwitchFrame * __f)
+{
+  try 
+  {
+    /* Create a switch to get to the correct resume point */
+    switch(__f->__suspend_index) {
+      case 0: break;
+      case 1: goto __resume_testSwitch_1;
+      case 2: goto __resume_testSwitch_2;
+    }
+    
+    /* co_await EduCoroutineExprTest.cpp:120 */
+    __f->__suspend_120_11 = __f->__promise.initial_suspend();
+    if(!__f->__suspend_120_11.await_ready()) {
+      __f->__suspend_120_11.await_suspend(std::coroutine_handle<task<int>::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
+      __f->__suspend_index = 1;
+      __f->__initial_await_suspend_called = true;
+      return;
+    } 
+    
+    __resume_testSwitch_1:
+    __f->__suspend_120_11.await_resume();
+    __f->v = get_random();
+    
+    /* co_await EduCoroutineExprTest.cpp:124 */
+    __f->__suspend_124_12 = __f->v.operator co_await();
+    if(!__f->__suspend_124_12.await_ready()) {
+      __builtin_coro_resume(__f->__suspend_124_12.await_suspend(std::coroutine_handle<task<int>::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>()).address());
+      __f->__suspend_index = 2;
+      return;
+    } 
+    
+    __resume_testSwitch_2:
+    __f->__suspend_124_12_res = __f->__suspend_124_12.await_resume();
+    switch(__f->__suspend_124_12_res) {
+      default: break;
+    }
+    /* co_return EduCoroutineExprTest.cpp:128 */
+    __f->__promise.return_value(0);
+    goto __final_suspend;
+  } catch(...) {
+    if(!__f->__initial_await_suspend_called) {
+      throw ;
+    } 
+    
+    __f->__promise.unhandled_exception();
+  }
+  
+  __final_suspend:
+  
+  /* co_await EduCoroutineExprTest.cpp:120 */
+  __f->__suspend_120_11_1 = __f->__promise.final_suspend();
+  if(!__f->__suspend_120_11_1.await_ready()) {
+    __builtin_coro_resume(__f->__suspend_120_11_1.await_suspend(std::coroutine_handle<task<int>::promise_type>::from_address(static_cast<void *>(__f))).address());
+  } 
+  
+  ;
+}
+
+/* This function invoked by coroutine_handle<>::destroy() */
+void __testSwitchDestroy(__testSwitchFrame * __f)
+{
+  /* destroy all variables with dtors */
+  __f->~__testSwitchFrame();
+  /* Deallocating the coroutine frame */
+  /* Note: The actual argument to delete is __builtin_coro_frame with the promise as parameter */
+  operator delete(static_cast<void *>(__f));
+}
+
+
+
+struct __testWhileFrame
+{
+  void (*resume_fn)(__testWhileFrame *);
+  void (*destroy_fn)(__testWhileFrame *);
+  std::__coroutine_traits_sfinae<task<int> >::promise_type __promise;
+  int __suspend_index;
+  bool __initial_await_suspend_called;
+  task<int> v;
+  int y;
+  std::suspend_always __suspend_131_11;
+  task<int>::awaiter __suspend_135_11;
+  int __suspend_135_11_res;
+  task<int>::promise_type::final_awaiter __suspend_131_11_1;
+};
+
+task<int> testWhile()
+{
+  /* Allocate the frame including the promise */
+  /* Note: The actual parameter new is __builtin_coro_size */
+  __testWhileFrame * __f = reinterpret_cast<__testWhileFrame *>(operator new(sizeof(__testWhileFrame)));
+  __f->__suspend_index = 0;
+  __f->__initial_await_suspend_called = false;
+  
+  /* Construct the promise. */
+  new (&__f->__promise)std::__coroutine_traits_sfinae<task<int> >::promise_type{};
+  
+  /* Forward declare the resume and destroy function. */
+  void __testWhileResume(__testWhileFrame * __f);
+  void __testWhileDestroy(__testWhileFrame * __f);
+  
+  /* Assign the resume and destroy function pointers. */
+  __f->resume_fn = &__testWhileResume;
+  __f->destroy_fn = &__testWhileDestroy;
+  
+  /* Call the made up function with the coroutine body for initial suspend.
+     This function will be called subsequently by coroutine_handle<>::resume()
+     which calls __builtin_coro_resume(__handle_) */
+  __testWhileResume(__f);
+  
+  
+  return __f->__promise.get_return_object();
+}
+
+/* This function invoked by coroutine_handle<>::resume() */
+void __testWhileResume(__testWhileFrame * __f)
+{
+  try 
+  {
+    /* Create a switch to get to the correct resume point */
+    switch(__f->__suspend_index) {
+      case 0: break;
+      case 1: goto __resume_testWhile_1;
+      case 2: goto __resume_testWhile_2;
+    }
+    
+    /* co_await EduCoroutineExprTest.cpp:131 */
+    __f->__suspend_131_11 = __f->__promise.initial_suspend();
+    if(!__f->__suspend_131_11.await_ready()) {
+      __f->__suspend_131_11.await_suspend(std::coroutine_handle<task<int>::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
+      __f->__suspend_index = 1;
+      __f->__initial_await_suspend_called = true;
+      return;
+    } 
+    
+    __resume_testWhile_1:
+    __f->__suspend_131_11.await_resume();
+    __f->v = get_random();
+    
+    /* co_await EduCoroutineExprTest.cpp:135 */
+    __f->__suspend_135_11 = __f->v.operator co_await();
+    if(!__f->__suspend_135_11.await_ready()) {
+      __builtin_coro_resume(__f->__suspend_135_11.await_suspend(std::coroutine_handle<task<int>::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>()).address());
+      __f->__suspend_index = 2;
+      return;
+    } 
+    
+    __resume_testWhile_2:
+    __f->__suspend_135_11_res = __f->__suspend_135_11.await_resume();
+    while(__f->__suspend_135_11_res) {
+      __f->y = {};
+    }
+    
+    /* co_return EduCoroutineExprTest.cpp:139 */
+    __f->__promise.return_value(0);
+    goto __final_suspend;
+  } catch(...) {
+    if(!__f->__initial_await_suspend_called) {
+      throw ;
+    } 
+    
+    __f->__promise.unhandled_exception();
+  }
+  
+  __final_suspend:
+  
+  /* co_await EduCoroutineExprTest.cpp:131 */
+  __f->__suspend_131_11_1 = __f->__promise.final_suspend();
+  if(!__f->__suspend_131_11_1.await_ready()) {
+    __builtin_coro_resume(__f->__suspend_131_11_1.await_suspend(std::coroutine_handle<task<int>::promise_type>::from_address(static_cast<void *>(__f))).address());
+  } 
+  
+  ;
+}
+
+/* This function invoked by coroutine_handle<>::destroy() */
+void __testWhileDestroy(__testWhileFrame * __f)
+{
+  /* destroy all variables with dtors */
+  __f->~__testWhileFrame();
+  /* Deallocating the coroutine frame */
+  /* Note: The actual argument to delete is __builtin_coro_frame with the promise as parameter */
+  operator delete(static_cast<void *>(__f));
+}
+
+
+
+struct __testDoWhileFrame
+{
+  void (*resume_fn)(__testDoWhileFrame *);
+  void (*destroy_fn)(__testDoWhileFrame *);
+  std::__coroutine_traits_sfinae<task<int> >::promise_type __promise;
+  int __suspend_index;
+  bool __initial_await_suspend_called;
+  task<int> v;
+  int yy;
+  std::suspend_always __suspend_142_11;
+  task<int>::awaiter __suspend_148_13;
+  int __suspend_148_13_res;
+  task<int>::promise_type::final_awaiter __suspend_142_11_1;
+};
+
+task<int> testDoWhile()
+{
+  /* Allocate the frame including the promise */
+  /* Note: The actual parameter new is __builtin_coro_size */
+  __testDoWhileFrame * __f = reinterpret_cast<__testDoWhileFrame *>(operator new(sizeof(__testDoWhileFrame)));
+  __f->__suspend_index = 0;
+  __f->__initial_await_suspend_called = false;
+  
+  /* Construct the promise. */
+  new (&__f->__promise)std::__coroutine_traits_sfinae<task<int> >::promise_type{};
+  
+  /* Forward declare the resume and destroy function. */
+  void __testDoWhileResume(__testDoWhileFrame * __f);
+  void __testDoWhileDestroy(__testDoWhileFrame * __f);
+  
+  /* Assign the resume and destroy function pointers. */
+  __f->resume_fn = &__testDoWhileResume;
+  __f->destroy_fn = &__testDoWhileDestroy;
+  
+  /* Call the made up function with the coroutine body for initial suspend.
+     This function will be called subsequently by coroutine_handle<>::resume()
+     which calls __builtin_coro_resume(__handle_) */
+  __testDoWhileResume(__f);
+  
+  
+  return __f->__promise.get_return_object();
+}
+
+/* This function invoked by coroutine_handle<>::resume() */
+void __testDoWhileResume(__testDoWhileFrame * __f)
+{
+  try 
+  {
+    /* Create a switch to get to the correct resume point */
+    switch(__f->__suspend_index) {
+      case 0: break;
+      case 1: goto __resume_testDoWhile_1;
+      case 2: goto __resume_testDoWhile_2;
+    }
+    
+    /* co_await EduCoroutineExprTest.cpp:142 */
+    __f->__suspend_142_11 = __f->__promise.initial_suspend();
+    if(!__f->__suspend_142_11.await_ready()) {
+      __f->__suspend_142_11.await_suspend(std::coroutine_handle<task<int>::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
+      __f->__suspend_index = 1;
+      __f->__initial_await_suspend_called = true;
+      return;
+    } 
+    
+    __resume_testDoWhile_1:
+    __f->__suspend_142_11.await_resume();
+    __f->v = get_random();
+    
+    /* co_await EduCoroutineExprTest.cpp:148 */
+    __f->__suspend_148_13 = __f->v.operator co_await();
+    if(!__f->__suspend_148_13.await_ready()) {
+      __builtin_coro_resume(__f->__suspend_148_13.await_suspend(std::coroutine_handle<task<int>::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>()).address());
+      __f->__suspend_index = 2;
+      return;
+    } 
+    
+    __resume_testDoWhile_2:
+    __f->__suspend_148_13_res = __f->__suspend_148_13.await_resume();
+    do {
+      __f->yy = {};
+    } while(__f->__suspend_148_13_res);
+    
+    /* co_return EduCoroutineExprTest.cpp:151 */
+    __f->__promise.return_value(0);
+    goto __final_suspend;
+  } catch(...) {
+    if(!__f->__initial_await_suspend_called) {
+      throw ;
+    } 
+    
+    __f->__promise.unhandled_exception();
+  }
+  
+  __final_suspend:
+  
+  /* co_await EduCoroutineExprTest.cpp:142 */
+  __f->__suspend_142_11_1 = __f->__promise.final_suspend();
+  if(!__f->__suspend_142_11_1.await_ready()) {
+    __builtin_coro_resume(__f->__suspend_142_11_1.await_suspend(std::coroutine_handle<task<int>::promise_type>::from_address(static_cast<void *>(__f))).address());
+  } 
+  
+  ;
+}
+
+/* This function invoked by coroutine_handle<>::destroy() */
+void __testDoWhileDestroy(__testDoWhileFrame * __f)
+{
+  /* destroy all variables with dtors */
+  __f->~__testDoWhileFrame();
+  /* Deallocating the coroutine frame */
+  /* Note: The actual argument to delete is __builtin_coro_frame with the promise as parameter */
+  operator delete(static_cast<void *>(__f));
+}
+
+
+
+struct __testForLoopFrame
+{
+  void (*resume_fn)(__testForLoopFrame *);
+  void (*destroy_fn)(__testForLoopFrame *);
+  std::__coroutine_traits_sfinae<task<int> >::promise_type __promise;
+  int __suspend_index;
+  bool __initial_await_suspend_called;
+  task<int> v;
+  std::suspend_always __suspend_154_11;
+  task<int>::awaiter __suspend_159_9;
+  int __suspend_159_9_res;
+  task<int>::awaiter __suspend_159_26;
+  int __suspend_159_26_res;
+  task<int>::awaiter __suspend_159_38;
+  int __suspend_159_38_res;
+  task<int>::awaiter __suspend_161_9;
+  int __suspend_161_9_res;
+  task<int>::promise_type::final_awaiter __suspend_154_11_1;
+};
+
+task<int> testForLoop()
+{
+  /* Allocate the frame including the promise */
+  /* Note: The actual parameter new is __builtin_coro_size */
+  __testForLoopFrame * __f = reinterpret_cast<__testForLoopFrame *>(operator new(sizeof(__testForLoopFrame)));
+  __f->__suspend_index = 0;
+  __f->__initial_await_suspend_called = false;
+  
+  /* Construct the promise. */
+  new (&__f->__promise)std::__coroutine_traits_sfinae<task<int> >::promise_type{};
+  
+  /* Forward declare the resume and destroy function. */
+  void __testForLoopResume(__testForLoopFrame * __f);
+  void __testForLoopDestroy(__testForLoopFrame * __f);
+  
+  /* Assign the resume and destroy function pointers. */
+  __f->resume_fn = &__testForLoopResume;
+  __f->destroy_fn = &__testForLoopDestroy;
+  
+  /* Call the made up function with the coroutine body for initial suspend.
+     This function will be called subsequently by coroutine_handle<>::resume()
+     which calls __builtin_coro_resume(__handle_) */
+  __testForLoopResume(__f);
+  
+  
+  return __f->__promise.get_return_object();
+}
+
+/* This function invoked by coroutine_handle<>::resume() */
+void __testForLoopResume(__testForLoopFrame * __f)
+{
+  try 
+  {
+    /* Create a switch to get to the correct resume point */
+    switch(__f->__suspend_index) {
+      case 0: break;
+      case 1: goto __resume_testForLoop_1;
+      case 2: goto __resume_testForLoop_2;
+      case 3: goto __resume_testForLoop_3;
+      case 4: goto __resume_testForLoop_4;
+      case 5: goto __resume_testForLoop_5;
+    }
+    
+    /* co_await EduCoroutineExprTest.cpp:154 */
+    __f->__suspend_154_11 = __f->__promise.initial_suspend();
+    if(!__f->__suspend_154_11.await_ready()) {
+      __f->__suspend_154_11.await_suspend(std::coroutine_handle<task<int>::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
+      __f->__suspend_index = 1;
+      __f->__initial_await_suspend_called = true;
+      return;
+    } 
+    
+    __resume_testForLoop_1:
+    __f->__suspend_154_11.await_resume();
+    __f->v = get_random();
+    
+    /* co_await EduCoroutineExprTest.cpp:159 */
+    __f->__suspend_159_9 = __f->v.operator co_await();
+    if(!__f->__suspend_159_9.await_ready()) {
+      __builtin_coro_resume(__f->__suspend_159_9.await_suspend(std::coroutine_handle<task<int>::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>()).address());
+      __f->__suspend_index = 2;
+      return;
+    } 
+    
+    __resume_testForLoop_2:
+    __f->__suspend_159_9_res = __f->__suspend_159_9.await_resume();
+    
+    /* co_await EduCoroutineExprTest.cpp:159 */
+    __f->__suspend_159_26 = __f->v.operator co_await();
+    if(!__f->__suspend_159_26.await_ready()) {
+      __builtin_coro_resume(__f->__suspend_159_26.await_suspend(std::coroutine_handle<task<int>::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>()).address());
+      __f->__suspend_index = 3;
+      return;
+    } 
+    
+    __resume_testForLoop_3:
+    __f->__suspend_159_26_res = __f->__suspend_159_26.await_resume();
+    
+    /* co_await EduCoroutineExprTest.cpp:159 */
+    __f->__suspend_159_38 = __f->v.operator co_await();
+    if(!__f->__suspend_159_38.await_ready()) {
+      __builtin_coro_resume(__f->__suspend_159_38.await_suspend(std::coroutine_handle<task<int>::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>()).address());
+      __f->__suspend_index = 4;
+      return;
+    } 
+    
+    __resume_testForLoop_4:
+    __f->__suspend_159_38_res = __f->__suspend_159_38.await_resume();
+    for(__f->__suspend_159_9_res; 0 != __f->__suspend_159_26_res; __f->__suspend_159_38_res) {
+      
+      /* co_await EduCoroutineExprTest.cpp:161 */
+      __f->__suspend_161_9 = __f->v.operator co_await();
+      if(!__f->__suspend_161_9.await_ready()) {
+        __builtin_coro_resume(__f->__suspend_161_9.await_suspend(std::coroutine_handle<task<int>::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>()).address());
+        __f->__suspend_index = 5;
+        return;
+      } 
+      
+      __resume_testForLoop_5:
+      __f->__suspend_161_9_res = __f->__suspend_161_9.await_resume();
+      __f->__suspend_161_9_res + 6;
+    }
+    
+    /* co_return EduCoroutineExprTest.cpp:164 */
+    __f->__promise.return_value(0);
+    goto __final_suspend;
+  } catch(...) {
+    if(!__f->__initial_await_suspend_called) {
+      throw ;
+    } 
+    
+    __f->__promise.unhandled_exception();
+  }
+  
+  __final_suspend:
+  
+  /* co_await EduCoroutineExprTest.cpp:154 */
+  __f->__suspend_154_11_1 = __f->__promise.final_suspend();
+  if(!__f->__suspend_154_11_1.await_ready()) {
+    __builtin_coro_resume(__f->__suspend_154_11_1.await_suspend(std::coroutine_handle<task<int>::promise_type>::from_address(static_cast<void *>(__f))).address());
+  } 
+  
+  ;
+}
+
+/* This function invoked by coroutine_handle<>::destroy() */
+void __testForLoopDestroy(__testForLoopFrame * __f)
+{
+  /* destroy all variables with dtors */
+  __f->~__testForLoopFrame();
+  /* Deallocating the coroutine frame */
+  /* Note: The actual argument to delete is __builtin_coro_frame with the promise as parameter */
+  operator delete(static_cast<void *>(__f));
+}
+
+
+

--- a/tests/EduCoroutineVoidTest.expect
+++ b/tests/EduCoroutineVoidTest.expect
@@ -212,7 +212,7 @@ void __seq_intResume(__seq_intFrame * __f)
     
     __resume_seq_int_1:
     __f->__suspend_34_14.await_resume();
-    for( __f->i = {}; ; ++__f->i) {
+    for(__f->i = {}; ; ++__f->i) {
       
       /* co_yield EduCoroutineVoidTest.cpp:36 */
       __f->__suspend_36_5 = __f->__promise.yield_value(__f->i);

--- a/tests/Issue518.cpp
+++ b/tests/Issue518.cpp
@@ -1,0 +1,97 @@
+// cmdline:-std=c++20
+// cmdlineinsights:-edu-show-coroutine-transformation
+
+#include <coroutine>
+#include <cstdint>
+#include <exception>
+#include <iostream>
+#include <iostream>
+#include <utility>
+
+template<class T>
+struct task
+{
+    struct promise_type
+    {
+        auto get_return_object()
+        {
+            return task(std::coroutine_handle<promise_type>::from_promise(*this));
+        }
+        std::suspend_always initial_suspend() { return {}; }
+        struct final_awaiter
+        {
+            bool await_ready() noexcept { return false; }
+            void await_resume() noexcept {}
+            std::coroutine_handle<>
+            await_suspend(std::coroutine_handle<promise_type> h) noexcept
+            {
+                // final_awaiter::await_suspend is called when the execution of the
+                // current coroutine (referred to by 'h') is about to finish.
+                // If the current coroutine was resumed by another coroutine via
+                // co_await get_task(), a handle to that coroutine has been stored
+                // as h.promise().previous. In that case, return the handle to resume
+                // the previous coroutine.
+                // Otherwise, return noop_coroutine(), whose resumption does nothing.
+
+                if (auto previous = h.promise().previous; previous)
+                    return previous;
+                else
+                    return std::noop_coroutine();
+            }
+        };
+        final_awaiter final_suspend() noexcept { return {}; }
+        void unhandled_exception() { throw; }
+        void return_value(T value) { result = std::move(value); }
+
+        T result;
+        std::coroutine_handle<> previous;
+    };
+
+    task(std::coroutine_handle<promise_type> h) : coro(h) {}
+    task(task&& t) = default;
+    task& operator=(task&& t) = default;
+    ~task() { coro.destroy(); }
+
+    struct awaiter
+    {
+        bool await_ready() { return false; }
+        T await_resume() { return std::move(coro.promise().result); }
+        auto await_suspend(std::coroutine_handle<> h)
+        {
+            coro.promise().previous = h;
+            return coro;
+        }
+        std::coroutine_handle<promise_type> coro;
+    };
+    awaiter operator co_await() { return awaiter{coro}; }
+    T operator()()
+    {
+        coro.resume();
+        return std::move(coro.promise().result);
+    }
+
+private:
+    std::coroutine_handle<promise_type> coro;
+};
+
+task<int> get_random()
+{
+    std::cout << "in get_random()\n";
+    co_return 4;
+}
+
+task<int> test()
+{
+    task<int> v = get_random();
+    task<int> u = get_random();
+    std::cout << "in test()\n";
+    int xres = (co_await v + co_await u);
+    co_return xres;
+}
+
+void noop_coroutine()
+{
+    task<int> t = test();
+    int result = t();
+    std::cout << result << '\n';
+}

--- a/tests/Issue518.expect
+++ b/tests/Issue518.expect
@@ -1,0 +1,476 @@
+/*************************************************************************************
+ * NOTE: The coroutine transformation you've enabled is a hand coded transformation! *
+ *       Most of it is _not_ present in the AST. What you see is an approximation.   *
+ *************************************************************************************/
+// cmdline:-std=c++20
+// cmdlineinsights:-edu-show-coroutine-transformation
+
+#include <coroutine>
+#include <cstdint>
+#include <exception>
+#include <iostream>
+#include <iostream>
+#include <utility>
+
+template<class T>
+struct task
+{
+  struct promise_type
+  {
+    inline auto get_return_object()
+    {
+      return task<T>(std::coroutine_handle<promise_type>::from_promise(*this));
+    }
+    
+    inline std::suspend_always initial_suspend()
+    {
+      return {};
+    }
+    
+    struct final_awaiter
+    {
+      inline bool await_ready() noexcept
+      {
+        return false;
+      }
+      
+      inline void await_resume() noexcept
+      {
+      }
+      
+      inline std::coroutine_handle<void> await_suspend(std::coroutine_handle<promise_type> h) noexcept
+      {
+        {
+          auto previous = h.promise().previous;
+          if(previous) {
+            return previous;
+          } else {
+            return static_cast<std::coroutine_handle<void>>(std::noop_coroutine().operator std::coroutine_handle<void>());
+          } 
+          
+        }
+        
+      }
+      
+    };
+    
+    inline final_awaiter final_suspend() noexcept
+    {
+      return {};
+    }
+    
+    inline void unhandled_exception()
+    {
+      throw ;
+    }
+    
+    inline void return_value(T value)
+    {
+      this->result = std::move(value);
+    }
+    
+    T result;
+    std::coroutine_handle<void> previous;
+  };
+  
+  inline task(std::coroutine_handle<promise_type> h)
+  : coro{h}
+  {
+  }
+  
+  inline task(task<T> && t) = default;
+  inline task<T> & operator=(task<T> && t) = default;
+  inline ~task()
+  {
+    this->coro.destroy();
+  }
+  
+  struct awaiter
+  {
+    inline bool await_ready()
+    {
+      return false;
+    }
+    
+    inline T await_resume()
+    {
+      return std::move(this->coro.promise().result);
+    }
+    
+    inline auto await_suspend(std::coroutine_handle<void> h)
+    {
+      this->coro.promise().previous = h;
+      return this->coro;
+    }
+    
+    std::coroutine_handle<promise_type> coro;
+  };
+  
+  inline awaiter operator co_await()
+  {
+    return awaiter{{this->coro}};
+  }
+  
+  inline T operator()()
+  {
+    this->coro.resume();
+    return std::move(this->coro.promise().result);
+  }
+  
+  
+  private: 
+  std::coroutine_handle<promise_type> coro;
+};
+
+/* First instantiated from: Issue518.cpp:77 */
+#ifdef INSIGHTS_USE_TEMPLATE
+template<>
+struct task<int>
+{
+  struct promise_type
+  {
+    inline task<int> get_return_object()
+    {
+      return task<int>(task<int>(std::coroutine_handle<promise_type>::from_promise(*this)));
+    }
+    
+    inline std::suspend_always initial_suspend()
+    {
+      return {};
+    }
+    
+    struct final_awaiter
+    {
+      inline bool await_ready() noexcept
+      {
+        return false;
+      }
+      
+      inline void await_resume() noexcept
+      {
+      }
+      
+      inline std::coroutine_handle<void> await_suspend(std::coroutine_handle<task<int>::promise_type> h) noexcept
+      {
+        {
+          std::coroutine_handle<void> previous = std::coroutine_handle<void>(h.promise().previous);
+          if(static_cast<bool>(previous.operator bool())) {
+            return std::coroutine_handle<void>(static_cast<std::coroutine_handle<void> &&>(previous));
+          } else {
+            return static_cast<std::coroutine_handle<void>>(std::noop_coroutine().operator std::coroutine_handle<void>());
+          } 
+          
+        }
+        
+      }
+      
+    };
+    
+    inline final_awaiter final_suspend() noexcept
+    {
+      return {};
+    }
+    
+    inline void unhandled_exception()
+    {
+      throw ;
+    }
+    
+    inline void return_value(int value)
+    {
+      this->result = std::move(value);
+    }
+    
+    int result;
+    std::coroutine_handle<void> previous;
+    // inline constexpr promise_type() noexcept = default;
+  };
+  
+  inline task(std::coroutine_handle<promise_type> h)
+  : coro{std::coroutine_handle<promise_type>(h)}
+  {
+  }
+  
+  inline constexpr task(task<int> && t) /* noexcept */ = default;
+  inline task<int> & operator=(task<int> && t) /* noexcept */ = default;
+  inline ~task() noexcept
+  {
+    this->coro.destroy();
+  }
+  
+  struct awaiter
+  {
+    inline bool await_ready()
+    {
+      return false;
+    }
+    
+    inline int await_resume()
+    {
+      return std::move(this->coro.promise().result);
+    }
+    
+    inline std::coroutine_handle<promise_type> await_suspend(std::coroutine_handle<void> h)
+    {
+      this->coro.promise().previous.operator=(h);
+      return std::coroutine_handle<promise_type>(this->coro);
+    }
+    
+    std::coroutine_handle<promise_type> coro;
+  };
+  
+  inline awaiter operator co_await()
+  {
+    return awaiter{std::coroutine_handle<promise_type>(this->coro)};
+  }
+  
+  inline int operator()()
+  {
+    this->coro.resume();
+    return std::move(this->coro.promise().result);
+  }
+  
+  
+  private: 
+  std::coroutine_handle<promise_type> coro;
+  public: 
+  // inline constexpr task(const task<int> &) /* noexcept */ = delete;
+  // inline task<int> & operator=(const task<int> &) /* noexcept */ = delete;
+};
+
+#endif
+
+
+struct __get_randomFrame
+{
+  void (*resume_fn)(__get_randomFrame *);
+  void (*destroy_fn)(__get_randomFrame *);
+  std::__coroutine_traits_sfinae<task<int> >::promise_type __promise;
+  int __suspend_index;
+  bool __initial_await_suspend_called;
+  std::suspend_always __suspend_77_11;
+  task<int>::promise_type::final_awaiter __suspend_77_11_1;
+};
+
+task<int> get_random()
+{
+  /* Allocate the frame including the promise */
+  /* Note: The actual parameter new is __builtin_coro_size */
+  __get_randomFrame * __f = reinterpret_cast<__get_randomFrame *>(operator new(sizeof(__get_randomFrame)));
+  __f->__suspend_index = 0;
+  __f->__initial_await_suspend_called = false;
+  
+  /* Construct the promise. */
+  new (&__f->__promise)std::__coroutine_traits_sfinae<task<int> >::promise_type{};
+  
+  /* Forward declare the resume and destroy function. */
+  void __get_randomResume(__get_randomFrame * __f);
+  void __get_randomDestroy(__get_randomFrame * __f);
+  
+  /* Assign the resume and destroy function pointers. */
+  __f->resume_fn = &__get_randomResume;
+  __f->destroy_fn = &__get_randomDestroy;
+  
+  /* Call the made up function with the coroutine body for initial suspend.
+     This function will be called subsequently by coroutine_handle<>::resume()
+     which calls __builtin_coro_resume(__handle_) */
+  __get_randomResume(__f);
+  
+  
+  return __f->__promise.get_return_object();
+}
+
+/* This function invoked by coroutine_handle<>::resume() */
+void __get_randomResume(__get_randomFrame * __f)
+{
+  try 
+  {
+    /* Create a switch to get to the correct resume point */
+    switch(__f->__suspend_index) {
+      case 0: break;
+      case 1: goto __resume_get_random_1;
+    }
+    
+    /* co_await Issue518.cpp:77 */
+    __f->__suspend_77_11 = __f->__promise.initial_suspend();
+    if(!__f->__suspend_77_11.await_ready()) {
+      __f->__suspend_77_11.await_suspend(std::coroutine_handle<task<int>::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
+      __f->__suspend_index = 1;
+      __f->__initial_await_suspend_called = true;
+      return;
+    } 
+    
+    __resume_get_random_1:
+    __f->__suspend_77_11.await_resume();
+    std::operator<<(std::cout, "in get_random()\n");
+    /* co_return Issue518.cpp:80 */
+    __f->__promise.return_value(4);
+    goto __final_suspend;
+  } catch(...) {
+    if(!__f->__initial_await_suspend_called) {
+      throw ;
+    } 
+    
+    __f->__promise.unhandled_exception();
+  }
+  
+  __final_suspend:
+  
+  /* co_await Issue518.cpp:77 */
+  __f->__suspend_77_11_1 = __f->__promise.final_suspend();
+  if(!__f->__suspend_77_11_1.await_ready()) {
+    __builtin_coro_resume(__f->__suspend_77_11_1.await_suspend(std::coroutine_handle<task<int>::promise_type>::from_address(static_cast<void *>(__f))).address());
+  } 
+  
+  ;
+}
+
+/* This function invoked by coroutine_handle<>::destroy() */
+void __get_randomDestroy(__get_randomFrame * __f)
+{
+  /* destroy all variables with dtors */
+  __f->~__get_randomFrame();
+  /* Deallocating the coroutine frame */
+  /* Note: The actual argument to delete is __builtin_coro_frame with the promise as parameter */
+  operator delete(static_cast<void *>(__f));
+}
+
+
+
+struct __testFrame
+{
+  void (*resume_fn)(__testFrame *);
+  void (*destroy_fn)(__testFrame *);
+  std::__coroutine_traits_sfinae<task<int> >::promise_type __promise;
+  int __suspend_index;
+  bool __initial_await_suspend_called;
+  task<int> v;
+  task<int> u;
+  int xres;
+  std::suspend_always __suspend_83_11;
+  task<int>::awaiter __suspend_88_17;
+  int __suspend_88_17_res;
+  task<int>::awaiter __suspend_88_30;
+  int __suspend_88_30_res;
+  task<int>::promise_type::final_awaiter __suspend_83_11_1;
+};
+
+task<int> test()
+{
+  /* Allocate the frame including the promise */
+  /* Note: The actual parameter new is __builtin_coro_size */
+  __testFrame * __f = reinterpret_cast<__testFrame *>(operator new(sizeof(__testFrame)));
+  __f->__suspend_index = 0;
+  __f->__initial_await_suspend_called = false;
+  
+  /* Construct the promise. */
+  new (&__f->__promise)std::__coroutine_traits_sfinae<task<int> >::promise_type{};
+  
+  /* Forward declare the resume and destroy function. */
+  void __testResume(__testFrame * __f);
+  void __testDestroy(__testFrame * __f);
+  
+  /* Assign the resume and destroy function pointers. */
+  __f->resume_fn = &__testResume;
+  __f->destroy_fn = &__testDestroy;
+  
+  /* Call the made up function with the coroutine body for initial suspend.
+     This function will be called subsequently by coroutine_handle<>::resume()
+     which calls __builtin_coro_resume(__handle_) */
+  __testResume(__f);
+  
+  
+  return __f->__promise.get_return_object();
+}
+
+/* This function invoked by coroutine_handle<>::resume() */
+void __testResume(__testFrame * __f)
+{
+  try 
+  {
+    /* Create a switch to get to the correct resume point */
+    switch(__f->__suspend_index) {
+      case 0: break;
+      case 1: goto __resume_test_1;
+      case 2: goto __resume_test_2;
+      case 3: goto __resume_test_3;
+    }
+    
+    /* co_await Issue518.cpp:83 */
+    __f->__suspend_83_11 = __f->__promise.initial_suspend();
+    if(!__f->__suspend_83_11.await_ready()) {
+      __f->__suspend_83_11.await_suspend(std::coroutine_handle<task<int>::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>());
+      __f->__suspend_index = 1;
+      __f->__initial_await_suspend_called = true;
+      return;
+    } 
+    
+    __resume_test_1:
+    __f->__suspend_83_11.await_resume();
+    __f->v = get_random();
+    __f->u = get_random();
+    std::operator<<(std::cout, "in test()\n");
+    
+    /* co_await Issue518.cpp:88 */
+    __f->__suspend_88_17 = __f->v.operator co_await();
+    if(!__f->__suspend_88_17.await_ready()) {
+      __builtin_coro_resume(__f->__suspend_88_17.await_suspend(std::coroutine_handle<task<int>::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>()).address());
+      __f->__suspend_index = 2;
+      return;
+    } 
+    
+    __resume_test_2:
+    __f->__suspend_88_17_res = __f->__suspend_88_17.await_resume();
+    
+    /* co_await Issue518.cpp:88 */
+    __f->__suspend_88_30 = __f->u.operator co_await();
+    if(!__f->__suspend_88_30.await_ready()) {
+      __builtin_coro_resume(__f->__suspend_88_30.await_suspend(std::coroutine_handle<task<int>::promise_type>::from_address(static_cast<void *>(__f)).operator std::coroutine_handle<void>()).address());
+      __f->__suspend_index = 3;
+      return;
+    } 
+    
+    __resume_test_3:
+    __f->__suspend_88_30_res = __f->__suspend_88_30.await_resume();
+    __f->xres = (__f->__suspend_88_17_res + __f->__suspend_88_30_res);
+    /* co_return Issue518.cpp:89 */
+    __f->__promise.return_value(__f->xres);
+    goto __final_suspend;
+  } catch(...) {
+    if(!__f->__initial_await_suspend_called) {
+      throw ;
+    } 
+    
+    __f->__promise.unhandled_exception();
+  }
+  
+  __final_suspend:
+  
+  /* co_await Issue518.cpp:83 */
+  __f->__suspend_83_11_1 = __f->__promise.final_suspend();
+  if(!__f->__suspend_83_11_1.await_ready()) {
+    __builtin_coro_resume(__f->__suspend_83_11_1.await_suspend(std::coroutine_handle<task<int>::promise_type>::from_address(static_cast<void *>(__f))).address());
+  } 
+  
+  ;
+}
+
+/* This function invoked by coroutine_handle<>::destroy() */
+void __testDestroy(__testFrame * __f)
+{
+  /* destroy all variables with dtors */
+  __f->~__testFrame();
+  /* Deallocating the coroutine frame */
+  /* Note: The actual argument to delete is __builtin_coro_frame with the promise as parameter */
+  operator delete(static_cast<void *>(__f));
+}
+
+
+
+void noop_coroutine()
+{
+  task<int> t = test();
+  int result = t.operator()();
+  std::operator<<(std::cout.operator<<(result), '\n');
+}
+


### PR DESCRIPTION
The original issue uncovered more shortcomings in the coroutine transformation.

a) It appears that `operator co_await` is the _only_ operator so far
   which must have a space between "operator" and the operator name.

b) Since `co_await` is an expression the keyword can occur in a lot of
   places, like lambdas. One limitation over lambdas is that a
   `co_await` occurs only in a `CoroutineBodyStmt`.

   This patch adds support for more case, however, some are of these
   transformations lead to code that is not logically correct. For
   example, all loop related statements with a `co_await` as a condition
   or increment expression are logically incorrect and I don't know a
   way to make them correct.