### PR TITLE
Clang 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,9 @@ on:
     types: [rebuild_trigger]
 
 env:
-  CMAKE_VERSION: 3.16.2
-  NINJA_VERSION: 1.10.0
-  LLVM_VERSION: 17.0.0
+  CMAKE_VERSION: 3.29.0
+  NINJA_VERSION: 1.11.1
+  LLVM_VERSION: 18.1.0
 
 jobs:
   checks:
@@ -29,7 +29,7 @@ jobs:
             name: "Linux Clang - Format check",
             os: ubuntu-20.04,
             build_type: Release,
-            cformat_name: 'clang-format-17'
+            cformat_name: 'clang-format-18'
           }
 
     steps:
@@ -42,7 +42,7 @@ jobs:
       run: |
         wget https://apt.llvm.org/llvm.sh
         chmod +x llvm.sh
-        sudo ./llvm.sh 17
+        sudo ./llvm.sh 18
         sudo apt-get install ${{ matrix.config.cformat_name }}
 
     - name: clang-format check
@@ -64,11 +64,11 @@ jobs:
         config:
         # AppleClang
         - {
-            name: "Clang 17 / LLVM 17 @ macOS Release",
-            os: macos-11,
+            name: "Clang 18 / LLVM 18 @ macOS Release",
+            os: macos-14,
             build_type: Release,
             cxx: "clang++",
-            llvm_version: "17.0.0",
+            llvm_version: "18.1.0",
             llvm_config: "llvm-config",
             coverage: "No",
             static: "No",
@@ -78,15 +78,16 @@ jobs:
             bin_name: "insights",
             archive_name: "insights-macos",
             upload: "Yes",
+            cmake_args: "-DCMAKE_OSX_ARCHITECTURES=arm64",
           }
 
         # AppleClang
         - {
-            name: "Clang 17 / LLVM 17 @ macOS Debug",
-            os: macos-11,
+            name: "Clang 18 / LLVM 18 @ macOS Debug",
+            os: macos-14,
             build_type: Release,
             cxx: "clang++",
-            llvm_version: "17.0.0",
+            llvm_version: "18.1.0",
             llvm_config: "llvm-config",
             coverage: "No",
             static: "No",
@@ -96,15 +97,16 @@ jobs:
             bin_name: "insights",
             archive_name: "insights-macos",
             upload: "No",
+            cmake_args: "-DCMAKE_OSX_ARCHITECTURES=arm64",
           }
 
         # # AppleClang
         # - {
-        #     name: "Clang 17 / LLVM 17 @ macOS Coverage & Debug",
-        #     os: macos-11,
+        #     name: "Clang 18 / LLVM 18 @ macOS Coverage & Debug",
+        #     os: macos-14,
         #     build_type: Release,
         #     cxx: "clang++",
-        #     llvm_version: "17.0.0",
+        #     llvm_version: "18.1.0",
         #     llvm_config: "llvm-config",
         #     coverage: "Yes",
         #     static: "No",
@@ -118,11 +120,11 @@ jobs:
 
           # # MSVC 2019
         # - {
-          #   name: "MSVC 2022 / LLVM 17 @ Windows Release",
+          #   name: "MSVC 2022 / LLVM 18 @ Windows Release",
           #   os: windows-2022,
           #   build_type: Release,
           #   cxx: "cl",
-          #   llvm_version: "17.0.0",
+          #   llvm_version: "18.1.0",
           #   llvm_config: "current/bin/llvm-config.exe",
           #   static: "Yes",
           #   debug: "No",
@@ -137,11 +139,11 @@ jobs:
 
         # # MSVC 2019
         # - {
-          #   name: "MSVC 2022 / LLVM 17 @ Windows Debug",
+          #   name: "MSVC 2022 / LLVM 18 @ Windows Debug",
           #   os: windows-2022,
           #   build_type: Release,
           #   cxx: "cl",
-          #   llvm_version: "17.0.0",
+          #   llvm_version: "18.1.0",
           #   llvm_config: "current/bin/llvm-config.exe",
           #   static: "Yes",
           #   debug: "Yes",
@@ -155,11 +157,11 @@ jobs:
 
         # # MSVC 2019
         # - {
-        #     name: "MSVC 2022 / LLVM 17 @ Windows Code Coverage & Debug",
+        #     name: "MSVC 2022 / LLVM 18 @ Windows Code Coverage & Debug",
         #     os: windows-2022,
         #     build_type: Release,
         #     cxx: "clang-cl.exe",
-        #     llvm_version: "17.0.0",
+        #     llvm_version: "18.1.0",
         #     llvm_config: "current/bin/llvm-config.exe",
         #     coverage: "Yes",
         #     static: "Yes",
@@ -199,8 +201,8 @@ jobs:
           cmake_dir="${cmake_base_dir}/bin"
         elif [ "$RUNNER_OS" == "macOS" ]; then
           ninja_suffix="mac.zip"
-          cmake_suffix="Darwin-x86_64.tar.gz"
-          cmake_base_dir="cmake-${cmake_version}-Darwin-x86_64"
+          cmake_suffix="macos-universal.tar.gz"
+          cmake_base_dir="cmake-${cmake_version}-macos-universal"
           cmake_dir="${cmake_base_dir}/CMake.app/Contents/bin"
         fi
 
@@ -261,12 +263,12 @@ jobs:
         key: ${{ runner.os }}-clang-${{ matrix.config.llvm_version }}-${{ hashFiles('${{ github.workspace }}/current') }}
 
     - name: Install Clang
-      if: "(startsWith(matrix.config.os, 'macos') || startsWith(matrix.config.os, 'Window')) && steps.cache-clang-binary.outputs.cache-hit != 'true'"
+      if: "(startsWith(matrix.config.os, 'macos') || startsWith(matrix.config.os, 'Window'))"
       shell: cmake -P {0}
       run: |
         set(llvm_version ${{ matrix.config.llvm_version }})
         set(path_separator ":")
-        set(archive_name "clang+llvm-${llvm_version}-x86_64-apple-darwin")
+        set(archive_name "clang+llvm-${llvm_version}-arm64-apple-darwin")
         if ("${{ runner.os }}" STREQUAL "Windows")
             set(archive_name "clang+llvm-${llvm_version}-win64-msvc")
             set(path_separator ";")
@@ -322,7 +324,7 @@ jobs:
         export HOMEBREW_NO_AUTO_UPDATE=1
         brew update > /dev/null
         brew install lcov || brew upgrade lcov
-        brew install gcc@10 || brew upgrade gcc@10 # for Clang 17 and newer gcov
+        brew install gcc@10 || brew upgrade gcc@10 # for Clang 18 and newer gcov
 
     - name: Setup MSVC Dev
       if: "startsWith(matrix.config.os, 'Windows')"
@@ -465,13 +467,13 @@ jobs:
       fail-fast: false
       matrix:
         config:
-        # GCC 12 / LLVM 17
+        # GCC 13 / LLVM 18
         - {
-            name: "GCC 12 / LLVM 17 @ Ubuntu Release @docker",
+            name: "GCC 13 / LLVM 18 @ Ubuntu Release @docker",
             build_type: Release,
-            cxx: "g++-12",
-            llvm_version: "17.0.0",
-            llvm_config: "/usr/bin/llvm-config-17",
+            cxx: "g++-13",
+            llvm_version: "18.1.0",
+            llvm_config: "/usr/bin/llvm-config-18",
             coverage: "No",
             static: "Yes",
             debug: "No",
@@ -484,13 +486,13 @@ jobs:
             docs: "Yes",
           }
 
-        # GCC 12 / LLVM 17
+        # GCC 13 / LLVM 18
         - {
-            name: "GCC 12 / LLVM 17 @ Ubuntu Code Coverage & Debug @docker",
+            name: "GCC 13 / LLVM 18 @ Ubuntu Code Coverage & Debug @docker",
             build_type: Release,
-            cxx: "g++-12",
-            llvm_version: "17.0.0",
-            llvm_config: "/usr/bin/llvm-config-17",
+            cxx: "g++-13",
+            llvm_version: "18.1.0",
+            llvm_config: "/usr/bin/llvm-config-18",
             coverage: "Yes",
             static: "No",
             debug: "Yes",
@@ -501,13 +503,13 @@ jobs:
             archive_name: "insights-ubuntu-14.04",
           }
 
-        # GCC 12 / LLVM 17
+        # GCC 13 / LLVM 18
         - {
-            name: "GCC 12 / LLVM 17 @ Ubuntu Code Coverage (libc++) @docker",
+            name: "GCC 13 / LLVM 18 @ Ubuntu Code Coverage (libc++) @docker",
             build_type: Release,
-            cxx: "g++-12",
-            llvm_version: "17.0.0",
-            llvm_config: "/usr/bin/llvm-config-17",
+            cxx: "g++-13",
+            llvm_version: "18.1.0",
+            llvm_config: "/usr/bin/llvm-config-18",
             coverage: "Yes",
             static: "No",
             debug: "Yes",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,4 @@
-cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
-# 3.8* is required because of C++17 support
+cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 
 # For better control enable MSVC_RUNTIME_LIBRARY target property
 # see https://cmake.org/cmake/help/latest/policy/CMP0091.html
@@ -33,7 +32,7 @@ option(INSIGHTS_STATIC              "Use static linking"         Off)
 
 set(INSIGHTS_LLVM_CONFIG "llvm-config" CACHE STRING "LLVM config executable to use")
 
-set(INSIGHTS_MIN_LLVM_MAJOR_VERSION 17)
+set(INSIGHTS_MIN_LLVM_MAJOR_VERSION 18)
 set(INSIGHTS_MIN_LLVM_VERSION ${INSIGHTS_MIN_LLVM_MAJOR_VERSION}.0)
 
 if(NOT DEFINED LLVM_VERSION_MAJOR)  # used when build inside the clang tool/extra folder
@@ -372,6 +371,17 @@ if (BUILD_INSIGHTS_OUTSIDE_LLVM)
     # additional libs required when building insights outside llvm
     set(ADDITIONAL_LIBS
         ${LLVM_LDFLAGS}
+    )
+
+    if(${LLVM_PACKAGE_VERSION_PLAIN} VERSION_GREATER_EQUAL "18.0.0")
+        set(ADDITIONAL_LIBS
+            ${ADDITIONAL_LIBS}
+            clangAPINotes
+        )
+    endif()
+
+    set(ADDITIONAL_LIBS
+        ${ADDITIONAL_LIBS}
         clangFrontend
         clangDriver
         clangSerialization
@@ -768,6 +778,7 @@ message(STATUS "[ Build summary ]")
 message(STATUS "CMAKE_GENERATOR       : ${CMAKE_GENERATOR}")
 message(STATUS "CMAKE_EXE_LINKER_FLAGS: ${CMAKE_EXE_LINKER_FLAGS}")
 message(STATUS "CMAKE_LINKER          : ${CMAKE_LINKER}")
+message(STATUS "CMAKE_OSX_ARCHITECTURES : ${CMAKE_OSX_ARCHITECTURES}")
 message(STATUS "Compiler ID           : ${CMAKE_CXX_COMPILER_ID}")
 message(STATUS "Compiler version      : ${CMAKE_CXX_COMPILER_VERSION}")
 message(STATUS "Compiler path         : ${CMAKE_CXX_COMPILER}")

--- a/Readme.md
+++ b/Readme.md
@@ -174,6 +174,14 @@ There are a couple of options that can be enabled with [cmake](https://cmake.org
 | INSIGHTS_USE_LIBCPP | Use libc++ for tests       | OFF     |
 | DEBUG               | Enable debug               | OFF     |
 
+### Building for ARM on macOS
+
+It seems best to supply the architecture during configuration:
+
+```
+cmake -DCMAKE_OSX_ARCHITECTURES=arm64 ../cppinsights
+```
+
 
 ### Use it with [Cevelop](https://www.cevelop.com)
 

--- a/scripts/prepare-release.py
+++ b/scripts/prepare-release.py
@@ -14,9 +14,9 @@ import subprocess
 def main():
     versionH = open('version.h.in', 'r').read()
 
-    oldClangStable = '16'
-    newClangStable = '17'
-    newInsightsVersion = '17.0'
+    oldClangStable = '17'
+    newClangStable = '18'
+    newInsightsVersion = '18.0'
     oldInsightsVersion = re.search(r'INSIGHTS_VERSION\s+"(.*?)"', versionH, re.DOTALL | re.MULTILINE).group(1)
 
 

--- a/tests/ClassOpInTemplateFunctionTest.expect
+++ b/tests/ClassOpInTemplateFunctionTest.expect
@@ -43,6 +43,7 @@ class Foo
   {
     if constexpr(true) {
       return this->mX;
+    } else /* constexpr */ {
     } 
     
   }

--- a/tests/EduCoroutineCoAwaitOperatorTest.expect
+++ b/tests/EduCoroutineCoAwaitOperatorTest.expect
@@ -148,7 +148,7 @@ awaiter operator co_await<long long, std::ratio<1, 1000> >(std::chrono::duration
     
   };
   
-  return awaiter{std::chrono::duration<long long, std::ratio<1, 1000000> >(d, nullptr)};
+  return awaiter{std::chrono::duration<long long, std::ratio<1, 1000000> >(d)};
 }
 #endif
 

--- a/tests/IfSwitchInitHandler5Test.expect
+++ b/tests/IfSwitchInitHandler5Test.expect
@@ -4,7 +4,7 @@
 int main()
 {
   std::shared_ptr<int> sharedPtr = std::make_shared<int>(2011);
-  std::weak_ptr<int> weakPtr = std::weak_ptr<int>(sharedPtr, 0);
+  std::weak_ptr<int> weakPtr = std::weak_ptr<int>(sharedPtr);
   {
     std::shared_ptr<int> sharedPtr1 = weakPtr.lock();
     if(sharedPtr1.operator bool()) {

--- a/tests/Issue15.expect
+++ b/tests/Issue15.expect
@@ -5,7 +5,7 @@
 
 std::chrono::duration<long long, std::ratio<1, 1> > operator""_s(unsigned long long s)
 {
-  return std::chrono::duration<long long, std::ratio<1, 1> >(s, nullptr);
+  return std::chrono::duration<long long, std::ratio<1, 1> >(s);
 }
 
 std::basic_string<char, std::char_traits<char>, std::allocator<char> > operator""_str(const char * s, std::size_t len)

--- a/tests/Issue41.cerr
+++ b/tests/Issue41.cerr
@@ -5,7 +5,7 @@
    29 |     template<class type_parameter_0_0>
       |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 In file included from .tmp.cpp:1:
-In file included from ... vector:310:
+In file included from ... vector:314:
 In file included from ... remove.h:13:
 ... find_if.h:25:9: error: no matching function for call to object of type '__lambda_12_26'
    25 |     if (__pred(*__first))

--- a/tests/LambdaHandlerVLA2Test.cerr
+++ b/tests/LambdaHandlerVLA2Test.cerr
@@ -1,3 +1,10 @@
+.tmp.cpp:3:15: warning: variable length arrays in C++ are a Clang extension [-Wvla-cxx-extension]
+    3 |   char buffer[n];
+      |               ^
+.tmp.cpp:3:15: note: function parameter 'n' with unknown value cannot be used in a constant expression
+.tmp.cpp:1:15: note: declared here
+    1 | void Test(int n)
+      |               ^
 .tmp.cpp:14:5: warning: declaration does not declare anything [-Wmissing-declarations]
    14 |     unsigned long;
       |     ^~~~~~~~~~~~~
@@ -7,6 +14,13 @@
 .tmp.cpp:1:15: note: 'n' declared here
     1 | void Test(int n)
       |               ^
+.tmp.cpp:15:20: warning: variable length arrays in C++ are a Clang extension [-Wvla-cxx-extension]
+   15 |     char (&buffer)[n];
+      |                    ^
+.tmp.cpp:15:20: note: function parameter 'n' with unknown value cannot be used in a constant expression
+.tmp.cpp:1:15: note: declared here
+    1 | void Test(int n)
+      |               ^
 .tmp.cpp:15:12: error: fields must have a constant size: 'variable length array in structure' extension will never be supported
    15 |     char (&buffer)[n];
       |            ^
@@ -14,6 +28,13 @@
    18 |     __lambda_6_5(char (&_buffer)[n])
       |                                  ^
 .tmp.cpp:1:15: note: 'n' declared here
+    1 | void Test(int n)
+      |               ^
+.tmp.cpp:18:34: warning: variable length arrays in C++ are a Clang extension [-Wvla-cxx-extension]
+   18 |     __lambda_6_5(char (&_buffer)[n])
+      |                                  ^
+.tmp.cpp:18:34: note: function parameter 'n' with unknown value cannot be used in a constant expression
+.tmp.cpp:1:15: note: declared here
     1 | void Test(int n)
       |               ^
 .tmp.cpp:22:5: error: no matching constructor for initialization of 'class __lambda_6_5'
@@ -28,4 +49,4 @@
 .tmp.cpp:18:5: note: candidate constructor not viable: no known conversion from 'char[n]' to 'char (&)[n]' for 1st argument
    18 |     __lambda_6_5(char (&_buffer)[n])
       |     ^            ~~~~~~~~~~~~~~~~~~
-1 warning and 4 errors generated.
+4 warnings and 4 errors generated.

--- a/tests/MacroExpensionTest.expect
+++ b/tests/MacroExpensionTest.expect
@@ -14,9 +14,9 @@ enum eTest
 /* PASSED: static_assert(true); */
 
 template<class T>
-constexpr const T pi = T(3.14159265358979323851L);
+constexpr const T pi = T(3.1415926535897931L);
 
 template<>
-constexpr const int pi<int> = int(3.14159265358979323851L);
+constexpr const int pi<int> = int(3.1415926535897931L);
 
 int i = pi<int>;

--- a/tests/NamespaceWithClassOperatorsTest.expect
+++ b/tests/NamespaceWithClassOperatorsTest.expect
@@ -3,14 +3,14 @@
 std::chrono::duration<double, std::ratio<1, 1> > Bar()
 {
   std::chrono::time_point<std::chrono::system_clock, std::chrono::duration<long long, std::ratio<1, 1000000> > > begin = std::chrono::system_clock::now();
-  return std::chrono::duration<double, std::ratio<1, 1> >(std::chrono::operator-(std::chrono::system_clock::now(), begin), nullptr);
+  return std::chrono::duration<double, std::ratio<1, 1> >(std::chrono::operator-(std::chrono::system_clock::now(), begin));
 }
 
 
 void Foo()
 {
   std::chrono::time_point<std::chrono::system_clock, std::chrono::duration<long long, std::ratio<1, 1000000> > > start = std::chrono::system_clock::now();
-  std::chrono::duration<double, std::ratio<1, 1> > theDuration = std::chrono::duration<double, std::ratio<1, 1> >(std::chrono::operator-(std::chrono::system_clock::now(), start), nullptr);
+  std::chrono::duration<double, std::ratio<1, 1> > theDuration = std::chrono::duration<double, std::ratio<1, 1> >(std::chrono::operator-(std::chrono::system_clock::now(), start));
 }
 
 int main()

--- a/tests/NonTypeTemplateParameterPackTest.cerr
+++ b/tests/NonTypeTemplateParameterPackTest.cerr
@@ -1,11 +1,11 @@
-.tmp.cpp:147:23: error: use of undeclared identifier 'my_array'; did you mean 'Test::my_array'?
-  147 |   Test::Map<int, int, my_array> a;
+.tmp.cpp:151:23: error: use of undeclared identifier 'my_array'; did you mean 'Test::my_array'?
+  151 |   Test::Map<int, int, my_array> a;
       |                       ^~~~~~~~
       |                       Test::my_array
-.tmp.cpp:106:9: note: 'Test::my_array' declared here
-  106 |   class my_array
+.tmp.cpp:110:9: note: 'Test::my_array' declared here
+  110 |   class my_array
       |         ^
-.tmp.cpp:147:23: error: use of undeclared identifier 'my_array'
-  147 |   Test::Map<int, int, my_array> a;
+.tmp.cpp:151:23: error: use of undeclared identifier 'my_array'
+  151 |   Test::Map<int, int, my_array> a;
       |                       ^
 2 errors generated.

--- a/tests/NonTypeTemplateParameterPackTest.expect
+++ b/tests/NonTypeTemplateParameterPackTest.expect
@@ -20,6 +20,7 @@ class Test
   {
     if constexpr(true) {
       return 1 + this->sum<5>();
+    } else /* constexpr */ {
     } 
     
   }
@@ -33,6 +34,7 @@ class Test
   {
     if constexpr(true) {
       return 5 + this->sum<7>();
+    } else /* constexpr */ {
     } 
     
   }
@@ -70,6 +72,7 @@ class Test
   {
     if constexpr(true) {
       return i + this->summ<int &, int &>(__rest1, __rest2);
+    } else /* constexpr */ {
     } 
     
   }
@@ -83,6 +86,7 @@ class Test
   {
     if constexpr(true) {
       return i + this->summ<int &>(__rest1);
+    } else /* constexpr */ {
     } 
     
   }

--- a/tests/StructuredBindingsHandler5Test.expect
+++ b/tests/StructuredBindingsHandler5Test.expect
@@ -90,6 +90,7 @@ class Point
   {
     if constexpr(true) {
       return this->GetX();
+    } else /* constexpr */ {
     } 
     
   }
@@ -131,6 +132,7 @@ class Point
   {
     if constexpr(true) {
       return this->GetX();
+    } else /* constexpr */ {
     } 
     
   }

--- a/tests/StructuredBindingsHandler6Test.expect
+++ b/tests/StructuredBindingsHandler6Test.expect
@@ -100,6 +100,7 @@ class Point
   {
     if constexpr(true) {
       return this->GetX();
+    } else /* constexpr */ {
     } 
     
   }

--- a/tests/TemplateArgumentsTest.expect
+++ b/tests/TemplateArgumentsTest.expect
@@ -44,6 +44,7 @@ inline const value_type * Normalize<std::basic_string<char, std::char_traits<cha
 {
   if constexpr(true) {
     return arg.c_str();
+  } else /* constexpr */ {
   } 
   
 }

--- a/tests/UserDefinedLiteral2Test.expect
+++ b/tests/UserDefinedLiteral2Test.expect
@@ -4,7 +4,7 @@ using seconds_t = std::chrono::duration<long long>;
 
 inline constexpr std::chrono::duration<long long, std::ratio<1, 1> > operator""_s(unsigned long long s)
 {
-  return std::chrono::duration<long long, std::ratio<1, 1> >(s, nullptr);
+  return std::chrono::duration<long long, std::ratio<1, 1> >(s);
 }
 
 int main()

--- a/tests/UserDefinedLiteralTest.expect
+++ b/tests/UserDefinedLiteralTest.expect
@@ -6,12 +6,12 @@ using seconds_t = std::chrono::duration<long long>;
 
 inline constexpr std::chrono::duration<long long, std::ratio<1, 1> > operator""_s(unsigned long long s)
 {
-  return std::chrono::duration<long long, std::ratio<1, 1> >(s, nullptr);
+  return std::chrono::duration<long long, std::ratio<1, 1> >(s);
 }
 
 inline constexpr std::chrono::duration<long double, std::ratio<1, 1> > operator""_s(long double s)
 {
-  return std::chrono::duration<long double, std::ratio<1, 1> >(s, nullptr);
+  return std::chrono::duration<long double, std::ratio<1, 1> >(s);
 }
 
 static constexpr const std::chrono::duration<long long, std::ratio<1, 1> > TIMEOUT = {operator""_s(1ULL)};

--- a/tests/VarTemplateDecl3Test.expect
+++ b/tests/VarTemplateDecl3Test.expect
@@ -1,10 +1,10 @@
 #define INSIGHTS_USE_TEMPLATE
 
 template<class T>
-constexpr const T pi = T(3.14159265358979323851L);
+constexpr const T pi = T(3.1415926535897931L);
 
 template<>
-constexpr const int pi<int> = int(3.14159265358979323851L);
+constexpr const int pi<int> = int(3.1415926535897931L);
 
 template<class T>
 T circular_area(T r)

--- a/tests/p0780_2Test.cerr
+++ b/tests/p0780_2Test.cerr
@@ -18,8 +18,8 @@ error: templates cannot be declared inside of a local class
    45 |     inline /*constexpr */ invoke_result_t<void (*const &)(int, int, int, int), const int &, const int &, const int &, const int &> operator()() const
       |                           ^~~~~~~~~~~~~~~
       |                           std::invoke_result_t
-... invoke.h:455:1: note: 'std::invoke_result_t' declared here
-  455 | using invoke_result_t = typename invoke_result<_Fn, _Args...>::type;
+... invoke.h:459:1: note: 'std::invoke_result_t' declared here
+  459 | using invoke_result_t = typename invoke_result<_Fn, _Args...>::type;
       | ^
 .tmp.cpp:68:10: error: no viable conversion from returned value of type 'class __lambda_15_12' to function return type 'int'
    68 |   return __lambda_15_12;

--- a/tests/p2589Test.expect
+++ b/tests/p2589Test.expect
@@ -11,5 +11,5 @@ struct Test
 int main()
 {
   Test t = {};
-  return Test::operator[](4);
+  return t.operator[](4);
 }

--- a/version.h.in
+++ b/version.h.in
@@ -1,7 +1,7 @@
 #ifndef INSIGHTS_VERSION_H
 #define INSIGHTS_VERSION_H
 
-#define INSIGHTS_VERSION "17.0"
+#define INSIGHTS_VERSION "18.1"
 #define GIT_REPO_URL "@GIT_REPO_URL@"
 #define GIT_COMMIT_HASH "@GIT_COMMIT_HASH@"
 
@@ -12,14 +12,8 @@
 
 // Build Clang's resource dir and include dir by hand. This is necessary, as we do not always have Clang installed. 
 // See: https://github.com/MaskRay/ccls/wiki/Install#clang-resource-directory
-#if CLANG_VERSION_MAJOR > 15
 #define INSIGHTS_CLANG_RESOURCE_DIR R"(-resource-dir=@LLVM_LIBDIR@/clang/@LLVM_PACKAGE_VERSION_MAJOR_PLAIN@)"
 #define INSIGHTS_CLANG_RESOURCE_INCLUDE_DIR R"(-I @LLVM_LIBDIR@/clang/@LLVM_PACKAGE_VERSION_MAJOR_PLAIN@/include)"
-#else
-#define INSIGHTS_CLANG_RESOURCE_DIR R"(-resource-dir=@LLVM_LIBDIR@/clang/@LLVM_PACKAGE_VERSION_PLAIN@)"
-#define INSIGHTS_CLANG_RESOURCE_INCLUDE_DIR R"(-I @LLVM_LIBDIR@/clang/@LLVM_PACKAGE_VERSION_PLAIN@/include)"
-#endif
-
 #define INSIGHTS_LLVM_INCLUDE_DIR R"(-isystem@LLVM_INCLUDE_DIR@/c++/v1)"
 
 #endif /* INSIGHTS_VERSION_H */


### PR DESCRIPTION
Switched to Clang 18 and updated GCC to 13.

This release uses macOS 14 @ARM.

The docker containers used for building are multi platform supporting Intel and ARM.