### PR TITLE
Fixed #501: Added a dedicated option to show all `CallExpr` template parameters.

### DIFF
--- a/CodeGenerator.cpp
+++ b/CodeGenerator.cpp
@@ -1711,9 +1711,10 @@ void CodeGenerator::InsertArg(const CallExpr* stmt)
 
     InsertArg(stmt->getCallee());
 
-    if(isa<UserDefinedLiteral>(stmt)) {
-        if(const auto* declRefExpr = dyn_cast_or_null<DeclRefExpr>(stmt->getCallee()->IgnoreImpCasts())) {
-            if(const auto* fd = dyn_cast_or_null<FunctionDecl>(declRefExpr->getDecl())) {
+    if(const auto* declRefExpr = dyn_cast_or_null<DeclRefExpr>(stmt->getCallee()->IgnoreImpCasts())) {
+        if(const auto* fd = dyn_cast_or_null<FunctionDecl>(declRefExpr->getDecl())) {
+            if((not declRefExpr->getNumTemplateArgs() and GetInsightsOptions().ShowAllCallExprTemplateParameters) or
+               isa<UserDefinedLiteral>(stmt)) {
                 InsertTemplateArgs(*fd);
             }
         }

--- a/InsightsOptions.def
+++ b/InsightsOptions.def
@@ -20,6 +20,7 @@ INSIGHTS_OPT("alt-syntax-subscription",
              false,
              "Transform array subscriptions E1[E2] into (*(E1 + E2)).", gInsightCategory)
 INSIGHTS_OPT("show-all-implicit-casts", ShowAllImplicitCasts, false, "Show all implicit casts which can be noisy.", gInsightCategory)
+INSIGHTS_OPT("show-all-callexpr-template-parameters", ShowAllCallExprTemplateParameters, false, "Show all template parameters of a CallExpr.", gInsightCategory)
 INSIGHTS_OPT("edu-show-initlist", UseShowInitializerList, false, "Transform a std::initializer list", gInsightEduCategory)
 INSIGHTS_OPT("edu-show-noexcept", UseShowNoexcept, false, "Transform a noexcept function", gInsightEduCategory)
 INSIGHTS_OPT("edu-show-padding", UseShowPadding, false, "Show the padding bytes in a struct/class", gInsightEduCategory)

--- a/docs/cmdl-examples/show-all-callexpr-template-parameters.cpp
+++ b/docs/cmdl-examples/show-all-callexpr-template-parameters.cpp
@@ -1,0 +1,6 @@
+#include <utility>
+
+auto Fun()
+{
+    return std::make_pair(5, 7.5);
+}

--- a/docs/opt-show-all-callexpr-template-parameters.md
+++ b/docs/opt-show-all-callexpr-template-parameters.md
@@ -1,0 +1,27 @@
+# show-all-callexpr-template-parameters {#show_all_callexpr_template_parameters}
+
+C++ Insights in default mode hides the template parameters used when invoking a function template. This option shows the
+usually hidden parameters.
+
+__Default:__ Off
+
+__Examples:__
+
+```.cpp
+#include <utility>
+
+auto Fun() {
+  return std::make_pair(5, 7.5);
+}
+```
+
+transforms into this:
+
+```.cpp
+#include <utility>
+
+std::pair<int, double> Fun()
+{
+  return std::make_pair<int, double>(5, 7.5);
+}
+```

--- a/tests/Issue501.cpp
+++ b/tests/Issue501.cpp
@@ -1,0 +1,7 @@
+// cmdlineinsights:-show-all-callexpr-template-parameters
+
+#include <utility>
+static int s1;
+static int s2;
+std::pair<int const&, int const&> fun() { return std::make_pair(s1, s2);
+}

--- a/tests/Issue501.expect
+++ b/tests/Issue501.expect
@@ -1,0 +1,12 @@
+// cmdlineinsights:-show-all-callexpr-template-parameters
+
+#include <utility>
+static int s1;
+
+static int s2;
+
+std::pair<const int &, const int &> fun()
+{
+  return std::pair<const int &, const int &>(std::make_pair<int &, int &>(s1, s2));
+}
+


### PR DESCRIPTION
While there are times when seeing the template parameters for a function call is beneficial, it can also clutter the output in cases where you look for something different. Hence, I made this an option.