### PR TITLE
Fixed #628: Cfront mode and coroutines.

### DIFF
--- a/CodeGenerator.cpp
+++ b/CodeGenerator.cpp
@@ -2549,6 +2549,10 @@ void CodeGenerator::InsertArg(const CStyleCastExpr* stmt)
 
 void CodeGenerator::InsertArg(const CXXNewExpr* stmt)
 {
+    const auto  noEmptyInitList = mNoEmptyInitList;
+    FinalAction _{[&] { mNoEmptyInitList = noEmptyInitList; }};
+    mNoEmptyInitList = GetInsightsOptions().UseShow2C ? NoEmptyInitList::Yes : NoEmptyInitList::No;
+
     mOutputFormatHelper.Append("new "sv);
 
     if(stmt->getNumPlacementArgs()) {

--- a/tests/Issue628.cerr
+++ b/tests/Issue628.cerr
@@ -1,0 +1,99 @@
+In file included from .tmp.cpp:9:
+In file included from ... iostream:43:
+In file included from ... ios:223:
+In file included from ... __locale:15:
+In file included from ... shared_ptr.h:33:
+In file included from ... unique_ptr.h:17:
+In file included from ... hash.h:28:
+In file included from ... cstring:63:
+In file included from ... string.h:61:
+... string.h:74:7: error: conflicting types for 'memset'
+   74 | void    *memset(void *__b, int __c, size_t __len);
+      |          ^
+.tmp.cpp:7:18: note: previous declaration is here
+    7 | extern "C" void* memset(void*, int, unsigned int);
+      |                  ^
+.tmp.cpp:24:3: error: use of undeclared identifier 'Constructor_std'
+   24 |   Constructor_std::chrono::duration<long long, std::ratio<1, 1000> >(&__this->delay, n);
+      |   ^
+.tmp.cpp:24:42: error: expected '(' for function-style cast or type construction
+   24 |   Constructor_std::chrono::duration<long long, std::ratio<1, 1000> >(&__this->delay, n);
+      |                                     ~~~~ ^
+.tmp.cpp:37:102: error: no member named 'operatorMinus' in namespace 'std::chrono'
+   37 |   const std::chrono::duration<long long, std::ratio<1, 1000000000> > __temporary20_49 = std::chrono::operatorMinus(&__temporary20_45, &start);
+      |                                                                                         ~~~~~~~~~~~~~^
+.tmp.cpp:38:44: error: use of undeclared identifier 'push'
+   38 |   std::function<bool ()> __temporary26_9 = push(&task_queue, __temporary26_9);
+      |                                            ^
+.tmp.cpp:39:3: error: use of undeclared identifier 'Destructor_std'
+   39 |   Destructor_std::function<bool ()>(&__temporary26_9);
+      |   ^
+.tmp.cpp:59:31: error: no type named 'promise_type' in 'Task'; did you mean simply 'promise_type'?
+   59 | inline Task get_return_object(Task::promise_type * __this)
+      |                               ^~~~~~~~~~~~~~~~~~
+      |                               promise_type
+.tmp.cpp:57:3: note: 'promise_type' declared here
+   57 | } promise_type;
+      |   ^
+.tmp.cpp:66:43: error: no type named 'promise_type' in 'Task'; did you mean simply 'promise_type'?
+   66 | inline std::suspend_never initial_suspend(Task::promise_type * __this)
+      |                                           ^~~~~~~~~~~~~~~~~~
+      |                                           promise_type
+.tmp.cpp:57:3: note: 'promise_type' declared here
+   57 | } promise_type;
+      |   ^
+.tmp.cpp:73:42: error: no type named 'promise_type' in 'Task'; did you mean simply 'promise_type'?
+   73 | inline std::suspend_always final_suspend(Task::promise_type * __this)
+      |                                          ^~~~~~~~~~~~~~~~~~
+      |                                          promise_type
+.tmp.cpp:57:3: note: 'promise_type' declared here
+   57 | } promise_type;
+      |   ^
+.tmp.cpp:80:33: error: no type named 'promise_type' in 'Task'; did you mean simply 'promise_type'?
+   80 | inline void unhandled_exception(Task::promise_type * __this)
+      |                                 ^~~~~~~~~~~~~~~~~~
+      |                                 promise_type
+.tmp.cpp:57:3: note: 'promise_type' declared here
+   57 | } promise_type;
+      |   ^
+.tmp.cpp:89:3: error: no type named 'promise_type' in 'std::__coroutine_traits_sfinae<Task>'; did you mean simply 'promise_type'?
+   89 |   std::__coroutine_traits_sfinae<Task>::promise_type __promise;
+      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      |   promise_type
+.tmp.cpp:57:3: note: 'promise_type' declared here
+   57 | } promise_type;
+      |   ^
+.tmp.cpp:102:53: error: use of undeclared identifier 'operatorNew_std'
+  102 |   __fooFrame * __f = reinterpret_cast<__fooFrame *>(operatorNew_std::size_t(sizeof(__fooFrame)));
+      |                                                     ^
+.tmp.cpp:107:24: error: no type named 'promise_type' in 'std::__coroutine_traits_sfinae<Task>'; did you mean simply 'promise_type'?
+  107 |   new (&__f->__promise)std::__coroutine_traits_sfinae<Task>::promise_type;
+      |                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      |                        promise_type
+.tmp.cpp:57:3: note: 'promise_type' declared here
+   57 | } promise_type;
+      |   ^
+.tmp.cpp:137:5: error: use of undeclared identifier '__temporary45_6'
+  137 |     __temporary45_6 = __f->__promise.initial_suspend();
+      |     ^
+.tmp.cpp:138:5: error: use of undeclared identifier '__temporary45_6'
+  138 |     __temporary45_6 = from_address(static_cast<void *>(__f));
+      |     ^
+.tmp.cpp:138:23: error: use of undeclared identifier 'from_address'; did you mean 'std::to_address'?
+  138 |     __temporary45_6 = from_address(static_cast<void *>(__f));
+      |                       ^~~~~~~~~~~~
+      |                       std::to_address
+... pointer_traits.h:232:45: note: 'std::to_address' declared here
+  232 | inline _LIBCPP_HIDE_FROM_ABI constexpr auto to_address(_Tp* __p) noexcept {
+      |                                             ^
+.tmp.cpp:143:5: error: expected expression
+  143 |     ) {
+      |     ^
+.tmp.cpp:144:41: error: use of undeclared identifier '__temporary45_6'
+  144 |       __f->__suspend_45_6.await_suspend(__temporary45_6.operator std::coroutine_handle<void>());
+      |                                         ^
+.tmp.cpp:157:10: error: no member named 'operatorLessLess' in namespace 'std'
+  157 |     std::operatorLessLess(std::cout, "1. hello from foo1").operator<<(std::endl);
+      |     ~~~~~^
+fatal error: too many errors emitted, stopping now [-ferror-limit=]
+20 errors generated.

--- a/tests/Issue628.cpp
+++ b/tests/Issue628.cpp
@@ -1,0 +1,56 @@
+// cmdline:-std=c++2c
+// cmdlineinsights:-edu-show-coroutine-transformation -edu-show-cfront
+
+#include <iostream>
+#include <coroutine>
+#include <thread>
+#include <queue>
+#include <functional>
+
+std::queue<std::function<bool()>> task_queue;
+
+struct sleep {
+    sleep(int n) : delay{n} {}
+
+    constexpr bool await_ready() const noexcept { return false; }
+
+    void await_suspend(std::coroutine_handle<> h) const noexcept {
+        auto start = std::chrono::steady_clock::now();
+        task_queue.push([start, h, d = delay] {
+            if (decltype(start)::clock::now() - start > d) {
+                h.resume();
+                return true;
+            } else {
+                return false;
+            }
+        });
+    }
+
+    void await_resume() const noexcept {}
+
+    std::chrono::milliseconds delay;
+};
+
+
+struct Task {
+    struct promise_type {
+        promise_type() = default;
+        Task get_return_object() { return {}; }
+        std::suspend_never initial_suspend() { return {}; } 
+        std::suspend_always final_suspend() noexcept { return {}; }
+        void unhandled_exception() {}
+    };
+};
+
+Task foo() noexcept {
+    std::cout << "1. hello from foo1" << std::endl;
+    for (int i = 0; i < 10; ++i) {
+        co_await sleep{10};
+        std::cout << "2. hello from foo1" << std::endl;
+    }
+}
+
+//call foo
+int main() {
+    foo();
+}

--- a/tests/Issue628.expect
+++ b/tests/Issue628.expect
@@ -1,0 +1,246 @@
+/*************************************************************************************
+ * NOTE: The coroutine transformation you've enabled is a hand coded transformation! *
+ *       Most of it is _not_ present in the AST. What you see is an approximation.   *
+ *************************************************************************************/
+void __cxa_start(void);
+void __cxa_atexit(void);
+extern "C" void* memset(void*, int, unsigned int);
+
+#include <iostream>
+#include <coroutine>
+#include <thread>
+#include <queue>
+#include <functional>
+
+std::queue<std::function<bool ()>, std::deque<std::function<bool ()>, std::allocator<std::function<bool ()> > > > task_queue;
+
+typedef struct sleep
+{
+  std::chrono::duration<long long, std::ratio<1, 1000> > delay;
+} sleep;
+
+inline sleep * Constructor_sleep(sleep * __this, int n)
+{
+  Constructor_std::chrono::duration<long long, std::ratio<1, 1000> >(&__this->delay, n);
+  return __this;
+}
+
+inline bool await_ready(const sleep * __this)
+{
+  return false;
+}
+
+inline void await_suspend(const sleep * __this, std::coroutine_handle<void> h)
+{
+  std::chrono::time_point<std::chrono::steady_clock, std::chrono::duration<long long, std::ratio<1, 1000000000> > > start = std::chrono::steady_clock::now();
+  const std::chrono::time_point<std::chrono::steady_clock, std::chrono::duration<long long, std::ratio<1, 1000000000> > > __temporary20_45 = std::chrono::steady_clock::now();
+  const std::chrono::duration<long long, std::ratio<1, 1000000000> > __temporary20_49 = std::chrono::operatorMinus(&__temporary20_45, &start);
+  std::function<bool ()> __temporary26_9 = push(&task_queue, __temporary26_9);
+  Destructor_std::function<bool ()>(&__temporary26_9);
+  /* __temporary20_49 // lifetime ends here */
+  /* __temporary20_45 // lifetime ends here */
+}
+
+inline void await_resume(const sleep * __this)
+{
+}
+
+
+typedef struct Task
+{
+  char __dummy;
+} Task;
+
+typedef struct promise_type
+{
+  char __dummy;
+} promise_type;
+
+inline Task get_return_object(Task::promise_type * __this)
+{
+  Task __temporary38_44;
+  return __temporary38_44;
+  /* __temporary38_44 // lifetime ends here */
+}
+
+inline std::suspend_never initial_suspend(Task::promise_type * __this)
+{
+  std::suspend_never __temporary39_56;
+  return __temporary39_56;
+  /* __temporary39_56 // lifetime ends here */
+}
+
+inline std::suspend_always final_suspend(Task::promise_type * __this)
+{
+  std::suspend_always __temporary40_64;
+  return __temporary40_64;
+  /* __temporary40_64 // lifetime ends here */
+}
+
+inline void unhandled_exception(Task::promise_type * __this)
+{
+}
+
+
+typedef struct __fooFrame
+{
+  void (*resume_fn)(__fooFrame *);
+  void (*destroy_fn)(__fooFrame *);
+  std::__coroutine_traits_sfinae<Task>::promise_type __promise;
+  int __suspend_index;
+  bool __initial_await_suspend_called;
+  int i;
+  std::suspend_never __suspend_45_6;
+  sleep __suspend_48_18;
+  std::suspend_always __suspend_45_6_1;
+} __fooFrame;
+
+Task foo(void) noexcept
+{
+  /* Allocate the frame including the promise */
+  /* Note: The actual parameter new is __builtin_coro_size */
+  __fooFrame * __f = reinterpret_cast<__fooFrame *>(operatorNew_std::size_t(sizeof(__fooFrame)));
+  __f->__suspend_index = 0;
+  __f->__initial_await_suspend_called = false;
+  
+  /* Construct the promise. */
+  new (&__f->__promise)std::__coroutine_traits_sfinae<Task>::promise_type;
+  
+  /* Forward declare the resume and destroy function. */
+  void __fooResume(__fooFrame * __f);
+  void __fooDestroy(__fooFrame * __f);
+  
+  /* Assign the resume and destroy function pointers. */
+  __f->resume_fn = &__fooResume;
+  __f->destroy_fn = &__fooDestroy;
+  
+  /* Call the made up function with the coroutine body for initial suspend.
+     This function will be called subsequently by coroutine_handle<>::resume()
+     which calls __builtin_coro_resume(__handle_) */
+  __fooResume(__f);
+  
+  
+  return __f->__promise.get_return_object();
+}
+
+/* This function invoked by coroutine_handle<>::resume() */
+void __fooResume(__fooFrame * __f)
+{
+  try 
+  {
+    /* Create a switch to get to the correct resume point */
+    switch(__f->__suspend_index) {
+      case 0: break;
+      case 1: goto __resume_foo_1;
+      case 2: goto __resume_foo_2;
+    }
+    __temporary45_6 = __f->__promise.initial_suspend();
+    __temporary45_6 = from_address(static_cast<void *>(__f));
+    
+    /* co_await Issue628.cpp:45 */
+    __f->__suspend_45_6 = __f->__promise.initial_suspend();
+    if(!__f->__suspend_45_6.await_ready();
+    ) {
+      __f->__suspend_45_6.await_suspend(__temporary45_6.operator std::coroutine_handle<void>());
+      ;
+      __f->__suspend_index = 1;
+      __f->__initial_await_suspend_called = true;
+      return;
+      /* __temporary45_6 // lifetime ends here */
+      /* __temporary45_6 // lifetime ends here */
+    } 
+    
+    __resume_foo_1:
+    __f->__suspend_45_6.await_resume();
+    /* __temporary45_6 // lifetime ends here */
+    /* __temporary45_6 // lifetime ends here */
+    std::operatorLessLess(std::cout, "1. hello from foo1").operator<<(std::endl);
+    for(__f->i = 0; __f->i < 10; ++__f->i) {
+      __temporary48_26;
+      __temporary48_26;
+      
+      /* co_await Issue628.cpp:48 */
+      __f->__suspend_48_18 = sleep{10};
+      if(!__f->__suspend_48_18.await_ready();
+      ) {
+        __temporary48_18 = from_address(static_cast<void *>(__f));
+        __f->__suspend_48_18.await_suspend(__temporary48_18.operator std::coroutine_handle<void>());
+        /* __temporary48_18 // lifetime ends here */
+        __f->__suspend_index = 2;
+        return;
+        /* __temporary48_26 // lifetime ends here */
+        /* __temporary48_26 // lifetime ends here */
+      } 
+      
+      __resume_foo_2:
+      __f->__suspend_48_18.await_resume();
+      /* __temporary48_26 // lifetime ends here */
+      /* __temporary48_26 // lifetime ends here */
+      std::operatorLessLess(std::cout, "2. hello from foo1").operator<<(std::endl);
+    }
+    
+    goto __final_suspend;
+  } catch(...) {
+    if(!__f->__initial_await_suspend_called) {
+      throw ;
+    } 
+    
+    __f->__promise.unhandled_exception();
+  }
+  
+  __final_suspend:
+  __temporary45_6 = __f->__promise.final_suspend();
+  __temporary45_6 = from_address(static_cast<void *>(__f));
+  
+  /* co_await Issue628.cpp:45 */
+  __f->__suspend_45_6_1 = __f->__promise.final_suspend();
+  if(!__f->__suspend_45_6_1.await_ready();
+  ) {
+    __f->__suspend_45_6_1.await_suspend(__temporary45_6.operator std::coroutine_handle<void>());
+    ;
+  } 
+  
+  ;
+  /* __temporary45_6 // lifetime ends here */
+  /* __temporary45_6 // lifetime ends here */
+}
+
+/* This function invoked by coroutine_handle<>::destroy() */
+void __fooDestroy(__fooFrame * __f)
+{
+  /* destroy all variables with dtors */
+  __f->~__fooFrame();
+  /* Deallocating the coroutine frame */
+  /* Note: The actual argument to delete is __builtin_coro_frame with the promise as parameter */
+  operatorDelete_voidp(static_cast<void *>(__f));
+}
+
+
+int __main(void)
+{
+  foo();
+  return 0;
+}
+
+int main(void)
+{
+  __cxa_start();
+  int ret = __main();
+  __cxa_atexit();
+  return ret;
+  /* ret // lifetime ends here */
+}
+
+void __cxa_start(void)
+{
+  Constructor_std::queue<std::function<bool ()>, std::deque<std::function<bool ()>, std::allocator<std::function<bool ()> > > >(&task_queue);
+  memset(&__temporary38_44, 0, sizeof(Task));
+  memset(&__temporary39_56, 0, sizeof(std::suspend_never));
+  memset(&__temporary40_64, 0, sizeof(std::suspend_always));
+}
+
+void __cxa_atexit(void)
+{
+  Destructor_std::queue<std::function<bool ()>, std::deque<std::function<bool ()>, std::allocator<std::function<bool ()> > > >(&task_queue);
+}
+

--- a/tests/runTest.py
+++ b/tests/runTest.py
@@ -164,7 +164,7 @@ def main():
 
         m = regExInsights.search(fileHeader)
         if m is not None:
-            insightsOpts = m.group(1)
+            insightsOpts = m.group(1).split(' ')
 
         if not os.path.isfile(expectFile) and not os.path.isfile(ignoreFile):
             print('Missing expect/ignore for: %s' %(f))
@@ -182,8 +182,8 @@ def main():
             cmd.append('-use-libc++')
 
 
-        if '' != insightsOpts:
-            cmd.append(insightsOpts)
+        if len(insightsOpts):
+            cmd.extend(insightsOpts)
 
         cmd.extend(['--', cppStd, '-m64'])
 


### PR DESCRIPTION
This patch fixes a crash. Certain parts of the coroutine transformation aren't correctly transformed to C code due to the architecture of the CodeGenerators.