### PR TITLE
Resolve mistake in README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -78,7 +78,7 @@ int main()
 }
 ```
 
-You can see all the compiler-provided special member functions and the downcast from `Derived` to `Base`.
+You can see all the compiler-provided special member functions and the upcast from `Derived` to `Base`.
 
 ## Why
 


### PR DESCRIPTION
Casting from `Derived` to `Base` is an upcast and not a downcast.