### PR TITLE
Fix potential out-of-bounds access by checking if  `start` is empty before removing prefix

### DIFF
--- a/CodeGenerator.cpp
+++ b/CodeGenerator.cpp
@@ -3725,7 +3725,9 @@ void CodeGenerator::InsertAttribute(const Attr& attr)
     std::string_view start{stream.str()};
 #if IS_CLANG_NEWER_THAN(18)
 #else
-    start.remove_prefix(1);
+    if(!start.empty()) {
+        start.remove_prefix(1);
+    }
 #endif
 
     mOutputFormatHelper.Append(start, " "sv);

--- a/tests/Issue681.cpp
+++ b/tests/Issue681.cpp
@@ -1,0 +1,25 @@
+#include <inttypes.h>
+
+/* WARNING: undefined if a = 0 */
+static inline int clz32(unsigned int a)
+{
+    return __builtin_clz(a);
+}
+
+/* WARNING: undefined if a = 0 */
+static inline int clz64(uint64_t a)
+{
+    return __builtin_clzll(a);
+}
+
+/* WARNING: undefined if a = 0 */
+static inline int ctz32(unsigned int a)
+{
+    return __builtin_ctz(a);
+}
+
+/* WARNING: undefined if a = 0 */
+static inline int ctz64(uint64_t a)
+{
+    return __builtin_ctzll(a);
+}

--- a/tests/Issue681.expect
+++ b/tests/Issue681.expect
@@ -1,0 +1,21 @@
+#include <inttypes.h>
+
+static inline int clz32(unsigned int a)
+{
+  return __builtin_clz(a);
+}
+
+static inline int clz64(uint64_t a)
+{
+  return __builtin_clzll(a);
+}
+
+static inline int ctz32(unsigned int a)
+{
+  return __builtin_ctz(a);
+}
+
+static inline int ctz64(uint64_t a)
+{
+  return __builtin_ctzll(a);
+}


### PR DESCRIPTION
If the code contains compiler builtin functions, it will crash with `/usr/include/c++/14.2.1/string_view:297: constexpr void std::basic_string_view<_CharT, _Traits>::remove_prefix(size_type) [with _CharT = char; _Traits = std::char_traits<char>; size_type = long unsigned int]: Assertion 'this->_M_len >= __n' failed.`

In other words: "support compiler builtin functions"

eg:
```cpp
#include <inttypes.h>

/* WARNING: undefined if a = 0 */
static inline int clz32(unsigned int a)
{
    return __builtin_clz(a);
}

/* WARNING: undefined if a = 0 */
static inline int clz64(uint64_t a)
{
    return __builtin_clzll(a);
}

/* WARNING: undefined if a = 0 */
static inline int ctz32(unsigned int a)
{
    return __builtin_ctz(a);
}

/* WARNING: undefined if a = 0 */
static inline int ctz64(uint64_t a)
{
    return __builtin_ctzll(a);
}
```

after fixes, the result is:

```cpp
#include <inttypes.h>

static inline int clz32(unsigned int a)
{
  return __builtin_clz(a);
}

 __attribute__((nothrow)) __attribute__((const)) extern int __builtin_clz(unsigned int);

static inline int clz64(uint64_t a)
{
  return __builtin_clzll(static_cast<unsigned long long>(a));
}

 __attribute__((nothrow)) __attribute__((const)) extern int __builtin_clzll(unsigned long long);

static inline int ctz32(unsigned int a)
{
  return __builtin_ctz(a);
}

 __attribute__((nothrow)) __attribute__((const)) extern int __builtin_ctz(unsigned int);

static inline int ctz64(uint64_t a)
{
  return __builtin_ctzll(static_cast<unsigned long long>(a));
}

 __attribute__((nothrow)) __attribute__((const)) extern int __builtin_ctzll(unsigned long long);
```
