### PR TITLE
Fixed #598: Added basic support for `SourceLocExpr`.

### DIFF
--- a/CodeGenerator.cpp
+++ b/CodeGenerator.cpp
@@ -589,6 +589,12 @@ static std::optional<std::string> GetFieldDeclNameForLambda(const FieldDecl&    
 }
 //-----------------------------------------------------------------------------
 
+void CodeGenerator::InsertArg(const SourceLocExpr* stmt)
+{
+    mOutputFormatHelper.Append(stmt->getBuiltinStr(), "()"sv);
+}
+//-----------------------------------------------------------------------------
+
 void CodeGenerator::InsertArg(const MemberExpr* stmt)
 {
     const auto* base = stmt->getBase();

--- a/CodeGeneratorTypes.h
+++ b/CodeGeneratorTypes.h
@@ -130,6 +130,7 @@ SUPPORTED_STMT(AttributedStmt)
 SUPPORTED_STMT(ConceptSpecializationExpr)
 SUPPORTED_STMT(RequiresExpr)
 SUPPORTED_STMT(StmtExpr)
+SUPPORTED_STMT(SourceLocExpr)
 SUPPORTED_STMT(CppInsightsCommentStmt)
 
 #undef IGNORED_DECL

--- a/tests/Issue598.cpp
+++ b/tests/Issue598.cpp
@@ -1,0 +1,7 @@
+// cmdline:-std=c++20
+
+#include <source_location>
+
+auto s = std::source_location::current();
+
+auto X = __builtin_LINE();

--- a/tests/Issue598.expect
+++ b/tests/Issue598.expect
@@ -1,0 +1,9 @@
+// cmdline:-std=c++20
+
+#include <source_location>
+
+std::source_location s = std::source_location::current(__builtin_source_location());
+
+
+unsigned int X = __builtin_LINE();
+


### PR DESCRIPTION
Basic means that the expression is not evaluated. C++ Insights only echos the builtin name that was used.