### PR TITLE
New lambda implementation

### DIFF
--- a/CfrontCodeGenerator.cpp
+++ b/CfrontCodeGenerator.cpp
@@ -83,22 +83,19 @@ CodeGeneratorVariant::CodeGenerators::CodeGenerators(OutputFormatHelper&        
                                                      CodeGenerator::ProcessingPrimaryTemplate processingPrimaryTemplate)
 {
     if(GetInsightsOptions().UseShow2C) {
-        new(&cfcg) CfrontCodeGenerator{
-            _outputFormatHelper, lambdaStack, CodeGenerator::LambdaInInitCapture::No, processingPrimaryTemplate};
+        new(&cfcg) CfrontCodeGenerator{_outputFormatHelper, lambdaStack, processingPrimaryTemplate};
     } else {
-        new(&cg) CodeGenerator{
-            _outputFormatHelper, lambdaStack, CodeGenerator::LambdaInInitCapture::No, processingPrimaryTemplate};
+        new(&cg) CodeGenerator{_outputFormatHelper, lambdaStack, processingPrimaryTemplate};
     }
 }
 //-----------------------------------------------------------------------------
 
-CodeGeneratorVariant::CodeGenerators::CodeGenerators(OutputFormatHelper&                _outputFormatHelper,
-                                                     CodeGenerator::LambdaInInitCapture lambdaInitCapture)
+CodeGeneratorVariant::CodeGenerators::CodeGenerators(OutputFormatHelper& _outputFormatHelper)
 {
     if(GetInsightsOptions().UseShow2C) {
-        new(&cfcg) CfrontCodeGenerator{_outputFormatHelper, lambdaInitCapture};
+        new(&cfcg) CfrontCodeGenerator{_outputFormatHelper};
     } else {
-        new(&cg) CodeGenerator{_outputFormatHelper, lambdaInitCapture};
+        new(&cg) CodeGenerator{_outputFormatHelper};
     }
 }
 //-----------------------------------------------------------------------------

--- a/CodeGenerator.cpp
+++ b/CodeGenerator.cpp
@@ -77,11 +77,17 @@ BUILD_OPT_AND_O(CanonicalType, const InitListExpr&, QualType)
     return t.getType().getCanonicalType();
 };
 
-static std::string AccessToStringWithColon(const AccessSpecifier& access)
+STRONG_BOOL(TrailingSpace);
+static std::string AccessToStringWithColon(const AccessSpecifier& access,
+                                           const TrailingSpace    endWithTrailingSpace = TrailingSpace::Yes)
 {
     std::string accessStr{getAccessSpelling(access)};
     if(not accessStr.empty()) {
-        accessStr += ": "sv;
+        if(TrailingSpace::Yes == endWithTrailingSpace) {
+            accessStr += ": "sv;
+        } else {
+            accessStr += ":"sv;
+        }
     }
 
     return accessStr;
@@ -192,39 +198,6 @@ public:
 
 protected:
     bool InsertNamespace() const override { return true; }
-};
-//-----------------------------------------------------------------------------
-
-/// \brief A special code generator for Lambda init captures which use \c std::move
-class LambdaInitCaptureCodeGenerator final : public CodeGenerator
-{
-public:
-    explicit LambdaInitCaptureCodeGenerator(OutputFormatHelper& outputFormatHelper,
-                                            LambdaStackType&    lambdaStack,
-                                            std::string_view    varName)
-    : CodeGenerator{outputFormatHelper, lambdaStack, ProcessingPrimaryTemplate::No}
-    , mVarName{varName}
-    {
-    }
-
-    using CodeGenerator::InsertArg;
-
-    /// Replace every \c VarDecl with the given variable name. This cover init captures which introduce a new name.
-    /// However, it means that _all_ VarDecl's will be changed.
-    /// TODO: Check if it is really good to replace all VarDecl's
-    void InsertArg(const DeclRefExpr* stmt) override
-    {
-        if(isa<VarDecl>(stmt->getDecl())) {
-            mOutputFormatHelper.Append("_"sv, mVarName);
-
-        } else {
-
-            CodeGenerator::InsertArg(stmt);
-        }
-    }
-
-private:
-    std::string_view mVarName;  ///< The name of the variable that needs to be prefixed with _.
 };
 //-----------------------------------------------------------------------------
 
@@ -422,8 +395,7 @@ void CodeGenerator::InsertArg(const VarTemplateDecl* stmt)
     // VarTemplatedDecl's can have lambdas as initializers. Push a VarDecl on the stack, otherwise the lambda would
     // appear in the middle of template<....> and the variable itself.
     {
-        LAMBDA_SCOPE_HELPER(Decltype);  // Needed for P0315Checker
-        mLambdaStack.back().setInsertName(true);
+        LAMBDA_SCOPE_HELPER(DecltypeWithName);  // Needed for P0315Checker
 
         InsertTemplateParameters(*stmt->getTemplateParameters());
     }
@@ -599,8 +571,7 @@ static std::optional<std::string> GetFieldDeclNameForLambda(const FieldDecl&    
 {
     if(cxxRecordDecl.isLambda()) {
         llvm::DenseMap<const ValueDecl*, FieldDecl*> captures{};
-
-        FieldDecl* thisCapture{};
+        FieldDecl*                                   thisCapture{};
 
         cxxRecordDecl.getCaptureFields(captures, thisCapture);
 
@@ -1888,8 +1859,7 @@ void CodeGenerator::InsertTemplateParameters(const TemplateParameterList& list,
 void CodeGenerator::InsertArg(const ClassTemplateDecl* stmt)
 {
     {
-        LAMBDA_SCOPE_HELPER(Decltype);  // Needed for P0315Checker
-        mLambdaStack.back().setInsertName(true);
+        LAMBDA_SCOPE_HELPER(DecltypeWithName);  // Needed for P0315Checker
 
         InsertTemplateParameters(*stmt->getTemplateParameters());
     }
@@ -2021,16 +1991,12 @@ void CodeGenerator::InsertArg(const CXXDeleteExpr* stmt)
 void CodeGenerator::InsertConstructorExpr(const auto* stmt)
 {
     {
-        CONDITIONAL_LAMBDA_SCOPE_HELPER(Decltype, not isa<DecltypeType>(stmt->getType()))
+        // only use this a insert point, if we are not coming from a decltype, for example decltype(decltype(...)) or
+        // decltype inside a concept.
+        CONDITIONAL_LAMBDA_SCOPE_HELPER(Decltype, not InsideDecltype());
 
         P0315Visitor dt{*this};
         dt.TraverseType(stmt->getType());
-
-        if(not mLambdaStack.empty()) {
-            for(const auto& e : mLambdaStack) {
-                RETURN_IF((LambdaCallerType::MemberCallExpr == e.callerType()) and isa<DecltypeType>(stmt->getType()));
-            }
-        }
     }
 
     mOutputFormatHelper.Append(GetName(stmt->getType(), Unqualified::Yes));
@@ -2143,7 +2109,7 @@ void CodeGenerator::InsertArg(const CXXInheritedCtorInitExpr* stmt)
 
 bool CodeGenerator::InsideDecltype() const
 {
-    return (not mLambdaStack.empty()) and (LambdaCallerType::Decltype == mLambdaStack.back().callerType());
+    return (not mLambdaStack.empty()) and (mLambdaStack.back().callerType() == LambdaCallerType::Decltype);
 }
 //-----------------------------------------------------------------------------
 
@@ -2254,7 +2220,7 @@ void CodeGenerator::InsertArg(const CallExpr* stmt)
 
     CONDITIONAL_LAMBDA_SCOPE_HELPER(CallExpr, not insideDecltype)
     if(insideDecltype) {
-        mLambdaStack.back().setInsertName(true);
+        mLambdaStack.back().setCallerType(LambdaCallerType::DecltypeWithName);
     }
 
     UpdateCurrentPos(mCurrentCallExprPos);
@@ -2303,7 +2269,7 @@ void CodeGenerator::InsertArg(const CallExpr* stmt)
     });
 
     if(insideDecltype) {
-        mLambdaStack.back().setInsertName(false);
+        mLambdaStack.back().setCallerType(LambdaCallerType::Decltype);
     }
 
     mCurrentCallExprPos.reset();
@@ -2909,34 +2875,17 @@ void CodeGenerator::InsertArg(const CXXOperatorCallExpr* stmt)
 }
 //-----------------------------------------------------------------------------
 
-void CodeGenerator::InsertArg(const LambdaExpr* stmt)
-{
-    if(not mLambdaStack.empty()) {
-        const bool insertName{mLambdaStack.back().insertName()};
-
-        HandleLambdaExpr(stmt, mLambdaStack.back());
-
-        if(insertName) {
-            mOutputFormatHelper.Append(GetLambdaName(*stmt));
-        }
-
-    } else if(LambdaInInitCapture::Yes == mLambdaInitCapture) {
-        LAMBDA_SCOPE_HELPER(InitCapture);
-        HandleLambdaExpr(stmt, mLambdaStack.back());
-    } else {
-        LAMBDA_SCOPE_HELPER(LambdaExpr);
-        HandleLambdaExpr(stmt, mLambdaStack.back());
-    }
-
-    if(not mLambdaStack.empty()) {
-        mLambdaStack.back().insertInits(mOutputFormatHelper);
-    }
-}
-//-----------------------------------------------------------------------------
-
 void CodeGenerator::InsertArg(const CXXThisExpr*)
 {
-    mOutputFormatHelper.Append(kwThis);
+    if(not mLambdaExpr) {
+        mOutputFormatHelper.Append(kwThis);
+    } else if(ranges::any_of(mLambdaExpr->captures(),
+                             [](const LambdaCapture& c) { return (c.getCaptureKind() == LCK_StarThis); })) {
+        mOutputFormatHelper.Append("(&"sv, kwInternalThis, ")"sv);
+
+    } else {
+        mOutputFormatHelper.Append(kwInternalThis);
+    }
 }
 //-----------------------------------------------------------------------------
 
@@ -3730,7 +3679,7 @@ void CodeGenerator::InsertArg(const CXXDeductionGuideDecl* stmt)
 
 void CodeGenerator::InsertTemplate(const FunctionTemplateDecl* stmt, bool withSpec)
 {
-    LAMBDA_SCOPE_HELPER(TemplateHead);
+    LAMBDA_SCOPE_HELPER(DecltypeWithName);
 
     mProcessingPrimaryTemplate = ProcessingPrimaryTemplate::Yes;
 
@@ -3856,13 +3805,10 @@ void CodeGenerator::InsertAttribute(const Attr& attr)
 
 void CodeGenerator::InsertArg(const CXXRecordDecl* stmt)
 {
-    const size_t insertPosBeforeClass{mOutputFormatHelper.CurrentPos()};
-    const auto   indentAtInsertPosBeforeClass{mOutputFormatHelper.GetIndent()};
-
     SCOPE_HELPER(stmt);
 
     // Prevent a case like in #205 where the lambda appears twice.
-    RETURN_IF(stmt->isLambda() and (mLambdaStack.empty() or (nullptr == mLambdaExpr)));
+    RETURN_IF(stmt->isLambda() and (mLambdaStack.empty()));
 
     const auto* classTemplatePartialSpecializationDecl = dyn_cast_or_null<ClassTemplatePartialSpecializationDecl>(stmt);
     const auto* classTemplateSpecializationDecl        = dyn_cast_or_null<ClassTemplateSpecializationDecl>(stmt);
@@ -3966,11 +3912,10 @@ void CodeGenerator::InsertArg(const CXXRecordDecl* stmt)
 
     UpdateCurrentPos(mCurrentFieldPos);
 
-    OnceTrue        firstRecordDecl{};
-    OnceTrue        firstDecl{};
+    const bool      isLambda{stmt->isLambda()};
     Decl::Kind      formerKind{};
     AccessSpecifier lastAccess{stmt->isClass() ? AS_private : AS_public};
-    for(const auto* d : stmt->decls()) {
+    for(OnceTrue firstRecordDecl{}, firstDecl{}; const auto* d : stmt->decls()) {
         if(isa<CXXRecordDecl>(d) and firstRecordDecl) {
             continue;
         }
@@ -3981,7 +3926,7 @@ void CodeGenerator::InsertArg(const CXXRecordDecl* stmt)
             // mOutputFormatHelper.AppendNewLine();
         }
 
-        if((stmt->isLambda() and isa<CXXDestructorDecl>(d)) and not d->isUsed()) {
+        if((isLambda and isa<CXXDestructorDecl>(d)) and not d->isUsed()) {
             continue;
         }
 
@@ -3992,6 +3937,16 @@ void CodeGenerator::InsertArg(const CXXRecordDecl* stmt)
 
             // skip inserting an access specifier of our own, if there is a real one coming.
             if(not isa<AccessSpecDecl>(d)) {
+                // For the captures of a lambda mimic the behavior of GCC. They create an aggregate first and later flip
+                // it to a class:
+                // https://github.com/gcc-mirror/gcc/blob/62a80185db84f20f3efb05c81598bffa95bcd63d/gcc/cp/lambda.cc#L56
+                // https://github.com/gcc-mirror/gcc/blob/62a80185db84f20f3efb05c81598bffa95bcd63d/gcc/cp/lambda.cc#L121
+                if(isa<FieldDecl>(d) and isLambda) {
+                    // ToDo: Leave a comment in a potential -with-comments mode that the standard requires the captures
+                    // to be private?
+                    mOutputFormatHelper.Append(kwCppCommentStartSpace);
+                }
+
                 mOutputFormatHelper.AppendNewLine(AccessToStringWithColon(lastAccess));
             }
         }
@@ -4001,250 +3956,25 @@ void CodeGenerator::InsertArg(const CXXRecordDecl* stmt)
         formerKind = d->getKind();
     }
 
-    if(stmt->isLambda()) {
-        const LambdaCallerType lambdaCallerType = mLambdaStack.back().callerType();
-        const bool             ctorRequired{stmt->capture_size() or stmt->lambdaIsDefaultConstructibleAndAssignable()};
-
-        if(ctorRequired) {
-            if(AS_public != lastAccess) {
-                mOutputFormatHelper.AppendNewLine();
-                // XXX avoid diff in tests. AccessToStringWithColon add "public: " before there was no space.
-                const auto       pub{AccessToStringWithColon(AS_public)};
-                std::string_view p{pub};
-                p.remove_suffix(1);
-                mOutputFormatHelper.AppendNewLine(p);
-            }
-
-            if(stmt->lambdaIsDefaultConstructibleAndAssignable()) {
-                mOutputFormatHelper.Append(kwCppCommentStartSpace);
-
-                if(stmt->hasConstexprDefaultConstructor()) {
-                    mOutputFormatHelper.Append(kwCommentStart, kwConstExprSpace, kwCCommentEndSpace);
-                }
-            }
-
-            mOutputFormatHelper.Append(GetName(*stmt), "("sv);
+    // Only a default constructible, i.e. captureless, lambda has a defaulted default constructor
+    if(isLambda and stmt->lambdaIsDefaultConstructibleAndAssignable()) {
+        if(AS_public != lastAccess) {
+            mOutputFormatHelper.AppendNewLine();
+            mOutputFormatHelper.AppendNewLine(AccessToStringWithColon(AS_public, TrailingSpace::No));
         }
 
-        SmallVector<std::string, 5> ctorInitializerList{};
-        std::string                 ctorArguments{'{'};
-        OnceTrue                    firstCtorArgument{};
+        mOutputFormatHelper.Append(kwCppCommentStartSpace);
 
-        auto addToInits =
-            [&](std::string_view name, const FieldDecl* fd, bool isThis, const Expr* expr, bool /*useBraces*/) {
-                if(firstCtorArgument) {
-                } else {
-                    mOutputFormatHelper.Append(", "sv);
-                    ctorArguments.append(", "sv);
-                }
-
-                bool byConstRef{false};
-                auto fieldName{isThis ? kwInternalThis : name};
-                auto fieldDeclType{fd->getType()};
-                bool isMoved{};
-
-                std::string fname = StrCat("_"sv, name);
-
-                // Special handling for lambdas with init captures which contain a move. In such a case, copy the
-                // initial move statement and make the variable a &&.
-                if(const auto* cxxConstructExpr = dyn_cast_or_null<CXXConstructExpr>(expr);
-                   cxxConstructExpr and cxxConstructExpr->getConstructor()->isMoveConstructor()) {
-
-                    OutputFormatHelper             ofm{};
-                    LambdaInitCaptureCodeGenerator codeGenerator{ofm, mLambdaStack, name};
-
-                    if(cxxConstructExpr->getNumArgs()) {
-                        ForEachArg(cxxConstructExpr->arguments(),
-                                   [&](const auto& arg) { codeGenerator.InsertArg(arg); });
-                    }
-
-                    fieldDeclType = stmt->getASTContext().getRValueReferenceType(fieldDeclType);
-
-                    fname = ofm;
-
-                    // If it is not an object, check for other conditions why we take the variable by const &/&& in the
-                    // ctor
-                } else if(not fieldDeclType->isReferenceType() and not fieldDeclType->isAnyPointerType() and
-                          not fieldDeclType->isUndeducedAutoType()) {
-                    byConstRef                      = true;
-                    const auto* exprWithoutImpCasts = expr->IgnoreParenImpCasts();
-
-                    // treat a move of a primitive type
-                    if(exprWithoutImpCasts->isXValue()) {
-                        byConstRef = false;
-
-                        OutputFormatHelper             ofm{};
-                        LambdaInitCaptureCodeGenerator codeGenerator{ofm, mLambdaStack, name};
-                        codeGenerator.InsertArg(expr);
-
-                        fname = ofm;
-
-                    } else if(exprWithoutImpCasts
-                                  ->isPRValue()  // If we are looking at an rvalue (temporary) we need a const ref
-                              or exprWithoutImpCasts->getType().isConstQualified()  // If the captured variable is const
-                                                                                    // we can take it only by const ref
-
-                    ) {
-                        // this must go before adding the L or R-value reference, otherwise we get T& const instead of
-                        // const T&
-
-                        if(exprWithoutImpCasts->isPRValue() and isa<CXXBindTemporaryExpr>(exprWithoutImpCasts) and
-                           not exprWithoutImpCasts->getType().isConstQualified()) {
-                            fieldDeclType = stmt->getASTContext().getRValueReferenceType(fieldDeclType);
-                            EnableGlobalInsert(GlobalInserts::HeaderUtility);
-                            fname   = StrCat("std::move("sv, fname, ")"sv);
-                            isMoved = true;
-
-                        } else {
-                            fieldDeclType.addConst();
-                        }
-                    }
-
-                    if(exprWithoutImpCasts->isXValue()) {
-                        fieldDeclType = stmt->getASTContext().getRValueReferenceType(fieldDeclType);
-
-                    } else if(not isMoved) {
-                        fieldDeclType = stmt->getASTContext().getLValueReferenceType(fieldDeclType);
-                    }
-                }
-
-                const std::string_view elips{
-                    Ellipsis(isa_and_nonnull<PackExpansionType>(fieldDeclType->getPointeeType().getTypePtrOrNull()))};
-
-                // To avoid seeing the templates stuff from std::move (typename...) the canonical type is used here.
-                fieldDeclType = fieldDeclType.getCanonicalType();
-
-                ctorInitializerList.push_back(StrCat(fieldName, "{"sv, fname, elips, "}"sv));
-
-                if(not isThis and expr) {
-                    LAMBDA_SCOPE_HELPER(Decltype);
-                    OutputFormatHelper ofmLambdaInCtor{};
-                    ofmLambdaInCtor.SetIndent(indentAtInsertPosBeforeClass);
-                    CodeGenerator cgLambdaInCtor{ofmLambdaInCtor, LambdaInInitCapture::Yes};
-
-                    if(P0315Visitor dt{cgLambdaInCtor}; dt.TraverseStmt(const_cast<Expr*>(expr))) {
-
-                        OutputFormatHelper   ofm{};
-                        CodeGeneratorVariant codeGenerator{ofm, mLambdaStack, mProcessingPrimaryTemplate};
-
-                        if(const auto* ctorExpr = dyn_cast_or_null<CXXConstructExpr>(expr);
-                           ctorExpr and byConstRef and (1 == ctorExpr->getNumArgs())) {
-                            codeGenerator->InsertArg(ctorExpr->getArg(0));
-
-                        } else {
-                            codeGenerator->InsertArg(expr);
-                        }
-
-                        //        if(isa<PackExpansionType>(stmt->getDecl()->getType().getTypePtrOrNull())) {
-                        //            mOutputFormatHelper.Append(kwElipsisSpace);
-                        //        }
-
-                        ctorArguments.append(ofm);
-
-                    } else {
-                        OutputFormatHelper          ofm{};
-                        LambdaNameOnlyCodeGenerator ccg{ofm};
-                        ccg.InsertArg(expr);
-
-                        ctorArguments.append(ofm.GetString());
-
-                        mOutputFormatHelper.InsertAt(insertPosBeforeClass, ofmLambdaInCtor);
-                    }
-                } else {
-                    if(isThis and not fieldDeclType->isPointerType()) {
-                        ctorArguments.append("*"sv);
-                    }
-
-                    ctorArguments.append(name);
-                }
-
-                mOutputFormatHelper.Append(GetTypeNameAsParameter(fieldDeclType, StrCat("_"sv, name)));
-            };
-
-        llvm::DenseMap<const ValueDecl*, FieldDecl*> captures{};
-        FieldDecl*                                   thisCapture{};
-
-        stmt->getCaptureFields(captures, thisCapture);
-
-        // Check if it captures this
-        if(thisCapture) {
-            const auto* captureInit = mLambdaExpr->capture_init_begin();
-
-            addToInits(kwThis, thisCapture, true, *captureInit, false);
+        if(stmt->hasConstexprDefaultConstructor()) {
+            mOutputFormatHelper.AppendComment(kwConstExpr);
+            mOutputFormatHelper.Append(" "sv);
         }
 
-        // Find the corresponding capture in the DenseMap. The DenseMap seems to be change its order each time.
-        // Hence we use \c captures() to keep the order stable. While using \c Captures to generate the code as
-        // it carries the better type infos.
-        for(const auto& [c, cinit] : zip(mLambdaExpr->captures(), mLambdaExpr->capture_inits())) {
-            if(not c.capturesVariable()) {
-                continue;
-            }
-
-            const auto* capturedVar = c.getCapturedVar();
-            if(const auto* value = captures[capturedVar]) {
-                // Since C++20 lambdas can capture structured bindings
-                if(const auto* bindingDecl = dyn_cast_or_null<BindingDecl>(capturedVar)) {
-                    const auto* decompositionDecl = cast<DecompositionDecl>(bindingDecl->getDecomposedDecl());
-                    addToInits(GetName(*capturedVar),
-                               value,
-                               false,
-                               cinit,
-                               VarDecl::ListInit == decompositionDecl->getInitStyle());
-                    continue;
-                }
-
-                addToInits(GetName(*capturedVar),
-                           value,
-                           false,
-                           cinit,
-                           VarDecl::ListInit == dyn_cast_or_null<VarDecl>(capturedVar)->getInitStyle());
-            }
-        }
-
-        ctorArguments.append("}"sv);
-
-        // generate the ctor only if it is required, i.e. we have captures. This is in fact a trick to get
-        // compiling code out of it. The compiler itself does not generate a constructor in many many cases.
-        if(ctorRequired) {
-            mOutputFormatHelper.Append(")"sv);
-
-            if(stmt->lambdaIsDefaultConstructibleAndAssignable()) {
-                mOutputFormatHelper.AppendNewLine(kwSpaceEqualsDefault);
-
-            } else {
-                mOutputFormatHelper.AppendNewLine();
-
-                for(OnceTrue firstCtorInitializer{}; const auto& initializer : ctorInitializerList) {
-                    if(firstCtorInitializer) {
-                        mOutputFormatHelper.Append(": "sv);
-                    } else {
-                        mOutputFormatHelper.Append(", "sv);
-                    }
-
-                    mOutputFormatHelper.AppendNewLine(initializer);
-                }
-
-                mOutputFormatHelper.AppendNewLine("{}"sv);
-            }
-        }
-
-        // close the class scope
-        mOutputFormatHelper.CloseScope();
-
-        if(not is{lambdaCallerType}.any_of(LambdaCallerType::VarDecl,
-                                           LambdaCallerType::InitCapture,
-                                           LambdaCallerType::CallExpr,
-                                           LambdaCallerType::MemberCallExpr,
-                                           LambdaCallerType::TemplateHead,
-                                           LambdaCallerType::Decltype)) {
-            mOutputFormatHelper.Append(" "sv, GetLambdaName(*stmt), ctorArguments);
-        } else if(not is{lambdaCallerType}.any_of(LambdaCallerType::TemplateHead, LambdaCallerType::Decltype)) {
-            mLambdaStack.back().inits().append(ctorArguments);
-        }
-    } else {
-        mOutputFormatHelper.CloseScope(OutputFormatHelper::NoNewLineBefore::Yes);
+        mOutputFormatHelper.AppendNewLine(GetName(*stmt), "()"sv, kwSpaceEqualsDefault);
     }
+
+    // close the class scope
+    mOutputFormatHelper.CloseScope(OutputFormatHelper::NoNewLineBefore::Yes);
 
     if(GetInsightsOptions().UseShow2C) {
         mOutputFormatHelper.Append(" "sv, GetName(*stmt));
@@ -4598,6 +4328,13 @@ void CodeGenerator::InsertTemplateArgs(const ClassTemplateSpecializationDecl& cl
         InsertTemplateArgs(ar->arguments());
     } else {
         InsertTemplateArgs(clsTemplateSpe.getTemplateArgs());
+#if 0
+    if(const TypeSourceInfo* typeAsWritten = clsTemplateSpe.getTypeAsWritten()) {
+        const TemplateSpecializationType* tmplSpecType = cast<TemplateSpecializationType>(typeAsWritten->getType());
+        InsertTemplateArgs(*tmplSpecType);
+        } else {
+            InsertTemplateArgs(clsTemplateSpe.getTemplateArgs());
+#endif
     }
 }
 //-----------------------------------------------------------------------------
@@ -4806,17 +4543,91 @@ std::string_view CodeGenerator::GetBuiltinTypeSuffix(const BuiltinType::Kind& ki
 }
 //-----------------------------------------------------------------------------
 
-void CodeGenerator::HandleLambdaExpr(const LambdaExpr* lambda, LambdaHelper& lambdaHelper)
+void CodeGenerator::InsertArg(const LambdaExpr* stmt)
 {
-    OutputFormatHelper& outputFormatHelper = lambdaHelper.buffer();
+    const auto stackEmpty{mLambdaStack.empty()};  // If the stack is empty we have a IIFE
+    CONDITIONAL_LAMBDA_SCOPE_HELPER(LambdaExpr, stackEmpty);
+
+    LambdaHelper&       lambdaHelper{mLambdaStack.back()};
+    OutputFormatHelper& outputFormatHelper{lambdaHelper.buffer()};
+    const size_t        insertPosBeforeClass{outputFormatHelper.CurrentPos()};
+    const auto          indentAtInsertPosBeforeClass{outputFormatHelper.GetIndent()};
 
     outputFormatHelper.AppendNewLine();
-    LambdaCodeGenerator codeGenerator{outputFormatHelper, mLambdaStack, mProcessingPrimaryTemplate};
-    codeGenerator.mCapturedThisAsCopy = ranges::any_of(
-        lambda->captures(), [](auto& c) { return (c.capturesThis() and (c.getCaptureKind() == LCK_StarThis)); });
+    CodeGeneratorVariant codeGenerator{outputFormatHelper, mLambdaStack, mProcessingPrimaryTemplate};
+    codeGenerator->mLambdaExpr = stmt;
+    codeGenerator->InsertArg(stmt->getLambdaClass());
 
-    codeGenerator.mLambdaExpr = lambda;
-    codeGenerator.InsertArg(lambda->getLambdaClass());
+    if(lambdaHelper.insertName()) {
+        mOutputFormatHelper.Append(GetLambdaName(*stmt));
+    }
+
+    // type only discarding captures as this is a capture-less context
+    if(is{lambdaHelper.callerType()}.any_of(LambdaCallerType::Decltype, LambdaCallerType::DecltypeWithName)) {
+        return;
+    }
+
+    // Process the captures, transfer them to initializer for an aggregate init call.
+    OutputFormatHelper ctorArguments{};
+    ctorArguments.Append("{"sv);
+
+    // We have to process the captures even if the stack was previously empty and we will discard all the initializers,
+    // because one of the captures could contain another lambda.
+    if(const auto* recordDecl{stmt->getLambdaClass()}; not recordDecl->lambdaIsDefaultConstructibleAndAssignable()) {
+        OnceFalse                                    needsComma{};
+        llvm::DenseMap<const ValueDecl*, FieldDecl*> captures{};
+        FieldDecl*                                   _{};
+
+        recordDecl->getCaptureFields(captures, _);
+
+        // Find the corresponding capture in the DenseMap. The DenseMap seems to be change its order each time.
+        // Hence we use \c captures() to keep the order stable. While using \c Captures to generate the code as
+        // it carries the better type infos.
+        for(const auto& [c, initExpr] : zip(stmt->captures(), stmt->capture_inits())) {
+            if(not c.capturesVariable() and not c.capturesThis()) {
+                // that can be a VLA
+                continue;
+            }
+
+            ctorArguments.AppendComma(needsComma);
+
+            LAMBDA_SCOPE_HELPER(Decltype);
+            OutputFormatHelper ofmLambdaInCtor{};
+            ofmLambdaInCtor.SetIndent(indentAtInsertPosBeforeClass);
+            CodeGenerator      cgLambdaInCtor{ofmLambdaInCtor};
+            OutputFormatHelper ofm{};
+
+            if(P0315Visitor dt{cgLambdaInCtor}; dt.TraverseStmt(const_cast<Expr*>(initExpr))) {
+                CodeGeneratorVariant codeGenerator{ofm, mLambdaStack, mProcessingPrimaryTemplate};
+
+                if(const auto* ctorExpr = dyn_cast_or_null<CXXConstructExpr>(initExpr);
+                   ctorExpr and (1 == ctorExpr->getNumArgs())) {
+                    codeGenerator->InsertArg(ctorExpr->getArg(0));
+
+                } else {
+                    codeGenerator->InsertArg(initExpr);
+                }
+
+            } else {
+                LambdaNameOnlyCodeGenerator ccg{ofm};
+                ccg.InsertArg(initExpr);
+
+                outputFormatHelper.InsertAt(insertPosBeforeClass, ofmLambdaInCtor);
+            }
+
+            ctorArguments.Append(ofm);
+
+            if(c.capturesVariable() and c.getCapturedVar()->isParameterPack()) {
+                ctorArguments.Append(kwElipsis);
+            }
+        }
+    }
+
+    ctorArguments.Append("}"sv);
+
+    if(not stackEmpty) {
+        mOutputFormatHelper.Append(ctorArguments);
+    }
 }
 //-----------------------------------------------------------------------------
 
@@ -5310,17 +5121,6 @@ void StructuredBindingsCodeGenerator::InsertArg(const DeclRefExpr* stmt)
         mOutputFormatHelper.Append(mVarName);
     } else {
         InsertTemplateArgs(*stmt);
-    }
-}
-//-----------------------------------------------------------------------------
-
-void LambdaCodeGenerator::InsertArg(const CXXThisExpr*)
-{
-    if(mCapturedThisAsCopy) {
-        mOutputFormatHelper.Append("(&"sv, kwInternalThis, ")"sv);
-
-    } else {
-        mOutputFormatHelper.Append(kwInternalThis);
     }
 }
 //-----------------------------------------------------------------------------

--- a/CodeGenerator.h
+++ b/CodeGenerator.h
@@ -106,16 +106,15 @@ protected:
     enum class LambdaCallerType
     {
         VarDecl,
-        InitCapture,
         CallExpr,
         OperatorCallExpr,
         MemberCallExpr,
-        LambdaExpr,
         ReturnStmt,
         BinaryOperator,
         CXXMethodDecl,
-        TemplateHead,
+        LambdaExpr,
         Decltype,
+        DecltypeWithName,
     };
 
     class LambdaHelper : public StackListEntry<LambdaHelper>
@@ -123,7 +122,7 @@ protected:
     public:
         LambdaHelper(const LambdaCallerType lambdaCallerType, OutputFormatHelper& outputFormatHelper)
         : mLambdaCallerType{lambdaCallerType}
-        , mCurrentVarDeclPos{outputFormatHelper.CurrentPos()}
+        , mCurrentDeclPos{outputFormatHelper.CurrentPos()}
         , mOutputFormatHelper{outputFormatHelper}
         {
             mLambdaOutputFormatHelper.SetIndent(mOutputFormatHelper);
@@ -132,55 +131,31 @@ protected:
         void finish()
         {
             if(not mLambdaOutputFormatHelper.empty()) {
-                mOutputFormatHelper.InsertAt(mCurrentVarDeclPos, mLambdaOutputFormatHelper);
+                mOutputFormatHelper.InsertAt(mCurrentDeclPos, mLambdaOutputFormatHelper);
             }
         }
 
         OutputFormatHelper& buffer() { return mLambdaOutputFormatHelper; }
-
-        std::string& inits() { return mInits; }
-
-        void insertInits(OutputFormatHelper& outputFormatHelper)
-        {
-            if(not mInits.empty()) {
-                outputFormatHelper.Append(mInits);
-                mInits.clear();
-            }
+        LambdaCallerType    callerType() const { return mLambdaCallerType; }
+        void                setCallerType(LambdaCallerType lambdaCallerType) { mLambdaCallerType = lambdaCallerType; }
+        bool                insertName() const
+        {  // do we require the name or only the datatype?
+            return (mLambdaCallerType != LambdaCallerType::Decltype) and
+                   (mLambdaCallerType != LambdaCallerType::LambdaExpr);
         }
 
-        LambdaCallerType callerType() const { return mLambdaCallerType; }
-        bool             insertName() const { return (LambdaCallerType::Decltype != mLambdaCallerType) or mForceName; }
-
-        void setInsertName(bool b) { mForceName = b; }
-
     private:
-        const LambdaCallerType mLambdaCallerType;
-        const size_t           mCurrentVarDeclPos;
-        OutputFormatHelper&    mOutputFormatHelper;
-        OutputFormatHelper     mLambdaOutputFormatHelper{};
-        std::string            mInits{};
-        bool                   mForceName{};
+        LambdaCallerType    mLambdaCallerType{};
+        const size_t        mCurrentDeclPos{};
+        OutputFormatHelper& mOutputFormatHelper;
+        OutputFormatHelper  mLambdaOutputFormatHelper{};
     };
     //-----------------------------------------------------------------------------
 
     using LambdaStackType = StackList<class LambdaHelper>;
 
-    STRONG_BOOL(LambdaInInitCapture);  ///! Signal whether we are processing a lambda created and assigned to an init
-                                       /// capture of another lambda.
-
     STRONG_BOOL(
         ProcessingPrimaryTemplate);  ///! We do not want to transform a primary template which contains a Coroutine.
-
-    constexpr CodeGenerator(OutputFormatHelper&       _outputFormatHelper,
-                            LambdaStackType&          lambdaStack,
-                            LambdaInInitCapture       lambdaInitCapture,
-                            ProcessingPrimaryTemplate processingPrimaryTemplate)
-    : mOutputFormatHelper{_outputFormatHelper}
-    , mLambdaStack{lambdaStack}
-    , mLambdaInitCapture{lambdaInitCapture}
-    , mProcessingPrimaryTemplate{processingPrimaryTemplate}
-    {
-    }
 
 public:
     explicit constexpr CodeGenerator(OutputFormatHelper& _outputFormatHelper)
@@ -188,15 +163,12 @@ public:
     {
     }
 
-    constexpr CodeGenerator(OutputFormatHelper& _outputFormatHelper, LambdaInInitCapture lambdaInitCapture)
-    : CodeGenerator{_outputFormatHelper, mLambdaStackThis, lambdaInitCapture, ProcessingPrimaryTemplate::No}
-    {
-    }
-
     constexpr CodeGenerator(OutputFormatHelper&       _outputFormatHelper,
                             LambdaStackType&          lambdaStack,
                             ProcessingPrimaryTemplate processingPrimaryTemplate)
-    : CodeGenerator{_outputFormatHelper, lambdaStack, LambdaInInitCapture::No, processingPrimaryTemplate}
+    : mOutputFormatHelper{_outputFormatHelper}
+    , mLambdaStack{lambdaStack}
+    , mProcessingPrimaryTemplate{processingPrimaryTemplate}
     {
     }
 
@@ -420,7 +392,6 @@ protected:
         OutputFormatHelper& GetBuffer(OutputFormatHelper& outputFormatHelper) const;
     };
 
-    void               HandleLambdaExpr(const LambdaExpr* stmt, LambdaHelper& lambdaHelper);
     static std::string FillConstantArray(const ConstantArrayType* ct, const std::string& value, const uint64_t startAt);
     static std::string GetValueOfValueInit(const QualType& t);
 
@@ -433,7 +404,6 @@ protected:
     STRONG_BOOL(UseCommaInsteadOfSemi);
     STRONG_BOOL(NoEmptyInitList);
     STRONG_BOOL(ShowConstantExprValue);
-    LambdaInInitCapture mLambdaInitCapture{LambdaInInitCapture::No};
 
     ShowConstantExprValue mShowConstantExprValue{ShowConstantExprValue::No};
     SkipVarDecl           mSkipVarDecl{SkipVarDecl::No};
@@ -458,18 +428,6 @@ protected:
     bool mSkipSemi{};
     ProcessingPrimaryTemplate                 mProcessingPrimaryTemplate{};
     static inline std::map<std::string, bool> mSeenDecls{};
-};
-//-----------------------------------------------------------------------------
-
-class LambdaCodeGenerator final : public CodeGenerator
-{
-public:
-    using CodeGenerator::CodeGenerator;
-
-    using CodeGenerator::InsertArg;
-    void InsertArg(const CXXThisExpr* stmt) override;
-
-    bool mCapturedThisAsCopy{};
 };
 //-----------------------------------------------------------------------------
 
@@ -679,7 +637,7 @@ class CodeGeneratorVariant
         CodeGenerators(OutputFormatHelper&                      _outputFormatHelper,
                        CodeGenerator::LambdaStackType&          lambdaStack,
                        CodeGenerator::ProcessingPrimaryTemplate processingPrimaryTemplate);
-        CodeGenerators(OutputFormatHelper& _outputFormatHelper, CodeGenerator::LambdaInInitCapture lambdaInitCapture);
+        CodeGenerators(OutputFormatHelper& _outputFormatHelper);
 
         ~CodeGenerators();
     } cgs;
@@ -690,11 +648,6 @@ class CodeGeneratorVariant
     void Set();
 
 public:
-    CodeGeneratorVariant(OutputFormatHelper& _outputFormatHelper)
-    : CodeGeneratorVariant{_outputFormatHelper, CodeGenerator::LambdaInInitCapture::No}
-    {
-    }
-
     CodeGeneratorVariant(OutputFormatHelper&                      _outputFormatHelper,
                          CodeGenerator::LambdaStackType&          lambdaStack,
                          CodeGenerator::ProcessingPrimaryTemplate processingPrimaryTemplate)
@@ -705,8 +658,8 @@ public:
         Set();
     }
 
-    CodeGeneratorVariant(OutputFormatHelper& _outputFormatHelper, CodeGenerator::LambdaInInitCapture lambdaInitCapture)
-    : cgs{_outputFormatHelper, lambdaInitCapture}
+    CodeGeneratorVariant(OutputFormatHelper& _outputFormatHelper)
+    : cgs{_outputFormatHelper}
     , ofm{_outputFormatHelper}
     , cg{}
     {

--- a/InsightsStaticStrings.h
+++ b/InsightsStaticStrings.h
@@ -99,6 +99,7 @@ consteval std::string_view KwWithNoSpace(std::string_view kw)
     return kw;
 }
 
+inline constexpr std::string_view kwConstExpr{KW_CONSTEXPR};
 inline constexpr std::string_view kwNoexcept{KW_NOEXCEPT};
 inline constexpr std::string_view kwRequires{KW_REQUIRES};
 inline constexpr std::string_view kwPublic{KW_PUBLIC};

--- a/tests/Basic.Start.Main.P5.3Test.expect
+++ b/tests/Basic.Start.Main.P5.3Test.expect
@@ -21,9 +21,8 @@ int main()
       return __lambda_3_13{}.operator()();
     }
     
-    
-  } __lambda_3_13{};
+  };
   
-  int x = __lambda_3_13.operator()();
+  int x = __lambda_3_13{}.operator()();
   return 0;
 }

--- a/tests/Basic.Start.Main.P5.4Test.expect
+++ b/tests/Basic.Start.Main.P5.4Test.expect
@@ -25,9 +25,8 @@ int main(int argc, const char ** argv)
       return __lambda_5_13{}.operator()();
     }
     
-    
-  } __lambda_5_13{};
+  };
   
-  int x = __lambda_5_13.operator()();
+  int x = __lambda_5_13{}.operator()();
   return 0;
 }

--- a/tests/ClassOperatorHandler2Test.expect
+++ b/tests/ClassOperatorHandler2Test.expect
@@ -112,10 +112,9 @@ int main()
       __lambda_60_5{}.operator()();
     }
     
-    
-  } __lambda_60_5{};
+  };
   
-  __lambda_60_5.operator()();
+  __lambda_60_5{}.operator()();
   int n = 10;
   f(n);
   f(42);

--- a/tests/ConstevalTest.expect
+++ b/tests/ConstevalTest.expect
@@ -40,8 +40,7 @@ class __lambda_16_15
   
   
   public:
-  // /*constexpr */ __lambda_16_15() = default;
-  
-} __lambda_16_15{};
+  // /* constexpr */ __lambda_16_15() = default;
+};
 
-/* PASSED: static_assert(__lambda_16_15.operator()()); */
+/* PASSED: static_assert(__lambda_16_15{}.operator()()); */

--- a/tests/ConstraintAutoParameterTest.expect
+++ b/tests/ConstraintAutoParameterTest.expect
@@ -26,8 +26,7 @@ class __lambda_6_15
   }
   
   public:
-  // /*constexpr */ __lambda_6_15() = default;
-  
+  // /* constexpr */ __lambda_6_15() = default;
 };
 
 __lambda_6_15 lambda = __lambda_6_15{};

--- a/tests/EduCoroutineWithLambdaTest.cerr
+++ b/tests/EduCoroutineWithLambdaTest.cerr
@@ -4,8 +4,8 @@
 .tmp.cpp:79:9: note: in instantiation of member function 'SyncAwait(std::suspend_always &&)::__lambda_45_24::operator()' requested here
    79 |   class __lambda_45_24
       |         ^
-.tmp.cpp:232:3: note: in instantiation of function template specialization 'SyncAwait<std::suspend_always>' requested here
-  232 |   SyncAwait(std::suspend_always{});
+.tmp.cpp:225:3: note: in instantiation of function template specialization 'SyncAwait<std::suspend_always>' requested here
+  225 |   SyncAwait(std::suspend_always{});
       |   ^
 .tmp.cpp:76:25: note: 'a' declared here
    76 | void SyncAwait(_AwrT && a)

--- a/tests/EduCoroutineWithLambdaTest.expect
+++ b/tests/EduCoroutineWithLambdaTest.expect
@@ -84,7 +84,6 @@ void SyncAwait(_AwrT && a)
       co_await a;
     }
     
-    
   };
   
   auto asyncLambda = __lambda_45_24{};
@@ -211,14 +210,8 @@ inline generator operator()() const
     }
     
     
-    private: 
+    // private: 
     std::suspend_always & a;
-    
-    public:
-    __lambda_45_24(std::suspend_always & _a)
-    : a{_a}
-    {}
-    
   };
   
   __lambda_45_24 asyncLambda = __lambda_45_24{a};

--- a/tests/EmptyLambda.expect
+++ b/tests/EmptyLambda.expect
@@ -20,8 +20,7 @@ void foo()
       __lambda_2_1{}.operator()();
     }
     
-    
-  } __lambda_2_1{};
+  };
   
-  __lambda_2_1.operator()();
+  __lambda_2_1{}.operator()();
 }

--- a/tests/ForStmtWithLambdaInInitTest.expect
+++ b/tests/ForStmtWithLambdaInInitTest.expect
@@ -12,17 +12,11 @@ int main()
       return x * 2;
     }
     
-    private: 
+    // private: 
     int & x;
-    
-    public:
-    __lambda_7_17(int & _x)
-    : x{_x}
-    {}
-    
-  } __lambda_7_17{x};
+  };
   
-  for(int i = __lambda_7_17.operator()(); i < 20; ++i) {
+  for(int i = __lambda_7_17{x}.operator()(); i < 20; ++i) {
     x = x + i;
   }
   
@@ -35,15 +29,9 @@ int main()
       return x * 2;
     }
     
-    private: 
+    // private: 
     int & x;
-    
-    public:
-    __lambda_11_17(int & _x)
-    : x{_x}
-    {}
-    
-  } __lambda_11_17{x};
+  };
   
     
   class __lambda_11_43
@@ -54,17 +42,11 @@ int main()
       return x * 2;
     }
     
-    private: 
+    // private: 
     int & x;
-    
-    public:
-    __lambda_11_43(int & _x)
-    : x{_x}
-    {}
-    
-  } __lambda_11_43{x};
+  };
   
-  for(int i = __lambda_11_17.operator()(), z = __lambda_11_43.operator()(); i < 20; ++i) {
+  for(int i = __lambda_11_17{x}.operator()(), z = __lambda_11_43{x}.operator()(); i < 20; ++i) {
     x = x + i;
   }
   
@@ -89,8 +71,7 @@ int main()
       __lambda_15_9{}.operator()();
     }
     
-    
-  } __lambda_15_9{};
+  };
   
     
   class __lambda_15_37
@@ -101,15 +82,9 @@ int main()
       return --x;
     }
     
-    private: 
+    // private: 
     int & x;
-    
-    public:
-    __lambda_15_37(int & _x)
-    : x{_x}
-    {}
-    
-  } __lambda_15_37{x};
+  };
   
     
   class __lambda_15_59
@@ -132,10 +107,9 @@ int main()
       __lambda_15_59{}.operator()();
     }
     
-    
-  } __lambda_15_59{};
+  };
   
-  for(__lambda_15_9.operator()(); static_cast<bool>(__lambda_15_37.operator()()); __lambda_15_59.operator()()) {
+  for(__lambda_15_9{}.operator()(); static_cast<bool>(__lambda_15_37{x}.operator()()); __lambda_15_59{}.operator()()) {
   }
   
       
@@ -159,8 +133,7 @@ int main()
       __lambda_19_9{}.operator()();
     }
     
-    
-  } __lambda_19_9{};
+  };
   
     
   class __lambda_20_9
@@ -183,8 +156,7 @@ int main()
       __lambda_20_9{}.operator()();
     }
     
-    
-  } __lambda_20_9{};
+  };
   
     
   class __lambda_20_37
@@ -195,15 +167,9 @@ int main()
       return --x;
     }
     
-    private: 
+    // private: 
     int & x;
-    
-    public:
-    __lambda_20_37(int & _x)
-    : x{_x}
-    {}
-    
-  } __lambda_20_37{x};
+  };
   
     
   class __lambda_20_59
@@ -226,10 +192,9 @@ int main()
       __lambda_20_59{}.operator()();
     }
     
-    
-  } __lambda_20_59{};
+  };
   
-  for(__lambda_19_9.operator()() , __lambda_20_9.operator()(); static_cast<bool>(__lambda_20_37.operator()()); __lambda_20_59.operator()()) {
+  for(__lambda_19_9{}.operator()() , __lambda_20_9{}.operator()(); static_cast<bool>(__lambda_20_37{x}.operator()()); __lambda_20_59{}.operator()()) {
   }
   
   return 0;

--- a/tests/IfStmtWithLambdaInInitTest.expect
+++ b/tests/IfStmtWithLambdaInInitTest.expect
@@ -22,10 +22,9 @@ int main()
         return __lambda_3_14{}.operator()();
       }
       
-      
-    } __lambda_3_14{};
+    };
     
-    int x = __lambda_3_14.operator()();
+    int x = __lambda_3_14{}.operator()();
             
     class __lambda_3_34
     {
@@ -47,10 +46,9 @@ int main()
         return __lambda_3_34{}.operator()();
       }
       
-      
-    } __lambda_3_34{};
+    };
     
-    int y = __lambda_3_34.operator()();
+    int y = __lambda_3_34{}.operator()();
             
     class __lambda_3_53
     {
@@ -72,10 +70,9 @@ int main()
         return __lambda_3_53{}.operator()();
       }
       
-      
-    } __lambda_3_53{};
+    };
     
-    int z = __lambda_3_53.operator()();
+    int z = __lambda_3_53{}.operator()();
     if(true) {
     } 
     

--- a/tests/Issue102.cerr
+++ b/tests/Issue102.cerr
@@ -4,16 +4,16 @@
 .tmp.cpp:403:31: error: unknown type name 'retType_73_4'
   403 |     inline constexpr operator retType_73_4 () const noexcept
       |                               ^
-.tmp.cpp:427:26: error: 'auto' not allowed in type alias
-  427 |     using retType_74_4 = auto (*)(int);
+.tmp.cpp:426:26: error: 'auto' not allowed in type alias
+  426 |     using retType_74_4 = auto (*)(int);
       |                          ^~~~
-.tmp.cpp:428:31: error: unknown type name 'retType_74_4'
-  428 |     inline constexpr operator retType_74_4 () const noexcept
+.tmp.cpp:427:31: error: unknown type name 'retType_74_4'
+  427 |     inline constexpr operator retType_74_4 () const noexcept
       |                               ^
-.tmp.cpp:446:5: error: templates cannot be declared inside of a local class
-  446 |     template<class type_parameter_1_0>
+.tmp.cpp:444:5: error: templates cannot be declared inside of a local class
+  444 |     template<class type_parameter_1_0>
       |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-.tmp.cpp:453:5: error: templates cannot be declared inside of a local class
-  453 |     template<class type_parameter_1_0>
+.tmp.cpp:451:5: error: templates cannot be declared inside of a local class
+  451 |     template<class type_parameter_1_0>
       |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 6 errors generated.

--- a/tests/Issue102.expect
+++ b/tests/Issue102.expect
@@ -411,7 +411,6 @@ decltype(auto) test(T && value)
       return __lambda_73_4{}.operator()(value);
     }
     
-    
   };
   
   
@@ -436,7 +435,6 @@ decltype(auto) test(T && value)
       return __lambda_74_4{}.operator()(i);
     }
     
-    
   };
   
   
@@ -455,7 +453,6 @@ decltype(auto) test(T && value)
     {
       return __lambda_75_4{}.operator()<type_parameter_1_0>(a);
     }
-    
   };
   
   return match(value, __lambda_73_4{}, __lambda_74_4{}, __lambda_75_4{});
@@ -487,7 +484,6 @@ int test<int>(int && value)
       return __lambda_73_4{}.operator()(value);
     }
     
-    
   };
   
   
@@ -512,7 +508,6 @@ int test<int>(int && value)
       return __lambda_74_4{}.operator()(i);
     }
     
-    
   };
   
   
@@ -531,7 +526,6 @@ int test<int>(int && value)
     {
       return __lambda_75_4{}.operator()<type_parameter_0_0>(a);
     }
-    
   };
   
   return match(value, __lambda_73_4{}, __lambda_74_4{}, __lambda_75_4{});
@@ -565,7 +559,6 @@ int test<const char (&)[3]>(const char (&value)[3])
       return __lambda_73_4{}.operator()(value);
     }
     
-    
   };
   
   
@@ -589,7 +582,6 @@ int test<const char (&)[3]>(const char (&value)[3])
     {
       return __lambda_74_4{}.operator()(i);
     }
-    
     
   };
   
@@ -619,7 +611,6 @@ int test<const char (&)[3]>(const char (&value)[3])
     {
       return __lambda_75_4{}.operator()<type_parameter_0_0>(a);
     }
-    
   };
   
   return match(value, __lambda_73_4{}, __lambda_74_4{}, __lambda_75_4{});
@@ -653,7 +644,6 @@ std::basic_string<char, std::char_traits<char>, std::allocator<char> > test<std:
       return __lambda_73_4{}.operator()(value);
     }
     
-    
   };
   
   
@@ -678,7 +668,6 @@ std::basic_string<char, std::char_traits<char>, std::allocator<char> > test<std:
       return __lambda_74_4{}.operator()(i);
     }
     
-    
   };
   
   
@@ -697,7 +686,6 @@ std::basic_string<char, std::char_traits<char>, std::allocator<char> > test<std:
     {
       return __lambda_75_4{}.operator()<type_parameter_0_0>(a);
     }
-    
   };
   
   return match(value, __lambda_73_4{}, __lambda_74_4{}, __lambda_75_4{});

--- a/tests/Issue127.expect
+++ b/tests/Issue127.expect
@@ -12,7 +12,6 @@ class __lambda_1_10
   {
     return __lambda_1_10{}.operator()<type_parameter_0_0>(__param0);
   }
-  
 };
 
 __lambda_1_10 f = __lambda_1_10{};

--- a/tests/Issue176.expect
+++ b/tests/Issue176.expect
@@ -26,8 +26,7 @@ class __lambda_6_12
   }
   
   public:
-  // /*constexpr */ __lambda_6_12() = default;
-  
+  // /* constexpr */ __lambda_6_12() = default;
 };
 
 __lambda_6_12 foo = __lambda_6_12{};

--- a/tests/Issue2.expect
+++ b/tests/Issue2.expect
@@ -32,20 +32,15 @@ int main()
     {
     }
     
-    private: 
+    // private: 
     Movable x;
     int c;
     public: 
     // inline __lambda_20_16(const __lambda_20_16 &) /* noexcept */ = delete;
     // inline __lambda_20_16 & operator=(const __lambda_20_16 &) /* noexcept */ = delete;
-    __lambda_20_16(Movable && _x, int & _c)
-    : x{std::move(_x)}
-    , c{_c}
-    {}
-    
   };
   
-  __lambda_20_16 fun = __lambda_20_16{Movable(std::move(m)), e};
+  __lambda_20_16 fun = __lambda_20_16{std::move(m), e};
   fun.operator()();
     
   class __lambda_24_16
@@ -55,14 +50,8 @@ int main()
     {
     }
     
-    private: 
+    // private: 
     int c;
-    
-    public:
-    __lambda_24_16(int && _c)
-    : c{std::move(_c)}
-    {}
-    
   };
   
   __lambda_24_16 bun = __lambda_24_16{std::move(e)};

--- a/tests/Issue205.expect
+++ b/tests/Issue205.expect
@@ -19,16 +19,12 @@ class EventContainer
       std::cout.operator<<(__this->val);
     }
     
-    private: 
+    // private: 
     EventContainer * __this;
     public: 
     // inline /*constexpr */ __lambda_6_43(const __lambda_6_43 &) noexcept = default;
     // inline /*constexpr */ __lambda_6_43(__lambda_6_43 &&) noexcept = default;
-    __lambda_6_43(EventContainer * _this)
-    : __this{_this}
-    {}
-    
-  } __lambda_6_43{this};
+  };
   
   // inline constexpr EventContainer() noexcept(false) = default;
 };

--- a/tests/Issue205_2.expect
+++ b/tests/Issue205_2.expect
@@ -17,20 +17,16 @@ class EventContainer
       std::cout.operator<<(__this->val);
     }
     
-    private: 
+    // private: 
     EventContainer * __this;
     public: 
     // inline /*constexpr */ __lambda_6_43(const __lambda_6_43 &) noexcept = default;
     // inline /*constexpr */ __lambda_6_43(__lambda_6_43 &&) noexcept = default;
-    __lambda_6_43(EventContainer * _this)
-    : __this{_this}
-    {}
-    
-  } __lambda_6_43{this};
+  };
   
   inline EventContainer()
   : val{1235}
-  , something{std::function<void ()>(__lambda_6_43)}
+  , something{std::function<void ()>(__lambda_6_43{this})}
   {
   }
   

--- a/tests/Issue238.expect
+++ b/tests/Issue238.expect
@@ -21,7 +21,6 @@ void f()
     {
       return __lambda_1_26{}.operator()<type_parameter_0_0>(container);
     }
-    
   };
   
   __lambda_1_26 lambda = __lambda_1_26{};

--- a/tests/Issue238_2.cerr
+++ b/tests/Issue238_2.cerr
@@ -7,7 +7,7 @@
 .tmp.cpp:56:16: error: declaration of variable 'test' with deduced type 'auto' requires an initializer
    56 |           auto test;
       |                ^
-.tmp.cpp:89:10: error: no matching member function for call to 'operator()'
-   89 |   lambda.operator()(MyArrayWrapper<int>(vec));
+.tmp.cpp:88:10: error: no matching member function for call to 'operator()'
+   88 |   lambda.operator()(MyArrayWrapper<int>(vec));
       |   ~~~~~~~^~~~~~~~~~
 4 errors generated.

--- a/tests/Issue238_2.expect
+++ b/tests/Issue238_2.expect
@@ -81,7 +81,6 @@ void f()
     {
       return __lambda_15_17{}.operator()<type_parameter_0_0>(container);
     }
-    
   };
   
   __lambda_15_17 lambda = __lambda_15_17{};

--- a/tests/Issue238_3.expect
+++ b/tests/Issue238_3.expect
@@ -24,8 +24,7 @@ void f()
     }
     
     public:
-    // /*constexpr */ __lambda_2_26() = default;
-    
+    // /* constexpr */ __lambda_2_26() = default;
   };
   
   __lambda_2_26 lambda = __lambda_2_26{};

--- a/tests/Issue258.expect
+++ b/tests/Issue258.expect
@@ -13,18 +13,14 @@ int main()
       std::operator<<(std::cout.operator<<(x.operator*()), '\n');
     }
     
-    private: 
+    // private: 
     std::unique_ptr<int, std::default_delete<int> > x;
     public: 
     // inline /*constexpr */ __lambda_7_19(const __lambda_7_19 &) /* noexcept */ = delete;
     // inline __lambda_7_19 & operator=(const __lambda_7_19 &) /* noexcept */ = delete;
     // inline ~__lambda_7_19() noexcept = default;
-    __lambda_7_19(std::unique_ptr<int, std::default_delete<int> > && _x)
-    : x{std::move(_x)}
-    {}
-    
   };
   
-  __lambda_7_19 lambda = __lambda_7_19{std::unique_ptr<int, std::default_delete<int> >(std::move(x))};
+  __lambda_7_19 lambda = __lambda_7_19{std::move(x)};
   return 0;
 }

--- a/tests/Issue258_2.expect
+++ b/tests/Issue258_2.expect
@@ -34,17 +34,13 @@ int main()
       printf("%d\n", x.Get());
     }
     
-    private: 
+    // private: 
     NonMoveable x;
     public: 
     // inline __lambda_22_19(const __lambda_22_19 &) /* noexcept */ = delete;
     // inline __lambda_22_19 & operator=(const __lambda_22_19 &) /* noexcept */ = delete;
-    __lambda_22_19(NonMoveable && _x)
-    : x{static_cast<NonMoveable &&>(_x)}
-    {}
-    
   };
   
-  __lambda_22_19 lambda = __lambda_22_19{NonMoveable(static_cast<NonMoveable &&>(x))};
+  __lambda_22_19 lambda = __lambda_22_19{static_cast<NonMoveable &&>(x)};
   return 0;
 }

--- a/tests/Issue264.expect
+++ b/tests/Issue264.expect
@@ -22,7 +22,6 @@ class __lambda_2_10
   {
     return __lambda_2_10{}.operator()<type_parameter_0_0... >(i...);
   }
-  
 };
 
 __lambda_2_10 f = __lambda_2_10{};
@@ -50,7 +49,6 @@ class __lambda_3_10
   {
     return __lambda_3_10{}.operator()<type_parameter_0_0... >(i...);
   }
-  
 };
 
 __lambda_3_10 g = __lambda_3_10{};

--- a/tests/Issue288.cerr
+++ b/tests/Issue288.cerr
@@ -7,32 +7,20 @@
 .tmp.cpp:20:7: error: 'auto' not allowed in non-static class member
    20 |       auto ex2;
       |       ^~~~
-.tmp.cpp:23:22: error: 'auto' not allowed in function prototype
-   23 |       __lambda_10_10(auto _ex1, auto _ex2)
-      |                      ^~~~
-.tmp.cpp:23:33: error: 'auto' not allowed in function prototype
-   23 |       __lambda_10_10(auto _ex1, auto _ex2)
-      |                                 ^~~~
-.tmp.cpp:39:7: error: templates cannot be declared inside of a local class
-   39 |       template<class type_parameter_1_0>
+.tmp.cpp:32:7: error: templates cannot be declared inside of a local class
+   32 |       template<class type_parameter_1_0>
       |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-.tmp.cpp:45:7: error: 'auto' not allowed in non-static class member
-   45 |       auto ex1;
+.tmp.cpp:38:7: error: 'auto' not allowed in non-static class member
+   38 |       auto ex1;
       |       ^~~~
-.tmp.cpp:46:7: error: 'auto' not allowed in non-static class member
-   46 |       auto ex2;
+.tmp.cpp:39:7: error: 'auto' not allowed in non-static class member
+   39 |       auto ex2;
       |       ^~~~
-.tmp.cpp:49:22: error: 'auto' not allowed in function prototype
-   49 |       __lambda_20_10(auto _ex1, auto _ex2)
-      |                      ^~~~
-.tmp.cpp:49:33: error: 'auto' not allowed in function prototype
-   49 |       __lambda_20_10(auto _ex1, auto _ex2)
-      |                                 ^~~~
-.tmp.cpp:158:3: error: unknown type name '__lambda_20_10'; did you mean 'expressions::__lambda_27_16'?
-  158 |   __lambda_20_10 f = expressions::operator&&(expressions::Gt_10, expressions::Lt_20);
+.tmp.cpp:137:3: error: unknown type name '__lambda_20_10'; did you mean 'expressions::__lambda_27_16'?
+  137 |   __lambda_20_10 f = expressions::operator&&(expressions::Gt_10, expressions::Lt_20);
       |   ^~~~~~~~~~~~~~
       |   expressions::__lambda_27_16
-.tmp.cpp:98:9: note: 'expressions::__lambda_27_16' declared here
-   98 |   class __lambda_27_16
+.tmp.cpp:79:9: note: 'expressions::__lambda_27_16' declared here
+   79 |   class __lambda_27_16
       |         ^
-11 errors generated.
+7 errors generated.

--- a/tests/Issue288.expect
+++ b/tests/Issue288.expect
@@ -15,19 +15,12 @@ namespace expressions
       {
         return (operator||(ex1(std::forward<decltype(val)>(val)), ex2(std::forward<decltype(val)>(val))));
       }
-      private: 
+      // private: 
       auto ex1;
       auto ex2;
-      
-      public:
-      __lambda_10_10(auto _ex1, auto _ex2)
-      : ex1{_ex1}
-      , ex2{_ex2}
-      {}
-      
-    } __lambda_10_10{std::move(ex1), std::move(ex2)};
+    };
     
-    return __lambda_10_10;
+    return __lambda_10_10{std::move(ex1), std::move(ex2)};
   }
   template<class Expr1, class Expr2>
   auto operator&&(Expr1 && ex1, Expr2 && ex2)
@@ -41,19 +34,12 @@ namespace expressions
       {
         return (operator&&(ex1(std::forward<decltype(val)>(val)), ex2(std::forward<decltype(val)>(val))));
       }
-      private: 
+      // private: 
       auto ex1;
       auto ex2;
-      
-      public:
-      __lambda_20_10(auto _ex1, auto _ex2)
-      : ex1{_ex1}
-      , ex2{_ex2}
-      {}
-      
-    } __lambda_20_10{std::move(ex1), std::move(ex2)};
+    };
     
-    return __lambda_20_10;
+    return __lambda_20_10{std::move(ex1), std::move(ex2)};
   }
   
   #ifdef INSIGHTS_USE_TEMPLATE
@@ -78,19 +64,14 @@ namespace expressions
       }
       #endif
       
-      private: 
+      // private: 
       __lambda_27_16 ex1;
       __lambda_32_16 ex2;
       public: 
       // inline /*constexpr */ __lambda_20_10 & operator=(const __lambda_20_10 &) /* noexcept */ = delete;
-      __lambda_20_10(__lambda_27_16 && _ex1, __lambda_32_16 && _ex2)
-      : ex1{std::move(_ex1)}
-      , ex2{std::move(_ex2)}
-      {}
-      
-    } __lambda_20_10{__lambda_27_16(std::move(ex1)), __lambda_32_16(std::move(ex2))};
+    };
     
-    return __lambda_20_10;
+    return __lambda_20_10{std::move(ex1), std::move(ex2)};
   }
   #endif
   
@@ -118,7 +99,6 @@ namespace expressions
     public: 
     // inline /*constexpr */ __lambda_27_16(__lambda_27_16 &&) noexcept = default;
     // inline /*constexpr */ __lambda_27_16 & operator=(const __lambda_27_16 &) /* noexcept */ = delete;
-    
   };
   
   __lambda_27_16 Gt_10 = __lambda_27_16{};
@@ -146,7 +126,6 @@ namespace expressions
     public: 
     // inline /*constexpr */ __lambda_32_16(__lambda_32_16 &&) noexcept = default;
     // inline /*constexpr */ __lambda_32_16 & operator=(const __lambda_32_16 &) /* noexcept */ = delete;
-    
   };
   
   __lambda_32_16 Lt_20 = __lambda_32_16{};

--- a/tests/Issue3.expect
+++ b/tests/Issue3.expect
@@ -26,7 +26,6 @@ void x()
           __lambda_4_5{}.operator()();
         }
         
-        
       };
       
       __lambda_4_5{};
@@ -43,7 +42,6 @@ void x()
     {
       __lambda_3_12{}.operator()();
     }
-    
     
   };
   

--- a/tests/Issue344.expect
+++ b/tests/Issue344.expect
@@ -20,8 +20,7 @@ int main()
       __lambda_3_3{}.operator()();
     }
     
-    
-  } __lambda_3_3{};
+  };
   
   return 0;
 }

--- a/tests/Issue347.expect
+++ b/tests/Issue347.expect
@@ -11,15 +11,11 @@ int main()
     {
     }
     
-    private: 
+    // private: 
     std::basic_string<char, std::char_traits<char>, std::allocator<char> > str;
     public: 
     // inline __lambda_5_12 & operator=(const __lambda_5_12 &) /* noexcept */ = delete;
     // inline ~__lambda_5_12() noexcept = default;
-    __lambda_5_12(const std::basic_string<char, std::char_traits<char>, std::allocator<char> > & _str)
-    : str{_str}
-    {}
-    
   };
   
   __lambda_5_12 foo = __lambda_5_12{str};

--- a/tests/Issue347_2.expect
+++ b/tests/Issue347_2.expect
@@ -11,15 +11,11 @@ int main()
     {
     }
     
-    private: 
+    // private: 
     const std::basic_string<char, std::char_traits<char>, std::allocator<char> > str;
     public: 
     // inline __lambda_5_12 & operator=(const __lambda_5_12 &) /* noexcept */ = delete;
     // inline ~__lambda_5_12() noexcept = default;
-    __lambda_5_12(const std::basic_string<char, std::char_traits<char>, std::allocator<char> > & _str)
-    : str{_str}
-    {}
-    
   };
   
   __lambda_5_12 foo = __lambda_5_12{str};

--- a/tests/Issue369_1.expect
+++ b/tests/Issue369_1.expect
@@ -32,8 +32,7 @@ const foo & create()
       return __lambda_4_23{}.operator()();
     }
     
-    
-  } __lambda_4_23{};
+  };
   
   static uint64_t __valueGuard;
   alignas(foo) static char __value[sizeof(foo)];
@@ -42,7 +41,7 @@ const foo & create()
     if(__cxa_guard_acquire(&__valueGuard)) {
       try 
       {
-        new (&__value)foo{std::move(__lambda_4_23.operator()())};
+        new (&__value)foo{std::move(__lambda_4_23{}.operator()())};
         __valueGuard = true;
       } catch(...) {
         __cxa_guard_abort(&__valueGuard);

--- a/tests/Issue369_2.expect
+++ b/tests/Issue369_2.expect
@@ -32,15 +32,14 @@ const void withNoexcept()
       return __lambda_4_23{}.operator()();
     }
     
-    
-  } __lambda_4_23{};
+  };
   
   static uint64_t __valueGuard;
   alignas(foo) static char __value[sizeof(foo)];
   
   if((__valueGuard & 255) == 0) {
     if(__cxa_guard_acquire(&__valueGuard)) {
-      new (&__value)foo{std::move(__lambda_4_23.operator()())};
+      new (&__value)foo{std::move(__lambda_4_23{}.operator()())};
       __valueGuard = true;
       __cxa_guard_release(&__valueGuard);
       /* __cxa_atexit(foo::~foo, &__value, &__dso_handle); */
@@ -73,8 +72,7 @@ const void withNoexceptFalse()
       return __lambda_8_23{}.operator()();
     }
     
-    
-  } __lambda_8_23{};
+  };
   
   static uint64_t __valueGuard;
   alignas(foo) static char __value[sizeof(foo)];
@@ -83,7 +81,7 @@ const void withNoexceptFalse()
     if(__cxa_guard_acquire(&__valueGuard)) {
       try 
       {
-        new (&__value)foo{std::move(__lambda_8_23.operator()())};
+        new (&__value)foo{std::move(__lambda_8_23{}.operator()())};
         __valueGuard = true;
       } catch(...) {
         __cxa_guard_abort(&__valueGuard);
@@ -120,15 +118,14 @@ const void withNoexceptTrue()
       return __lambda_12_23{}.operator()();
     }
     
-    
-  } __lambda_12_23{};
+  };
   
   static uint64_t __valueGuard;
   alignas(foo) static char __value[sizeof(foo)];
   
   if((__valueGuard & 255) == 0) {
     if(__cxa_guard_acquire(&__valueGuard)) {
-      new (&__value)foo{std::move(__lambda_12_23.operator()())};
+      new (&__value)foo{std::move(__lambda_12_23{}.operator()())};
       __valueGuard = true;
       __cxa_guard_release(&__valueGuard);
       /* __cxa_atexit(foo::~foo, &__value, &__dso_handle); */
@@ -166,10 +163,9 @@ const void withNoexceptNoexceptCtor()
       return __lambda_19_23{}.operator()();
     }
     
-    
-  } __lambda_19_23{};
+  };
   
-  static buh value = __lambda_19_23.operator()();
+  static buh value = __lambda_19_23{}.operator()();
 }
 
 foo func()

--- a/tests/Issue379.expect
+++ b/tests/Issue379.expect
@@ -14,16 +14,9 @@ struct C
         return __this->m + a;
       }
       
-      private: 
+      // private: 
       C * __this;
       int & a;
-      
-      public:
-      __lambda_6_19(C * _this, int & _a)
-      : __this{_this}
-      , a{_a}
-      {}
-      
     };
     
     const __lambda_6_19 b = __lambda_6_19{this, a};

--- a/tests/Issue386.cerr
+++ b/tests/Issue386.cerr
@@ -4,7 +4,4 @@
 .tmp.cpp:26:11: error: 'auto' not allowed in non-static class member
    26 |           auto rhs;
       |           ^~~~
-.tmp.cpp:29:48: error: 'auto' not allowed in function prototype
-   29 |           __lambda_15_17(vector<T, N> * _this, auto _rhs)
-      |                                                ^~~~
-3 errors generated.
+2 errors generated.

--- a/tests/Issue386.expect
+++ b/tests/Issue386.expect
@@ -21,16 +21,9 @@ namespace tnt
           {
             ((__this->data[I] = std::exchange(rhs.data[I], U(0))) , ...);
           }
-          private: 
+          // private: 
           vector<T, N> * __this;
           auto rhs;
-          
-          public:
-          __lambda_15_17(vector<T, N> * _this, auto _rhs)
-          : __this{_this}
-          , rhs{_rhs}
-          {}
-          
         };
         
         __lambda_15_17{this, std::move(rhs)}(std::make_index_sequence<S>{});

--- a/tests/Issue386_2.expect
+++ b/tests/Issue386_2.expect
@@ -21,10 +21,9 @@ int main()
         __lambda_3_14{}.operator()();
       }
       
-      
-    } __lambda_3_14{};
+    };
     
-    __lambda_3_14.operator()();
+    __lambda_3_14{}.operator()();
   } 
   
   for(; false; ) {
@@ -48,10 +47,9 @@ int main()
         __lambda_5_18{}.operator()();
       }
       
-      
-    } __lambda_5_18{};
+    };
     
-    __lambda_5_18.operator()();
+    __lambda_5_18{}.operator()();
   }
   
   while(false) {
@@ -75,10 +73,9 @@ int main()
         __lambda_7_18{}.operator()();
       }
       
-      
-    } __lambda_7_18{};
+    };
     
-    __lambda_7_18.operator()();
+    __lambda_7_18{}.operator()();
   }
   
   return 0;

--- a/tests/Issue4.expect
+++ b/tests/Issue4.expect
@@ -14,14 +14,8 @@ int main()
       printf("a: %c\n", static_cast<int>(uuu));
     }
     
-    private: 
+    // private: 
     char uuu;
-    
-    public:
-    __lambda_9_11(const char & _uuu)
-    : uuu{_uuu}
-    {}
-    
   };
   
   __lambda_9_11 && l = __lambda_9_11{arr[1]};

--- a/tests/Issue402.expect
+++ b/tests/Issue402.expect
@@ -1,7 +1,6 @@
 int main()
 {
-    
-      
+        
   class __lambda_2_8
   {
     public: 
@@ -23,8 +22,8 @@ int main()
     
     public: 
     // inline /*constexpr */ __lambda_2_8 & operator=(const __lambda_2_8 &) /* noexcept */ = delete;
-    
   };
+  
   
   class __lambda_2_3
   {
@@ -33,15 +32,11 @@ int main()
     {
     }
     
-    private: 
+    // private: 
     __lambda_2_8 var;
     public: 
     // inline /*constexpr */ __lambda_2_3 & operator=(const __lambda_2_3 &) /* noexcept */ = delete;
-    __lambda_2_3(const __lambda_2_8 & _var)
-    : var{_var}
-    {}
-    
-  } __lambda_2_3{__lambda_2_8{}};
+  };
   
   return 0;
 }

--- a/tests/Issue41.cerr
+++ b/tests/Issue41.cerr
@@ -10,7 +10,7 @@ In file included from ... algorithm:1859:
 ... find_if.h:25:9: error: no matching function for call to object of type '__lambda_12_26'
    25 |     if (__pred(*__first))
       |         ^~~~~~
-.tmp.cpp:37:104: note: in instantiation of function template specialization 'std::find_if<std::__wrap_iter<std::string *>, __lambda_12_26>' requested here
-   37 |   std::__wrap_iter<std::basic_string<char, std::char_traits<char>, std::allocator<char> > *> it = std::find_if(std::begin(v), std::end(v), __lambda_12_26{});
+.tmp.cpp:36:104: note: in instantiation of function template specialization 'std::find_if<std::__wrap_iter<std::string *>, __lambda_12_26>' requested here
+   36 |   std::__wrap_iter<std::basic_string<char, std::char_traits<char>, std::allocator<char> > *> it = std::find_if(std::begin(v), std::end(v), __lambda_12_26{});
       |                                                                                                        ^
 3 errors generated.

--- a/tests/Issue41.expect
+++ b/tests/Issue41.expect
@@ -31,7 +31,6 @@ int main()
     {
       return __lambda_12_26{}.operator()<type_parameter_0_0>(str);
     }
-    
   };
   
   std::__wrap_iter<std::basic_string<char, std::char_traits<char>, std::allocator<char> > *> it = std::find_if(std::begin(v), std::end(v), __lambda_12_26{});

--- a/tests/Issue46.expect
+++ b/tests/Issue46.expect
@@ -19,7 +19,6 @@ class __lambda_1_10
     return __lambda_1_10{}.operator()();
   }
   
-  
 };
 
 __lambda_1_10 x = __lambda_1_10{};
@@ -33,14 +32,8 @@ class __lambda_5_11
     return b * a;
   }
   
-  private: 
+  // private: 
   int a;
-  
-  public:
-  __lambda_5_11(const int & _a)
-  : a{_a}
-  {}
-  
 };
 
 __lambda_5_11 x2 = __lambda_5_11{5};

--- a/tests/Issue467.expect
+++ b/tests/Issue467.expect
@@ -24,7 +24,6 @@ int main()
       __lambda_5_14{}.operator()();
     }
     
-    
   };
   
   __lambda_5_14 l = __lambda_5_14{};

--- a/tests/Issue468.expect
+++ b/tests/Issue468.expect
@@ -21,8 +21,7 @@ class __lambda_3_29
   
   
   public:
-  // /*constexpr */ __lambda_3_29() = default;
-  
+  // /* constexpr */ __lambda_3_29() = default;
 };
 
 template<class F = __lambda_3_29>

--- a/tests/Issue490.expect
+++ b/tests/Issue490.expect
@@ -21,8 +21,7 @@ class __lambda_3_24
   
   
   public:
-  // /*constexpr */ __lambda_3_24() = default;
-  
+  // /* constexpr */ __lambda_3_24() = default;
 };
 
 __lambda_3_24 foo();

--- a/tests/Issue490_2.expect
+++ b/tests/Issue490_2.expect
@@ -21,8 +21,7 @@ class __lambda_3_20
   
   
   public:
-  // /*constexpr */ __lambda_3_20() = default;
-  
+  // /* constexpr */ __lambda_3_20() = default;
 };
 
 using x = __lambda_3_20;

--- a/tests/Issue491.expect
+++ b/tests/Issue491.expect
@@ -1,5 +1,4 @@
 
-
 class __lambda_1_16
 {
   public: 
@@ -19,8 +18,8 @@ class __lambda_1_16
     __lambda_1_16{}.operator()();
   }
   
-  
 };
+
 
 class __lambda_1_10
 {
@@ -29,14 +28,8 @@ class __lambda_1_10
   {
   }
   
-  private: 
+  // private: 
   void (*var)();
-  
-  public:
-  __lambda_1_10(void (*_var)())
-  : var{_var}
-  {}
-  
 };
 
 __lambda_1_10 x = __lambda_1_10{+__lambda_1_16{}.operator __lambda_1_16::retType_1_16()};

--- a/tests/Issue492.expect
+++ b/tests/Issue492.expect
@@ -25,8 +25,7 @@ void f()
     }
     
     public: 
-    // /*constexpr */ __lambda_10_34() = default;
-    
+    // /* constexpr */ __lambda_10_34() = default;
   };
   
   std::priority_queue<int, std::vector<int, std::allocator<int> >, __lambda_10_34> min_heap = std::priority_queue<int, std::vector<int, std::allocator<int> >, __lambda_10_34>();

--- a/tests/Issue492_2.expect
+++ b/tests/Issue492_2.expect
@@ -49,8 +49,7 @@ void f()
     
     
     public:
-    // /*constexpr */ __lambda_18_34() = default;
-    
+    // /* constexpr */ __lambda_18_34() = default;
   };
   
   priority_queue<int, float, __lambda_18_34> min_heap = priority_queue<int, float, __lambda_18_34>();

--- a/tests/Issue506.expect
+++ b/tests/Issue506.expect
@@ -41,7 +41,6 @@ int main()
       return __lambda_12_50{}.operator()(ch);
     }
     
-    
   };
   
   std::cout.operator<<(search('A', ::isalpha, ::isdigit, __lambda_12_50{}));

--- a/tests/Issue550.expect
+++ b/tests/Issue550.expect
@@ -20,8 +20,7 @@ class __lambda_4_13
   
   
   public:
-  // /*constexpr */ __lambda_4_13() = default;
-  
+  // /* constexpr */ __lambda_4_13() = default;
 };
 
 __lambda_4_13 temp = __lambda_4_13{};
@@ -50,8 +49,7 @@ class __lambda_7_14
   }
   
   public:
-  // /*constexpr */ __lambda_7_14() = default;
-  
+  // /* constexpr */ __lambda_7_14() = default;
 };
 
 __lambda_7_14 temp2 = __lambda_7_14{};
@@ -69,14 +67,8 @@ int main()
     {
     }
     
-    private: 
+    // private: 
     int v;
-    
-    public:
-    __lambda_17_16(int & _v)
-    : v{_v}
-    {}
-    
   };
   
   __lambda_17_16 temp3 = __lambda_17_16{v};

--- a/tests/Issue605.expect
+++ b/tests/Issue605.expect
@@ -1,5 +1,3 @@
-#include <utility> // std::move
-
 #include <cstdio>
 #include <functional>
 #include <memory>
@@ -16,17 +14,13 @@ int main()
     {
     }
     
-    private: 
+    // private: 
     std::unique_ptr<int, std::default_delete<int> > a;
     public: 
     // inline /*constexpr */ __lambda_11_5(const __lambda_11_5 &) /* noexcept */ = delete;
     // inline /*constexpr */ __lambda_11_5 & operator=(const __lambda_11_5 &) /* noexcept */ = delete;
     // inline /*constexpr */ ~__lambda_11_5() noexcept = default;
-    __lambda_11_5(std::unique_ptr<int, std::default_delete<int> > && _a)
-    : a{std::move(_a)}
-    {}
-    
-  } __lambda_11_5{std::make_unique<int>(42)};
+  };
   
   ;
   return 0;

--- a/tests/Issue628.expect
+++ b/tests/Issue628.expect
@@ -43,19 +43,13 @@ struct mysleep
         
       }
       
-      private: 
+      // private: 
       std::chrono::time_point<std::chrono::steady_clock, std::chrono::duration<long long, std::ratio<1, 1000000000> > > start;
       std::coroutine_handle<void> h;
       std::chrono::duration<long long, std::ratio<1, 1000> > d;
       public: 
       // inline /*constexpr */ __lambda_20_25(const __lambda_20_25 &) noexcept = default;
       // inline /*constexpr */ __lambda_20_25(__lambda_20_25 &&) noexcept = default;
-      __lambda_20_25(const std::chrono::time_point<std::chrono::steady_clock, std::chrono::duration<long long, std::ratio<1, 1000000000> > > & _start, const std::coroutine_handle<void> & _h, const std::chrono::duration<long long, std::ratio<1, 1000> > & _d)
-      : start{_start}
-      , h{_h}
-      , d{_d}
-      {}
-      
     };
     
     task_queue.push(std::function<bool ()>(__lambda_20_25{start, h, this->delay}));

--- a/tests/Issue633.expect
+++ b/tests/Issue633.expect
@@ -21,17 +21,11 @@ int main()
           return k;
         }
         
-        private: 
+        // private: 
         std::tuple_element<0, std::pair<const int, int> >::type k;
-        
-        public:
-        __lambda_9_8(const int & _k)
-        : k{_k}
-        {}
-        
-      } __lambda_9_8{k};
+      };
       
-      __lambda_9_8.operator()();
+      __lambda_9_8{k}.operator()();
     }
     
   }

--- a/tests/Issue64.expect
+++ b/tests/Issue64.expect
@@ -11,18 +11,14 @@ void func(const std::basic_string<char, std::char_traits<char>, std::allocator<c
       return arg.size();
     }
     
-    private: 
+    // private: 
     const std::basic_string<char, std::char_traits<char>, std::allocator<char> > arg;
     public: 
     // inline __lambda_5_11 & operator=(const __lambda_5_11 &) /* noexcept */ = delete;
     // inline ~__lambda_5_11() noexcept = default;
-    __lambda_5_11(const std::basic_string<char, std::char_traits<char>, std::allocator<char> > & _arg)
-    : arg{_arg}
-    {}
-    
-  } __lambda_5_11{arg};
+  };
   
-  unsigned long s = __lambda_5_11.operator()();
+  unsigned long s = __lambda_5_11{arg}.operator()();
 }
 
 int main()

--- a/tests/Issue682.expect
+++ b/tests/Issue682.expect
@@ -27,10 +27,9 @@ class __lambda_5_17
     return __lambda_5_17{}.operator()();
   }
   
-  
-} __lambda_5_17{};
+};
 
-/* PASSED: static_assert(__lambda_5_17.operator()()); */
+/* PASSED: static_assert(__lambda_5_17{}.operator()()); */
 
 int main()
 {

--- a/tests/Issue704.expect
+++ b/tests/Issue704.expect
@@ -17,14 +17,8 @@ void foo()
     {
     }
     
-    private: 
+    // private: 
     int x;
-    
-    public:
-    __lambda_12_17(int & _x)
-    : x{_x}
-    {}
-    
   };
   
   __lambda_12_17 g = __lambda_12_17{x};
@@ -44,14 +38,8 @@ void bar()
     {
     }
     
-    private: 
+    // private: 
     int x;
-    
-    public:
-    __lambda_19_20(int & _x)
-    : x{_x}
-    {}
-    
   };
   
   __lambda_19_20 g = __lambda_19_20{x};

--- a/tests/LambdaAndInClassInitializerTest.expect
+++ b/tests/LambdaAndInClassInitializerTest.expect
@@ -53,15 +53,9 @@ class EventContainer
       __this->val;
     }
     
-    private: 
+    // private: 
     EventContainer * __this;
-    
-    public:
-    __lambda_17_38(EventContainer * _this)
-    : __this{_this}
-    {}
-    
-  } __lambda_17_38{this};
+  };
   
   // inline constexpr EventContainer() noexcept(false) = default;
 };

--- a/tests/LambdaAsTemplateArgTest.expect
+++ b/tests/LambdaAsTemplateArgTest.expect
@@ -32,14 +32,8 @@ int main()
       return (x + y) + b;
     }
     
-    private: 
+    // private: 
     int & y;
-    
-    public:
-    __lambda_12_14(int & _y)
-    : y{_y}
-    {}
-    
   };
   
   __lambda_12_14 l = __lambda_12_14{y};

--- a/tests/LambdaCapturingFunctionTest.expect
+++ b/tests/LambdaCapturingFunctionTest.expect
@@ -20,14 +20,8 @@ int main()
       d(3);
     }
     
-    private: 
+    // private: 
     D & d;
-    
-    public:
-    __lambda_15_14(void (*&_d)(int))
-    : d{_d}
-    {}
-    
   };
   
   __lambda_15_14 l = __lambda_15_14{d};

--- a/tests/LambdaConstexprTest.expect
+++ b/tests/LambdaConstexprTest.expect
@@ -10,14 +10,8 @@ void Test()
       int Dim[3];
     }
     
-    private: 
+    // private: 
     const int Size;
-    
-    public:
-    __lambda_4_18(const int & _Size)
-    : Size{_Size}
-    {}
-    
   };
   
   __lambda_4_18 Lambda = __lambda_4_18{Size};

--- a/tests/LambdaHandler2Test.expect
+++ b/tests/LambdaHandler2Test.expect
@@ -21,7 +21,6 @@ int main()
       return __lambda_8_26{}.operator()(a, b);
     }
     
-    
   };
   
   using FuncPtr_8 = int (*)(int, char);

--- a/tests/LambdaHandler3Test.expect
+++ b/tests/LambdaHandler3Test.expect
@@ -26,14 +26,8 @@ int main()
       return x + y;
     }
     
-    private: 
+    // private: 
     int & y;
-    
-    public:
-    __lambda_10_13(int & _y)
-    : y{_y}
-    {}
-    
   };
   
   return Is(__lambda_10_13{y});

--- a/tests/LambdaHandler4Test.expect
+++ b/tests/LambdaHandler4Test.expect
@@ -12,14 +12,8 @@ class Foo
         __this->Get();
       }
       
-      private: 
+      // private: 
       Foo * __this;
-      
-      public:
-      __lambda_6_18(Foo * _this)
-      : __this{_this}
-      {}
-      
     };
     
     __lambda_6_18 f = __lambda_6_18{this};
@@ -32,14 +26,8 @@ class Foo
         __this->Get();
       }
       
-      private: 
+      // private: 
       Foo * __this;
-      
-      public:
-      __lambda_10_18(Foo * _this)
-      : __this{_this}
-      {}
-      
     };
     
     __lambda_10_18 g = __lambda_10_18{this};
@@ -52,14 +40,8 @@ class Foo
         (&__this)->Get();
       }
       
-      private: 
+      // private: 
       Foo __this;
-      
-      public:
-      __lambda_14_18(const Foo & _this)
-      : __this{_this}
-      {}
-      
     };
     
     __lambda_14_18 h = __lambda_14_18{*this};
@@ -95,15 +77,9 @@ struct X
         return __this->operator()(__this->x + __this->y);
       }
       
-      private: 
+      // private: 
       X * __this;
-      
-      public:
-      __lambda_35_9(X * _this)
-      : __this{_this}
-      {}
-      
-    } __lambda_35_9{this};
+    };
     
   }
   

--- a/tests/LambdaHandler5Test.expect
+++ b/tests/LambdaHandler5Test.expect
@@ -20,10 +20,9 @@ int main()
       __lambda_4_5{}.operator()();
     }
     
-    
-  } __lambda_4_5{};
+  };
   
-  __lambda_4_5.operator()();
+  __lambda_4_5{}.operator()();
     
   class __lambda_7_5
   {
@@ -45,10 +44,9 @@ int main()
       __lambda_7_5{}.operator()();
     }
     
-    
-  } __lambda_7_5{};
+  };
   
-  __lambda_7_5.operator()();
+  __lambda_7_5{}.operator()();
   int a;
   int b;
     
@@ -72,9 +70,8 @@ int main()
       __lambda_13_5{}.operator()(x, y);
     }
     
-    
-  } __lambda_13_5{};
+  };
   
-  __lambda_13_5.operator()(a, b);
+  __lambda_13_5{}.operator()(a, b);
   return 0;
 }

--- a/tests/LambdaHandler6Test.expect
+++ b/tests/LambdaHandler6Test.expect
@@ -11,18 +11,11 @@ int main()
       l1 = (2 * l2);
     }
     
-    private: 
+    // private: 
     int & l1;
     int & l2;
-    
-    public:
-    __lambda_5_5(int & _l1, int & _l2)
-    : l1{_l1}
-    , l2{_l2}
-    {}
-    
-  } __lambda_5_5{l1, l2};
+  };
   
-  __lambda_5_5.operator()();
+  __lambda_5_5{l1, l2}.operator()();
   return 0;
 }

--- a/tests/LambdaHandler7Test.expect
+++ b/tests/LambdaHandler7Test.expect
@@ -25,7 +25,6 @@ int main()
       return __lambda_8_57{}.operator()(fir, sec);
     }
     
-    
   };
   
   int fak = std::accumulate(myVec.begin(), myVec.end(), 1, __lambda_8_57{});

--- a/tests/LambdaHandler8Test.expect
+++ b/tests/LambdaHandler8Test.expect
@@ -25,14 +25,8 @@ int get(int & v)
       return v;
     }
     
-    private: 
+    // private: 
     int & v;
-    
-    public:
-    __lambda_9_18(int & _v)
-    : v{_v}
-    {}
-    
   };
   
   int x = Test(__lambda_9_18{v});

--- a/tests/LambdaHandler9Test.expect
+++ b/tests/LambdaHandler9Test.expect
@@ -21,7 +21,6 @@ int main()
       }
     }
     
-    
   };
   
   __lambda_5_14 l = __lambda_5_14{};
@@ -40,7 +39,6 @@ int main()
       
     }
     
-    
   };
   
   __lambda_14_14 w = __lambda_14_14{};
@@ -57,7 +55,6 @@ int main()
         default: return;
       }
     }
-    
     
   };
   
@@ -76,7 +73,6 @@ int main()
       
     }
     
-    
   };
   
   __lambda_36_14 f = __lambda_36_14{};
@@ -94,7 +90,6 @@ int main()
       }
       
     }
-    
     
   };
   

--- a/tests/LambdaHandlerCaptureLessTest.cerr
+++ b/tests/LambdaHandlerCaptureLessTest.cerr
@@ -4,7 +4,7 @@
 .tmp.cpp:33:5: error: templates cannot be declared inside of a local class
    33 |     template<class type_parameter_0_0, class type_parameter_0_1>
       |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-.tmp.cpp:51:58: error: no type named 'retType_4_28' in '__lambda_4_28'
-   51 |   FuncPtr_4 fp = __lambda_4_28{}.operator __lambda_4_28::retType_4_28();
+.tmp.cpp:50:58: error: no type named 'retType_4_28' in '__lambda_4_28'
+   50 |   FuncPtr_4 fp = __lambda_4_28{}.operator __lambda_4_28::retType_4_28();
       |                                           ~~~~~~~~~~~~~~~^
 3 errors generated.

--- a/tests/LambdaHandlerCaptureLessTest.expect
+++ b/tests/LambdaHandlerCaptureLessTest.expect
@@ -44,7 +44,6 @@ int main()
     }
     #endif
     
-    
   };
   
   using FuncPtr_4 = int (*)(int, char);

--- a/tests/LambdaHandlerInFunctionTest.expect
+++ b/tests/LambdaHandlerInFunctionTest.expect
@@ -46,7 +46,6 @@ int main()
       __lambda_10_10{}.operator()();
     }
     
-    
   };
   
   Test(__lambda_10_10{});
@@ -72,9 +71,8 @@ int main()
       return __lambda_12_10{}.operator()();
     }
     
-    
-  } __lambda_12_10{};
+  };
   
-  Test(__lambda_12_10.operator()());
+  Test(__lambda_12_10{}.operator()());
   return 0;
 }

--- a/tests/LambdaHandlerTest.cerr
+++ b/tests/LambdaHandlerTest.cerr
@@ -1,16 +1,16 @@
-.tmp.cpp:174:5: error: templates cannot be declared inside of a local class
-  174 |     template<class type_parameter_0_0>
+.tmp.cpp:137:5: error: templates cannot be declared inside of a local class
+  137 |     template<class type_parameter_0_0>
       |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-.tmp.cpp:201:11: error: no matching member function for call to 'operator()'
-  201 |   lambda7.operator()(foo, 2);
+.tmp.cpp:158:11: error: no matching member function for call to 'operator()'
+  158 |   lambda7.operator()(foo, 2);
       |   ~~~~~~~~^~~~~~~~~~
-.tmp.cpp:206:5: error: templates cannot be declared inside of a local class
-  206 |     template<class type_parameter_0_0>
+.tmp.cpp:163:5: error: templates cannot be declared inside of a local class
+  163 |     template<class type_parameter_0_0>
       |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-.tmp.cpp:227:5: error: templates cannot be declared inside of a local class
-  227 |     template<class type_parameter_0_0, class type_parameter_0_1>
+.tmp.cpp:178:5: error: templates cannot be declared inside of a local class
+  178 |     template<class type_parameter_0_0, class type_parameter_0_1>
       |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-.tmp.cpp:254:12: error: no matching member function for call to 'operator()'
-  254 |   lambda73.operator()(foo, b, 44);
+.tmp.cpp:199:12: error: no matching member function for call to 'operator()'
+  199 |   lambda73.operator()(foo, b, 44);
       |   ~~~~~~~~~^~~~~~~~~~
 5 errors generated.

--- a/tests/LambdaHandlerTest.expect
+++ b/tests/LambdaHandlerTest.expect
@@ -14,14 +14,8 @@ class Bar
         printf("%d\n", __this->a);
       }
       
-      private: 
+      // private: 
       Bar * __this;
-      
-      public:
-      __lambda_8_18(Bar * _this)
-      : __this{_this}
-      {}
-      
     };
     
     __lambda_8_18 x = __lambda_8_18{this};
@@ -44,14 +38,8 @@ int main()
       printf("%d\n", foo);
     }
     
-    private: 
+    // private: 
     int & foo;
-    
-    public:
-    __lambda_20_19(int & _foo)
-    : foo{_foo}
-    {}
-    
   };
   
   __lambda_20_19 lambda = __lambda_20_19{foo};
@@ -77,7 +65,6 @@ int main()
       __lambda_24_20{}.operator()();
     }
     
-    
   };
   
   __lambda_24_20 lambda2 = __lambda_24_20{};
@@ -92,14 +79,8 @@ int main()
       return foo;
     }
     
-    private: 
+    // private: 
     int & foo;
-    
-    public:
-    __lambda_28_20(int & _foo)
-    : foo{_foo}
-    {}
-    
   };
   
   __lambda_28_20 lambda3 = __lambda_28_20{foo};
@@ -114,14 +95,8 @@ int main()
       return foo + x;
     }
     
-    private: 
+    // private: 
     int & foo;
-    
-    public:
-    __lambda_32_20(int & _foo)
-    : foo{_foo}
-    {}
-    
   };
   
   __lambda_32_20 lambda4 = __lambda_32_20{foo};
@@ -135,14 +110,8 @@ int main()
       return foo + x;
     }
     
-    private: 
+    // private: 
     int & foo;
-    
-    public:
-    __lambda_34_20(int & _foo)
-    : foo{_foo}
-    {}
-    
   };
   
   __lambda_34_20 lambda5 = __lambda_34_20{foo};
@@ -156,14 +125,8 @@ int main()
       return (foo + x) + b;
     }
     
-    private: 
+    // private: 
     int & foo;
-    
-    public:
-    __lambda_36_20(int & _foo)
-    : foo{_foo}
-    {}
-    
   };
   
   __lambda_36_20 lambda6 = __lambda_36_20{foo};
@@ -187,14 +150,8 @@ int main()
     }
     #endif
     
-    private: 
+    // private: 
     int & foo;
-    
-    public:
-    __lambda_38_20(int & _foo)
-    : foo{_foo}
-    {}
-    
   };
   
   __lambda_38_20 lambda7 = __lambda_38_20{foo};
@@ -209,14 +166,8 @@ int main()
       printf("%d\n", foo + x);
       return (foo + x) + b;
     }
-    private: 
+    // private: 
     int & foo;
-    
-    public:
-    __lambda_41_21(int & _foo)
-    : foo{_foo}
-    {}
-    
   };
   
   __lambda_41_21 lambda71 = __lambda_41_21{foo};
@@ -240,14 +191,8 @@ int main()
     }
     #endif
     
-    private: 
+    // private: 
     int & foo;
-    
-    public:
-    __lambda_43_21(int & _foo)
-    : foo{_foo}
-    {}
-    
   };
   
   __lambda_43_21 lambda73 = __lambda_43_21{foo};
@@ -262,16 +207,9 @@ int main()
       return (foo + x) + bb;
     }
     
-    private: 
+    // private: 
     int foo;
     int b;
-    
-    public:
-    __lambda_46_20(int & _foo, int & _b)
-    : foo{_foo}
-    , b{_b}
-    {}
-    
   };
   
   __lambda_46_20 lambda8 = __lambda_46_20{foo, b};
@@ -285,16 +223,9 @@ int main()
       return (foo + x) + bb;
     }
     
-    private: 
+    // private: 
     int foo;
     int b;
-    
-    public:
-    __lambda_48_20(int & _foo, int & _b)
-    : foo{_foo}
-    , b{_b}
-    {}
-    
   };
   
   __lambda_48_20 lambda9 = __lambda_48_20{foo, b};

--- a/tests/LambdaHandlerVLA2Test.cerr
+++ b/tests/LambdaHandlerVLA2Test.cerr
@@ -24,29 +24,4 @@
 .tmp.cpp:15:12: error: fields must have a constant size: 'variable length array in structure' extension will never be supported
    15 |     char (&buffer)[n];
       |            ^
-.tmp.cpp:18:34: error: reference to local variable 'n' declared in enclosing function 'Test'
-   18 |     __lambda_6_5(char (&_buffer)[n])
-      |                                  ^
-.tmp.cpp:1:15: note: 'n' declared here
-    1 | void Test(int n)
-      |               ^
-.tmp.cpp:18:34: warning: variable length arrays in C++ are a Clang extension [-Wvla-cxx-extension]
-   18 |     __lambda_6_5(char (&_buffer)[n])
-      |                                  ^
-.tmp.cpp:18:34: note: function parameter 'n' with unknown value cannot be used in a constant expression
-.tmp.cpp:1:15: note: declared here
-    1 | void Test(int n)
-      |               ^
-.tmp.cpp:22:5: error: no matching constructor for initialization of 'class __lambda_6_5'
-   22 |   } __lambda_6_5{buffer};
-      |     ^           ~~~~~~~~
-.tmp.cpp:5:9: note: candidate constructor (the implicit copy constructor) not viable: no known conversion from 'char[n]' to 'const __lambda_6_5' for 1st argument
-    5 |   class __lambda_6_5
-      |         ^~~~~~~~~~~~
-.tmp.cpp:5:9: note: candidate constructor (the implicit move constructor) not viable: no known conversion from 'char[n]' to '__lambda_6_5' for 1st argument
-    5 |   class __lambda_6_5
-      |         ^~~~~~~~~~~~
-.tmp.cpp:18:5: note: candidate constructor not viable: no known conversion from 'char[n]' to 'char (&)[n]' for 1st argument
-   18 |     __lambda_6_5(char (&_buffer)[n])
-      |     ^            ~~~~~~~~~~~~~~~~~~
-4 warnings and 4 errors generated.
+3 warnings and 2 errors generated.

--- a/tests/LambdaHandlerVLA2Test.expect
+++ b/tests/LambdaHandlerVLA2Test.expect
@@ -10,18 +10,12 @@ void Test(int n)
       return static_cast<int>(buffer[i]) > static_cast<int>(buffer[x]);
     }
     
-    private: 
+    // private: 
     unsigned long;
     char (&buffer)[n];
-    
-    public:
-    __lambda_6_5(char (&_buffer)[n])
-    : buffer{_buffer}
-    {}
-    
-  } __lambda_6_5{buffer};
+  };
   
-  __lambda_6_5.operator()(1, 2);
+  __lambda_6_5{buffer}.operator()(1, 2);
 }
 
 int main()

--- a/tests/LambdaImplicitCaptureTest.expect
+++ b/tests/LambdaImplicitCaptureTest.expect
@@ -13,17 +13,11 @@ int main()
       return x;
     }
     
-    private: 
+    // private: 
     int x;
-    
-    public:
-    __lambda_7_14(int & _x)
-    : x{_x}
-    {}
-    
-  } __lambda_7_14{x};
+  };
   
-  int z = __lambda_7_14.operator()();
+  int z = __lambda_7_14{x}.operator()();
   printf("x: %d z: %d\n", x, z);
   return 0;
 }

--- a/tests/LambdaInLamda2Test.cerr
+++ b/tests/LambdaInLamda2Test.cerr
@@ -1,28 +1,25 @@
-.tmp.cpp:8:27: error: unknown type name 'S'
-    8 |     inline /*constexpr */ S operator()() const
+.tmp.cpp:7:27: error: unknown type name 'S'
+    7 |     inline /*constexpr */ S operator()() const
       |                           ^
-.tmp.cpp:19:25: error: unknown type name 'S'
-   19 |     using retType_5_7 = S (*)();
+.tmp.cpp:18:25: error: unknown type name 'S'
+   18 |     using retType_5_7 = S (*)();
       |                         ^
-.tmp.cpp:20:31: error: unknown type name 'retType_5_7'
-   20 |     inline constexpr operator retType_5_7 () const noexcept
+.tmp.cpp:19:31: error: unknown type name 'retType_5_7'
+   19 |     inline constexpr operator retType_5_7 () const noexcept
       |                               ^
-.tmp.cpp:26:34: error: unknown type name 'S'
-   26 |     static inline /*constexpr */ S __invoke()
+.tmp.cpp:25:34: error: unknown type name 'S'
+   25 |     static inline /*constexpr */ S __invoke()
       |                                  ^
-.tmp.cpp:16:16: warning: braces around scalar initializer [-Wbraced-scalar-init]
-   16 |       return S{{676}};
+.tmp.cpp:15:16: warning: braces around scalar initializer [-Wbraced-scalar-init]
+   15 |       return S{{676}};
       |                ^~~~~
-.tmp.cpp:16:14: error: no viable conversion from returned value of type 'S' to function return type 'int'
-   16 |       return S{{676}};
+.tmp.cpp:15:14: error: no viable conversion from returned value of type 'S' to function return type 'int'
+   15 |       return S{{676}};
       |              ^~~~~~~~
-.tmp.cpp:37:27: error: unknown type name 'S'
-   37 |     inline /*constexpr */ S operator()()
+.tmp.cpp:36:27: error: unknown type name 'S'
+   36 |     inline /*constexpr */ S operator()()
       |                           ^
-.tmp.cpp:44:5: error: unknown type name 'S'
-   44 |     S s;
+.tmp.cpp:43:5: error: unknown type name 'S'
+   43 |     S s;
       |     ^
-.tmp.cpp:47:24: error: unknown type name 'S'
-   47 |     __lambda_4_5(const S & _s)
-      |                        ^
-1 warning and 8 errors generated.
+1 warning and 7 errors generated.

--- a/tests/LambdaInLamda2Test.expect
+++ b/tests/LambdaInLamda2Test.expect
@@ -1,7 +1,6 @@
 int main()
 {
-    
-      
+        
   class __lambda_5_7
   {
     public: 
@@ -28,8 +27,8 @@ int main()
       return __lambda_5_7{}.operator()();
     }
     
-    
   };
+  
   
   class __lambda_4_5
   {
@@ -40,14 +39,10 @@ int main()
       return S(s);
     }
     
-    private: 
+    // private: 
     S s;
     public: 
     // inline /*constexpr */ __lambda_4_5(const __lambda_4_5 &) noexcept = default;
-    __lambda_4_5(const S & _s)
-    : s{_s}
-    {}
-    
   };
   
   __lambda_4_5 l = __lambda_4_5{__lambda_5_7{}.operator()()};

--- a/tests/LambdaInLamdaTest.expect
+++ b/tests/LambdaInLamdaTest.expect
@@ -16,29 +16,17 @@ int main()
           buffer = 2;
         }
         
-        private: 
+        // private: 
         char & buffer;
-        
-        public:
-        __lambda_6_9(char & _buffer)
-        : buffer{_buffer}
-        {}
-        
-      } __lambda_6_9{buffer};
+      };
       
-      __lambda_6_9.operator()();
+      __lambda_6_9{buffer}.operator()();
     }
     
-    private: 
+    // private: 
     char & buffer;
-    
-    public:
-    __lambda_4_5(char & _buffer)
-    : buffer{_buffer}
-    {}
-    
-  } __lambda_4_5{buffer};
+  };
   
-  __lambda_4_5.operator()();
+  __lambda_4_5{buffer}.operator()();
   return 0;
 }

--- a/tests/LambdaInMemberCallExprTest.expect
+++ b/tests/LambdaInMemberCallExprTest.expect
@@ -30,7 +30,6 @@ int main()
     {
     }
     
-    
   };
   
   t.foo<__lambda_13_12>(__lambda_13_12{});

--- a/tests/LambdaInVarDeclTest.expect
+++ b/tests/LambdaInVarDeclTest.expect
@@ -16,17 +16,11 @@ int main()
           return c;
         }
         
-        private: 
+        // private: 
         char & c;
-        
-        public:
-        __lambda_6_17(char & _c)
-        : c{_c}
-        {}
-        
-      } __lambda_6_17{c};
+      };
       
-      int x = static_cast<int>(__lambda_6_17.operator()());
+      int x = static_cast<int>(__lambda_6_17{c}.operator()());
     }
     
   }

--- a/tests/LambdaInVariadicTemplateTest.cerr
+++ b/tests/LambdaInVariadicTemplateTest.cerr
@@ -4,16 +4,16 @@
 .tmp.cpp:59:31: error: unknown type name 'retType_13_4'
    59 |     inline constexpr operator retType_13_4 () const noexcept
       |                               ^
-.tmp.cpp:83:26: error: 'auto' not allowed in type alias
-   83 |     using retType_14_4 = auto (*)(int);
+.tmp.cpp:82:26: error: 'auto' not allowed in type alias
+   82 |     using retType_14_4 = auto (*)(int);
       |                          ^~~~
-.tmp.cpp:84:31: error: unknown type name 'retType_14_4'
-   84 |     inline constexpr operator retType_14_4 () const noexcept
+.tmp.cpp:83:31: error: unknown type name 'retType_14_4'
+   83 |     inline constexpr operator retType_14_4 () const noexcept
       |                               ^
-.tmp.cpp:102:5: error: templates cannot be declared inside of a local class
-  102 |     template<class type_parameter_1_0>
+.tmp.cpp:100:5: error: templates cannot be declared inside of a local class
+  100 |     template<class type_parameter_1_0>
       |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-.tmp.cpp:109:5: error: templates cannot be declared inside of a local class
-  109 |     template<class type_parameter_1_0>
+.tmp.cpp:107:5: error: templates cannot be declared inside of a local class
+  107 |     template<class type_parameter_1_0>
       |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 6 errors generated.

--- a/tests/LambdaInVariadicTemplateTest.expect
+++ b/tests/LambdaInVariadicTemplateTest.expect
@@ -67,7 +67,6 @@ decltype(auto) test(T && value)
       return __lambda_13_4{}.operator()(value);
     }
     
-    
   };
   
   
@@ -92,7 +91,6 @@ decltype(auto) test(T && value)
       return __lambda_14_4{}.operator()(i);
     }
     
-    
   };
   
   
@@ -111,7 +109,6 @@ decltype(auto) test(T && value)
     {
       return __lambda_15_4{}.operator()<type_parameter_1_0>(a);
     }
-    
   };
   
   return match(value, __lambda_13_4{}, __lambda_14_4{}, __lambda_15_4{});
@@ -143,7 +140,6 @@ int test<int>(int && value)
       return __lambda_13_4{}.operator()(value);
     }
     
-    
   };
   
   
@@ -168,7 +164,6 @@ int test<int>(int && value)
       return __lambda_14_4{}.operator()(i);
     }
     
-    
   };
   
   
@@ -187,7 +182,6 @@ int test<int>(int && value)
     {
       return __lambda_15_4{}.operator()<type_parameter_0_0>(a);
     }
-    
   };
   
   return match(value, __lambda_13_4{}, __lambda_14_4{}, __lambda_15_4{});
@@ -221,7 +215,6 @@ int test<const char (&)[3]>(const char (&value)[3])
       return __lambda_13_4{}.operator()(value);
     }
     
-    
   };
   
   
@@ -246,7 +239,6 @@ int test<const char (&)[3]>(const char (&value)[3])
       return __lambda_14_4{}.operator()(i);
     }
     
-    
   };
   
   
@@ -265,7 +257,6 @@ int test<const char (&)[3]>(const char (&value)[3])
     {
       return __lambda_15_4{}.operator()<type_parameter_0_0>(a);
     }
-    
   };
   
   return match(value, __lambda_13_4{}, __lambda_14_4{}, __lambda_15_4{});
@@ -299,7 +290,6 @@ int test<std::basic_string<char, std::char_traits<char>, std::allocator<char> > 
       return __lambda_13_4{}.operator()(value);
     }
     
-    
   };
   
   
@@ -324,7 +314,6 @@ int test<std::basic_string<char, std::char_traits<char>, std::allocator<char> > 
       return __lambda_14_4{}.operator()(i);
     }
     
-    
   };
   
   
@@ -343,7 +332,6 @@ int test<std::basic_string<char, std::char_traits<char>, std::allocator<char> > 
     {
       return __lambda_15_4{}.operator()<type_parameter_0_0>(a);
     }
-    
   };
   
   return match(value, __lambda_13_4{}, __lambda_14_4{}, __lambda_15_4{});
@@ -377,7 +365,6 @@ int test<float>(float && value)
       return __lambda_13_4{}.operator()(value);
     }
     
-    
   };
   
   
@@ -402,7 +389,6 @@ int test<float>(float && value)
       return __lambda_14_4{}.operator()(i);
     }
     
-    
   };
   
   
@@ -421,7 +407,6 @@ int test<float>(float && value)
     {
       return __lambda_15_4{}.operator()<type_parameter_0_0>(a);
     }
-    
   };
   
   return match(value, __lambda_13_4{}, __lambda_14_4{}, __lambda_15_4{});

--- a/tests/LambdaInitCaptureTest.cpp
+++ b/tests/LambdaInitCaptureTest.cpp
@@ -1,0 +1,8 @@
+int main()
+{
+   const int x{3};
+
+   auto lambInit = [x=x] {};
+
+   auto lamb = [x] {};
+}

--- a/tests/LambdaInitCaptureTest.expect
+++ b/tests/LambdaInitCaptureTest.expect
@@ -1,0 +1,31 @@
+int main()
+{
+  const int x = {3};
+    
+  class __lambda_5_20
+  {
+    public: 
+    inline /*constexpr */ void operator()() const
+    {
+    }
+    
+    // private: 
+    int x;
+  };
+  
+  __lambda_5_20 lambInit = __lambda_5_20{x};
+    
+  class __lambda_7_16
+  {
+    public: 
+    inline /*constexpr */ void operator()() const
+    {
+    }
+    
+    // private: 
+    const int x;
+  };
+  
+  __lambda_7_16 lamb = __lambda_7_16{x};
+  return 0;
+}

--- a/tests/LambdaPackExpansionTest.cerr
+++ b/tests/LambdaPackExpansionTest.cerr
@@ -4,20 +4,4 @@
 .tmp.cpp:32:13: error: data member type contains unexpanded parameter pack 'Args'
    32 |     Args... args;
       |     ~~~~    ^
-.tmp.cpp:35:26: error: unknown type name 'type_parameter_0_0'
-   35 |     __lambda_19_15(const type_parameter_0_0... & _args)
-      |                          ^
-.tmp.cpp:35:44: error: '...' must immediately precede declared identifier
-   35 |     __lambda_19_15(const type_parameter_0_0... & _args)
-      |                                            ^~~
-      |                                                  ...
-.tmp.cpp:35:44: error: type 'const int &' of function parameter pack does not contain any unexpanded parameter packs
-   35 |     __lambda_19_15(const type_parameter_0_0... & _args)
-      |                    ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~
-.tmp.cpp:36:17: error: pack expansion does not contain any unexpanded parameter packs
-   36 |     : args{_args...}
-      |            ~~~~~^
-.tmp.cpp:41:13: error: initializer contains unexpanded parameter pack 'args'
-   41 |   auto lm = __lambda_19_15{args};
-      |             ^              ~~~~
-7 errors generated.
+2 errors generated.

--- a/tests/LambdaPackExpansionTest.expect
+++ b/tests/LambdaPackExpansionTest.expect
@@ -28,17 +28,11 @@ void f2(Args... args)
       return g(args... );
     }
     
-    private: 
+    // private: 
     Args... args;
-    
-    public:
-    __lambda_19_15(const type_parameter_0_0... & _args)
-    : args{_args...}
-    {}
-    
   };
   
-  auto lm = __lambda_19_15{args};
+  auto lm = __lambda_19_15{args...};
   lm();
 }
 
@@ -56,22 +50,12 @@ void f2<int, int, int, int, int>(int __args0, int __args1, int __args2, int __ar
       return g(__args0, __args1, __args2, __args3, __args4);
     }
     
-    private: 
+    // private: 
     int __args0;
     int __args1;
     int __args2;
     int __args3;
     int __args4;
-    
-    public:
-    __lambda_19_15(int & ___args0, int & ___args1, int & ___args2, int & ___args3, int & ___args4)
-    : __args0{___args0}
-    , __args1{___args1}
-    , __args2{___args2}
-    , __args3{___args3}
-    , __args4{___args4}
-    {}
-    
   };
   
   __lambda_19_15 lm = __lambda_19_15{__args0, __args1, __args2, __args3, __args4};

--- a/tests/LambdaWithConstCapture.expect
+++ b/tests/LambdaWithConstCapture.expect
@@ -9,14 +9,8 @@ int main()
     {
     }
     
-    private: 
+    // private: 
     char uuu;
-    
-    public:
-    __lambda_4_11(const char & _uuu)
-    : uuu{_uuu}
-    {}
-    
   };
   
   __lambda_4_11 && l = __lambda_4_11{a};

--- a/tests/LambdaWithFunctionPointerTest.expect
+++ b/tests/LambdaWithFunctionPointerTest.expect
@@ -22,7 +22,6 @@ class __lambda_3_12
   {
     return __lambda_3_12{}.operator()<type_parameter_0_0>(fp, a);
   }
-  
 };
 
 __lambda_3_12 Fwd = __lambda_3_12{};
@@ -70,7 +69,6 @@ class __lambda_5_10
     return __lambda_5_10{}.operator()<int>(a);
   }
   #endif
-  
   
 };
 

--- a/tests/LambdaWithStaticInvokerTest.cerr
+++ b/tests/LambdaWithStaticInvokerTest.cerr
@@ -1,21 +1,21 @@
-.tmp.cpp:127:36: error: no type named 'retType_25_16' in '__lambda_25_16'; did you mean '__lambda_5_14::retType_5_14'?
-  127 |   FuncPtr_29 fp = glambda.operator __lambda_25_16::retType_25_16();
+.tmp.cpp:124:36: error: no type named 'retType_25_16' in '__lambda_25_16'; did you mean '__lambda_5_14::retType_5_14'?
+  124 |   FuncPtr_29 fp = glambda.operator __lambda_25_16::retType_25_16();
       |                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       |                                    __lambda_5_14::retType_5_14
 .tmp.cpp:13:11: note: '__lambda_5_14::retType_5_14' declared here
    13 |     using retType_5_14 = int (*)();
       |           ^
-.tmp.cpp:127:27: error: no member named 'operator int (*)()' in '__lambda_25_16'
-  127 |   FuncPtr_29 fp = glambda.operator __lambda_25_16::retType_25_16();
+.tmp.cpp:124:27: error: no member named 'operator int (*)()' in '__lambda_25_16'
+  124 |   FuncPtr_29 fp = glambda.operator __lambda_25_16::retType_25_16();
       |                   ~~~~~~~ ^
-.tmp.cpp:198:47: error: no type named 'retType_32_27' in '__lambda_32_27'; did you mean '__lambda_14_20::retType_14_20'?
-  198 |   FuncPtr_41 fp = lWithParamsAndNTTP.operator __lambda_32_27::retType_32_27();
+.tmp.cpp:194:47: error: no type named 'retType_32_27' in '__lambda_32_27'; did you mean '__lambda_14_20::retType_14_20'?
+  194 |   FuncPtr_41 fp = lWithParamsAndNTTP.operator __lambda_32_27::retType_32_27();
       |                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       |                                               __lambda_14_20::retType_14_20
-.tmp.cpp:46:9: note: '__lambda_14_20::retType_14_20' declared here
-   46 |   using retType_14_20 = int (*)(int, int);
+.tmp.cpp:45:9: note: '__lambda_14_20::retType_14_20' declared here
+   45 |   using retType_14_20 = int (*)(int, int);
       |         ^
-.tmp.cpp:198:38: error: no member named 'operator int (*)(int, int)' in '__lambda_32_27'
-  198 |   FuncPtr_41 fp = lWithParamsAndNTTP.operator __lambda_32_27::retType_32_27();
+.tmp.cpp:194:38: error: no member named 'operator int (*)(int, int)' in '__lambda_32_27'
+  194 |   FuncPtr_41 fp = lWithParamsAndNTTP.operator __lambda_32_27::retType_32_27();
       |                   ~~~~~~~~~~~~~~~~~~ ^
 4 errors generated.

--- a/tests/LambdaWithStaticInvokerTest.expect
+++ b/tests/LambdaWithStaticInvokerTest.expect
@@ -24,8 +24,7 @@ void NoParams()
     
     
     public:
-    // /*constexpr */ __lambda_5_14() = default;
-    
+    // /* constexpr */ __lambda_5_14() = default;
   };
   
   __lambda_5_14 l = __lambda_5_14{};
@@ -57,8 +56,7 @@ class __lambda_14_20
   
   
   public:
-  // /*constexpr */ __lambda_14_20() = default;
-  
+  // /* constexpr */ __lambda_14_20() = default;
 };
 
 __lambda_14_20 lWithParams = __lambda_14_20{};
@@ -115,8 +113,7 @@ class __lambda_25_16
   
   
   public:
-  // /*constexpr */ __lambda_25_16() = default;
-  
+  // /* constexpr */ __lambda_25_16() = default;
 };
 
 __lambda_25_16 glambda = __lambda_25_16{};
@@ -185,8 +182,7 @@ class __lambda_32_27
   
   
   public:
-  // /*constexpr */ __lambda_32_27() = default;
-  
+  // /* constexpr */ __lambda_32_27() = default;
 };
 
 __lambda_32_27 lWithParamsAndNTTP = __lambda_32_27{};

--- a/tests/MemberExprTemplateTest.expect
+++ b/tests/MemberExprTemplateTest.expect
@@ -35,15 +35,9 @@ void test(X x)
       x.ff<int, int, double>(17, 2, 55.5);
     }
     
-    private: 
+    // private: 
     X & x;
-    
-    public:
-    __lambda_10_5(X & _x)
-    : x{_x}
-    {}
-    
-  } __lambda_10_5{x};
+  };
   
-  __lambda_10_5.operator()();
+  __lambda_10_5{x}.operator()();
 }

--- a/tests/MultipleLambdasInOneLineTest.expect
+++ b/tests/MultipleLambdasInOneLineTest.expect
@@ -23,8 +23,7 @@ int main()
       __lambda_5_3{}.operator()();
     }
     
-    
-  } __lambda_5_3{};
+  };
   
     
   class __lambda_5_33
@@ -47,9 +46,8 @@ int main()
       __lambda_5_33{}.operator()();
     }
     
-    
-  } __lambda_5_33{};
+  };
   
-  __lambda_5_3.operator()() , __lambda_5_33.operator()();
+  __lambda_5_3{}.operator()() , __lambda_5_33{}.operator()();
   return 0;
 }

--- a/tests/RangeForStmtHandlerTest.expect
+++ b/tests/RangeForStmtHandlerTest.expect
@@ -16,14 +16,8 @@ struct A
         return ++i;
       }
       
-      private: 
+      // private: 
       int & i;
-      
-      public:
-      __lambda_10_38(int & _i)
-      : i{_i}
-      {}
-      
     };
     
     std::generate(&this->v[0], &this->v[10], __lambda_10_38{i});
@@ -47,14 +41,8 @@ struct B
         return ++i;
       }
       
-      private: 
+      // private: 
       int & i;
-      
-      public:
-      __lambda_22_38(int & _i)
-      : i{_i}
-      {}
-      
     };
     
     std::generate(&this->v[0], &this->v[10], __lambda_22_38{i});

--- a/tests/ReplaceClangNamespaceTest.expect
+++ b/tests/ReplaceClangNamespaceTest.expect
@@ -31,9 +31,8 @@ int main()
       __lambda_11_5{}.operator()();
     }
     
-    
-  } __lambda_11_5{};
+  };
   
-  __lambda_11_5.operator()();
+  __lambda_11_5{}.operator()();
   return 0;
 }

--- a/tests/StdInitializerList2Test.cerr
+++ b/tests/StdInitializerList2Test.cerr
@@ -1,10 +1,7 @@
 .tmp.cpp:8:64: error: cannot initialize an array element of type 'const int' with an lvalue of type 'const int[2]'
     8 |   std::initializer_list<int> list = std::initializer_list<int>{__list8_43, 2};
       |                                                                ^~~~~~~~~~
-.tmp.cpp:23:12: error: no viable conversion from 'const std::initializer_list<int>' to 'const int'
-   23 |     : list{_list}
-      |            ^~~~~
-.tmp.cpp:37:41: error: cannot initialize an array element of type 'const int' with an lvalue of type 'const int[2]'
-   37 |       return std::initializer_list<int>{__list14_56, 2};
+.tmp.cpp:31:41: error: cannot initialize an array element of type 'const int' with an lvalue of type 'const int[2]'
+   31 |       return std::initializer_list<int>{__list14_56, 2};
       |                                         ^~~~~~~~~~~
-3 errors generated.
+2 errors generated.

--- a/tests/StdInitializerList2Test.expect
+++ b/tests/StdInitializerList2Test.expect
@@ -15,14 +15,8 @@ int main(int argc, const char **)
       return std::initializer_list<int>(list);
     }
     
-    private: 
+    // private: 
     std::initializer_list<int> list;
-    
-    public:
-    __lambda_10_17(const std::initializer_list<int> & _list)
-    : list{_list}
-    {}
-    
   };
   
   __lambda_10_17 lamb = __lambda_10_17{list};
@@ -37,16 +31,9 @@ int main(int argc, const char **)
       return std::initializer_list<int>{__list14_56, 2};
     }
     
-    private: 
+    // private: 
     int i;
     int x;
-    
-    public:
-    __lambda_14_18(int & _i, int & _x)
-    : i{_i}
-    , x{_x}
-    {}
-    
   };
   
   __lambda_14_18 lamb2 = __lambda_14_18{i, x};

--- a/tests/StructuredBindingsHandler7Test.expect
+++ b/tests/StructuredBindingsHandler7Test.expect
@@ -12,16 +12,10 @@ int main()
       char & b = __buffer5[1];
     }
     
-    private: 
+    // private: 
     char (&buffer)[2];
-    
-    public:
-    __lambda_4_5(char (&_buffer)[2])
-    : buffer{_buffer}
-    {}
-    
-  } __lambda_4_5{buffer};
+  };
   
-  __lambda_4_5.operator()();
+  __lambda_4_5{buffer}.operator()();
   return 0;
 }

--- a/tests/TemplateMemberFunctionTest.expect
+++ b/tests/TemplateMemberFunctionTest.expect
@@ -77,7 +77,6 @@ int main()
       __lambda_33_10{}.operator()();
     }
     
-    
   };
   
   f.Do<__lambda_33_10>(__lambda_33_10{});
@@ -102,7 +101,6 @@ int main()
       __lambda_35_18{}.operator()();
     }
     
-    
   };
   
   f.DoOther<1>(__lambda_35_18{});
@@ -126,7 +124,6 @@ int main()
     {
       __lambda_37_21{}.operator()();
     }
-    
     
   };
   

--- a/tests/TemplatesWithAutoAndLambdaTest.cerr
+++ b/tests/TemplatesWithAutoAndLambdaTest.cerr
@@ -4,22 +4,22 @@
 .tmp.cpp:19:5: error: templates cannot be declared inside of a local class
    19 |     template<class type_parameter_1_0>
       |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-.tmp.cpp:41:5: error: templates cannot be declared inside of a local class
-   41 |     template<class type_parameter_0_0>
+.tmp.cpp:40:5: error: templates cannot be declared inside of a local class
+   40 |     template<class type_parameter_0_0>
       |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-.tmp.cpp:48:5: error: templates cannot be declared inside of a local class
-   48 |     template<>
+.tmp.cpp:47:5: error: templates cannot be declared inside of a local class
+   47 |     template<>
       |     ^~~~~~~~~~
-.tmp.cpp:57:5: error: templates cannot be declared inside of a local class
-   57 |     template<>
+.tmp.cpp:56:5: error: templates cannot be declared inside of a local class
+   56 |     template<>
       |     ^~~~~~~~~~
-.tmp.cpp:65:5: error: templates cannot be declared inside of a local class
-   65 |     template<class type_parameter_0_0>
+.tmp.cpp:64:5: error: templates cannot be declared inside of a local class
+   64 |     template<class type_parameter_0_0>
       |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-.tmp.cpp:68:42: error: 'type_parameter_0_0' does not refer to a value
-   68 |       return __lambda_11_28{}.operator()<type_parameter_0_0>(arg);
+.tmp.cpp:67:42: error: 'type_parameter_0_0' does not refer to a value
+   67 |       return __lambda_11_28{}.operator()<type_parameter_0_0>(arg);
       |                                          ^
-.tmp.cpp:65:20: note: declared here
-   65 |     template<class type_parameter_0_0>
+.tmp.cpp:64:20: note: declared here
+   64 |     template<class type_parameter_0_0>
       |                    ^
 7 errors generated.

--- a/tests/TemplatesWithAutoAndLambdaTest.expect
+++ b/tests/TemplatesWithAutoAndLambdaTest.expect
@@ -21,7 +21,6 @@ void print(const T1 & arg1, const Types &... args)
     {
       return __lambda_11_28{}.operator()<type_parameter_1_0>(arg);
     }
-    
   };
   
   auto coutSpaceAndArg = __lambda_11_28{};
@@ -67,7 +66,6 @@ void print<' ', char[3], double, std::basic_string<char, std::char_traits<char>,
     {
       return __lambda_11_28{}.operator()<type_parameter_0_0>(arg);
     }
-    
   };
   
   __lambda_11_28 coutSpaceAndArg = __lambda_11_28{};

--- a/tests/TypeAliasTest.expect
+++ b/tests/TypeAliasTest.expect
@@ -14,9 +14,8 @@ int main()
       return x + y;
     }
     
-    
-  } __lambda_3_12{};
+  };
   
-  int w = __lambda_3_12.operator()();
+  int w = __lambda_3_12{}.operator()();
   return 0;
 }

--- a/tests/VarTemplateWithLambdaTest.cerr
+++ b/tests/VarTemplateWithLambdaTest.cerr
@@ -1,11 +1,11 @@
-.tmp.cpp:23:7: error: redefinition of '__lambda_8_23' as different kind of symbol
-   23 | class __lambda_8_23
+.tmp.cpp:22:7: error: redefinition of '__lambda_8_23' as different kind of symbol
+   22 | class __lambda_8_23
       |       ^
 .tmp.cpp:5:7: note: previous definition is here
     5 | class __lambda_8_23
       |       ^
-.tmp.cpp:49:29: error: no viable constructor or deduction guide for deduction of template arguments of '__lambda_8_23'
-   49 | constexpr const auto func = __lambda_8_23{};
+.tmp.cpp:47:29: error: no viable constructor or deduction guide for deduction of template arguments of '__lambda_8_23'
+   47 | constexpr const auto func = __lambda_8_23{};
       |                             ^
 .tmp.cpp:5:7: note: candidate template ignored: couldn't infer template argument 'T'
     5 | class __lambda_8_23
@@ -15,17 +15,17 @@
     5 | class __lambda_8_23
       |       ^~~~~~~~~~~~~
 .tmp.cpp:5:7: note: implicit deduction guide declared as 'template <typename T> __lambda_8_23(__lambda_8_23<T>) -> __lambda_8_23<T>'
-.tmp.cpp:51:1: error: extraneous 'template<>' in declaration of variable 'func'
-   51 | template<>
+.tmp.cpp:49:1: error: extraneous 'template<>' in declaration of variable 'func'
+   49 | template<>
       | ^~~~~~~~~~
-.tmp.cpp:52:31: error: redefinition of 'func'
-   52 | constexpr const __lambda_8_23 func<double> = __lambda_8_23{};
+.tmp.cpp:50:31: error: redefinition of 'func'
+   50 | constexpr const __lambda_8_23 func<double> = __lambda_8_23{};
       |                               ^
-.tmp.cpp:49:22: note: previous definition is here
-   49 | constexpr const auto func = __lambda_8_23{};
+.tmp.cpp:47:22: note: previous definition is here
+   47 | constexpr const auto func = __lambda_8_23{};
       |                      ^
-.tmp.cpp:52:31: error: no viable constructor or deduction guide for deduction of template arguments of '__lambda_8_23'
-   52 | constexpr const __lambda_8_23 func<double> = __lambda_8_23{};
+.tmp.cpp:50:31: error: no viable constructor or deduction guide for deduction of template arguments of '__lambda_8_23'
+   50 | constexpr const __lambda_8_23 func<double> = __lambda_8_23{};
       |                               ^
 .tmp.cpp:5:7: note: candidate template ignored: couldn't infer template argument 'T'
     5 | class __lambda_8_23
@@ -35,65 +35,65 @@
     5 | class __lambda_8_23
       |       ^~~~~~~~~~~~~
 .tmp.cpp:5:7: note: implicit deduction guide declared as 'template <typename T> __lambda_8_23(__lambda_8_23<T>) -> __lambda_8_23<T>'
-.tmp.cpp:52:35: error: expected ';' after top level declarator
-   52 | constexpr const __lambda_8_23 func<double> = __lambda_8_23{};
+.tmp.cpp:50:35: error: expected ';' after top level declarator
+   50 | constexpr const __lambda_8_23 func<double> = __lambda_8_23{};
       |                                   ^
       |                                   ;
-.tmp.cpp:74:7: error: redefinition of '__lambda_11_29' as different kind of symbol
-   74 | class __lambda_11_29
+.tmp.cpp:71:7: error: redefinition of '__lambda_11_29' as different kind of symbol
+   71 | class __lambda_11_29
       |       ^
-.tmp.cpp:56:7: note: previous definition is here
-   56 | class __lambda_11_29
+.tmp.cpp:54:7: note: previous definition is here
+   54 | class __lambda_11_29
       |       ^
-.tmp.cpp:100:35: error: no viable constructor or deduction guide for deduction of template arguments of '__lambda_11_29'
-  100 | constexpr const auto funcBraced = __lambda_11_29{};
+.tmp.cpp:96:35: error: no viable constructor or deduction guide for deduction of template arguments of '__lambda_11_29'
+   96 | constexpr const auto funcBraced = __lambda_11_29{};
       |                                   ^
-.tmp.cpp:56:7: note: candidate template ignored: couldn't infer template argument 'T'
-   56 | class __lambda_11_29
+.tmp.cpp:54:7: note: candidate template ignored: couldn't infer template argument 'T'
+   54 | class __lambda_11_29
       |       ^
-.tmp.cpp:56:7: note: implicit deduction guide declared as 'template <typename T> __lambda_11_29() -> __lambda_11_29<T>'
-.tmp.cpp:56:7: note: candidate function template not viable: requires 1 argument, but 0 were provided
-   56 | class __lambda_11_29
+.tmp.cpp:54:7: note: implicit deduction guide declared as 'template <typename T> __lambda_11_29() -> __lambda_11_29<T>'
+.tmp.cpp:54:7: note: candidate function template not viable: requires 1 argument, but 0 were provided
+   54 | class __lambda_11_29
       |       ^~~~~~~~~~~~~~
-.tmp.cpp:56:7: note: implicit deduction guide declared as 'template <typename T> __lambda_11_29(__lambda_11_29<T>) -> __lambda_11_29<T>'
-.tmp.cpp:102:1: error: extraneous 'template<>' in declaration of variable 'funcBraced'
-  102 | template<>
+.tmp.cpp:54:7: note: implicit deduction guide declared as 'template <typename T> __lambda_11_29(__lambda_11_29<T>) -> __lambda_11_29<T>'
+.tmp.cpp:98:1: error: extraneous 'template<>' in declaration of variable 'funcBraced'
+   98 | template<>
       | ^~~~~~~~~~
-.tmp.cpp:103:32: error: redefinition of 'funcBraced'
-  103 | constexpr const __lambda_11_29 funcBraced<int> = __lambda_11_29{};
+.tmp.cpp:99:32: error: redefinition of 'funcBraced'
+   99 | constexpr const __lambda_11_29 funcBraced<int> = __lambda_11_29{};
       |                                ^
-.tmp.cpp:100:22: note: previous definition is here
-  100 | constexpr const auto funcBraced = __lambda_11_29{};
+.tmp.cpp:96:22: note: previous definition is here
+   96 | constexpr const auto funcBraced = __lambda_11_29{};
       |                      ^
-.tmp.cpp:103:32: error: no viable constructor or deduction guide for deduction of template arguments of '__lambda_11_29'
-  103 | constexpr const __lambda_11_29 funcBraced<int> = __lambda_11_29{};
+.tmp.cpp:99:32: error: no viable constructor or deduction guide for deduction of template arguments of '__lambda_11_29'
+   99 | constexpr const __lambda_11_29 funcBraced<int> = __lambda_11_29{};
       |                                ^
-.tmp.cpp:56:7: note: candidate template ignored: couldn't infer template argument 'T'
-   56 | class __lambda_11_29
+.tmp.cpp:54:7: note: candidate template ignored: couldn't infer template argument 'T'
+   54 | class __lambda_11_29
       |       ^
-.tmp.cpp:56:7: note: implicit deduction guide declared as 'template <typename T> __lambda_11_29() -> __lambda_11_29<T>'
-.tmp.cpp:56:7: note: candidate function template not viable: requires 1 argument, but 0 were provided
-   56 | class __lambda_11_29
+.tmp.cpp:54:7: note: implicit deduction guide declared as 'template <typename T> __lambda_11_29() -> __lambda_11_29<T>'
+.tmp.cpp:54:7: note: candidate function template not viable: requires 1 argument, but 0 were provided
+   54 | class __lambda_11_29
       |       ^~~~~~~~~~~~~~
-.tmp.cpp:56:7: note: implicit deduction guide declared as 'template <typename T> __lambda_11_29(__lambda_11_29<T>) -> __lambda_11_29<T>'
-.tmp.cpp:103:42: error: expected ';' after top level declarator
-  103 | constexpr const __lambda_11_29 funcBraced<int> = __lambda_11_29{};
+.tmp.cpp:54:7: note: implicit deduction guide declared as 'template <typename T> __lambda_11_29(__lambda_11_29<T>) -> __lambda_11_29<T>'
+.tmp.cpp:99:42: error: expected ';' after top level declarator
+   99 | constexpr const __lambda_11_29 funcBraced<int> = __lambda_11_29{};
       |                                          ^
       |                                          ;
-.tmp.cpp:107:21: error: expected '(' for function-style cast or type construction
-  107 |   return func<double>.operator()(x);
+.tmp.cpp:103:21: error: expected '(' for function-style cast or type construction
+  103 |   return func<double>.operator()(x);
       |               ~~~~~~^
-.tmp.cpp:107:22: error: expected expression
-  107 |   return func<double>.operator()(x);
+.tmp.cpp:103:22: error: expected expression
+  103 |   return func<double>.operator()(x);
       |                      ^
-.tmp.cpp:113:44: error: expected '(' for function-style cast or type construction
-  113 |   return static_cast<double>(funcBraced<int>.operator()(x));
+.tmp.cpp:109:44: error: expected '(' for function-style cast or type construction
+  109 |   return static_cast<double>(funcBraced<int>.operator()(x));
       |                                         ~~~^
-.tmp.cpp:113:45: error: expected expression
-  113 |   return static_cast<double>(funcBraced<int>.operator()(x));
+.tmp.cpp:109:45: error: expected expression
+  109 |   return static_cast<double>(funcBraced<int>.operator()(x));
       |                                             ^
-.tmp.cpp:113:45: error: expected ')'
-.tmp.cpp:113:29: note: to match this '('
-  113 |   return static_cast<double>(funcBraced<int>.operator()(x));
+.tmp.cpp:109:45: error: expected ')'
+.tmp.cpp:109:29: note: to match this '('
+  109 |   return static_cast<double>(funcBraced<int>.operator()(x));
       |                             ^
 17 errors generated.

--- a/tests/VarTemplateWithLambdaTest.expect
+++ b/tests/VarTemplateWithLambdaTest.expect
@@ -16,7 +16,6 @@ class __lambda_8_23
   {
     return __lambda_8_23{}.operator()<type_parameter_1_0>(x);
   }
-  
 };
 
 
@@ -43,7 +42,6 @@ class __lambda_8_23
   {
     return __lambda_8_23{}.operator()<type_parameter_0_0>(x);
   }
-  
 };
 
 constexpr const auto func = __lambda_8_23{};
@@ -67,7 +65,6 @@ class __lambda_11_29
   {
     return __lambda_11_29{}.operator()<type_parameter_1_0>(x);
   }
-  
 };
 
 
@@ -94,7 +91,6 @@ class __lambda_11_29
   {
     return __lambda_11_29{}.operator()<type_parameter_0_0>(x);
   }
-  
 };
 
 constexpr const auto funcBraced = __lambda_11_29{};

--- a/tests/VisitorTest.expect
+++ b/tests/VisitorTest.expect
@@ -42,7 +42,6 @@ int main()
     
     // inline /*constexpr */ __lambda_8_7 & operator=(const __lambda_8_7 &) /* noexcept */ = delete;
     // inline /*constexpr */ __lambda_8_7(__lambda_8_7 &&) noexcept = default;
-    
   };
   
   
@@ -55,7 +54,6 @@ int main()
     
     // inline /*constexpr */ __lambda_9_7 & operator=(const __lambda_9_7 &) /* noexcept */ = delete;
     // inline /*constexpr */ __lambda_9_7(__lambda_9_7 &&) noexcept = default;
-    
   };
   
   visitor<__lambda_8_7, __lambda_9_7> my_visitor = visitor{__lambda_8_7(__lambda_8_7{}), __lambda_9_7(__lambda_9_7{})};

--- a/tests/p0195Test.expect
+++ b/tests/p0195Test.expect
@@ -56,7 +56,6 @@ int main()
     public: 
     // inline /*constexpr */ __lambda_12_7 & operator=(const __lambda_12_7 &) /* noexcept */ = delete;
     // inline /*constexpr */ __lambda_12_7(__lambda_12_7 &&) noexcept = default;
-    
   };
   
   
@@ -82,7 +81,6 @@ int main()
     public: 
     // inline /*constexpr */ __lambda_13_7 & operator=(const __lambda_13_7 &) /* noexcept */ = delete;
     // inline /*constexpr */ __lambda_13_7(__lambda_13_7 &&) noexcept = default;
-    
   };
   
   overload<__lambda_12_7, __lambda_13_7> ol = {__lambda_12_7(__lambda_12_7{}), __lambda_13_7(__lambda_13_7{})};

--- a/tests/p0315Test.expect
+++ b/tests/p0315Test.expect
@@ -25,8 +25,7 @@ namespace A
     
     
     public:
-    // /*constexpr */ __lambda_6_33() = default;
-    
+    // /* constexpr */ __lambda_6_33() = default;
   };
   
   template<class F = __lambda_6_33>

--- a/tests/p0315_2Test.expect
+++ b/tests/p0315_2Test.expect
@@ -22,8 +22,7 @@ class __lambda_5_28
   
   
   public:
-  // /*constexpr */ __lambda_5_28() = default;
-  
+  // /* constexpr */ __lambda_5_28() = default;
 };
 
 static std::array<__lambda_5_28, 2> ff();
@@ -56,8 +55,7 @@ class __lambda_11_27
   
   
   public:
-  // /*constexpr */ __lambda_11_27() = default;
-  
+  // /* constexpr */ __lambda_11_27() = default;
 };
 
 static Container<__lambda_11_27, 2> c();
@@ -84,8 +82,7 @@ class __lambda_13_17
   
   
   public:
-  // /*constexpr */ __lambda_13_17() = default;
-  
+  // /* constexpr */ __lambda_13_17() = default;
 };
 
 static __lambda_13_17 & f();
@@ -112,8 +109,7 @@ class __lambda_15_24
   
   
   public:
-  // /*constexpr */ __lambda_15_24() = default;
-  
+  // /* constexpr */ __lambda_15_24() = default;
 };
 
 static void h(__lambda_15_24 *)
@@ -142,8 +138,7 @@ class __lambda_17_24
   
   
   public:
-  // /*constexpr */ __lambda_17_24() = default;
-  
+  // /* constexpr */ __lambda_17_24() = default;
 };
 
 
@@ -169,8 +164,7 @@ class __lambda_17_43
   
   
   public:
-  // /*constexpr */ __lambda_17_43() = default;
-  
+  // /* constexpr */ __lambda_17_43() = default;
 };
 
 static void w(__lambda_17_24 *, __lambda_17_43 &)

--- a/tests/p0315_3Test.cerr
+++ b/tests/p0315_3Test.cerr
@@ -1,20 +1,20 @@
-.tmp.cpp:37:26: error: 'auto' not allowed in type alias
-   37 |     using retType_9_14 = auto (*)();
+.tmp.cpp:36:26: error: 'auto' not allowed in type alias
+   36 |     using retType_9_14 = auto (*)();
       |                          ^~~~
-.tmp.cpp:38:31: error: unknown type name 'retType_9_14'; did you mean '__lambda_7_5::retType_7_5'?
-   38 |     inline constexpr operator retType_9_14 () const noexcept
+.tmp.cpp:37:31: error: unknown type name 'retType_9_14'; did you mean '__lambda_7_5::retType_7_5'?
+   37 |     inline constexpr operator retType_9_14 () const noexcept
       |                               ^~~~~~~~~~~~
       |                               __lambda_7_5::retType_7_5
 .tmp.cpp:11:11: note: '__lambda_7_5::retType_7_5' declared here
    11 |     using retType_7_5 = auto (*)() -> void;
       |           ^
-.tmp.cpp:40:14: error: function '__invoke' with deduced return type cannot be used before it is defined
-   40 |       return __invoke;
+.tmp.cpp:39:14: error: function '__invoke' with deduced return type cannot be used before it is defined
+   39 |       return __invoke;
       |              ^
-.tmp.cpp:44:24: note: '__invoke' declared here
-   44 |     static inline auto __invoke()
+.tmp.cpp:43:24: note: '__invoke' declared here
+   43 |     static inline auto __invoke()
       |                        ^
-.tmp.cpp:38:22: error: no return statement in constexpr function
-   38 |     inline constexpr operator retType_9_14 () const noexcept
+.tmp.cpp:37:22: error: no return statement in constexpr function
+   37 |     inline constexpr operator retType_9_14 () const noexcept
       |                      ^
 4 errors generated.

--- a/tests/p0315_3Test.expect
+++ b/tests/p0315_3Test.expect
@@ -22,8 +22,7 @@ namespace Test
     
     
     public:
-    // /*constexpr */ __lambda_7_5() = default;
-    
+    // /* constexpr */ __lambda_7_5() = default;
   };
   
   
@@ -48,8 +47,7 @@ namespace Test
     
     
     public:
-    // /*constexpr */ __lambda_9_14() = default;
-    
+    // /* constexpr */ __lambda_9_14() = default;
   };
   
   template<typename T>

--- a/tests/p0315_4Test.expect
+++ b/tests/p0315_4Test.expect
@@ -24,8 +24,7 @@ struct Test
     
     
     public:
-    // /*constexpr */ __lambda_5_13() = default;
-    
+    // /* constexpr */ __lambda_5_13() = default;
   };
   
   __lambda_5_13 a;
@@ -50,8 +49,7 @@ struct Test
     }
     
     public: 
-    // /*constexpr */ __lambda_7_29() = default;
-    
+    // /* constexpr */ __lambda_7_29() = default;
   };
   
   void (*fp)() = (+__lambda_7_29{}.operator __lambda_7_29::retType_7_29());

--- a/tests/p0315_5Test.cerr
+++ b/tests/p0315_5Test.cerr
@@ -1,5 +1,5 @@
-.tmp.cpp:32:37: error: '__invoke' is a private member of '__lambda_7_32'
-   32 | static LambdaInNTTP<&__lambda_7_32::__invoke> lambdaInNTTP();
+.tmp.cpp:31:37: error: '__invoke' is a private member of '__lambda_7_32'
+   31 | static LambdaInNTTP<&__lambda_7_32::__invoke> lambdaInNTTP();
       |                                     ^
 .tmp.cpp:22:37: note: declared private here
    22 |   static inline /*constexpr */ void __invoke()

--- a/tests/p0315_5Test.expect
+++ b/tests/p0315_5Test.expect
@@ -25,8 +25,7 @@ class __lambda_7_32
   }
   
   public: 
-  // /*constexpr */ __lambda_7_32() = default;
-  
+  // /* constexpr */ __lambda_7_32() = default;
 };
 
 static LambdaInNTTP<&__lambda_7_32::__invoke> lambdaInNTTP();

--- a/tests/p0315_6Test.expect
+++ b/tests/p0315_6Test.expect
@@ -19,8 +19,7 @@ class __lambda_3_47
   }
   
   public: 
-  // /*constexpr */ __lambda_3_47() = default;
-  
+  // /* constexpr */ __lambda_3_47() = default;
 };
 
 using FuncPtr_3 = auto (*)() -> void;
@@ -48,8 +47,7 @@ class __lambda_5_16
   
   
   public:
-  // /*constexpr */ __lambda_5_16() = default;
-  
+  // /* constexpr */ __lambda_5_16() = default;
 };
 
 using FuncPtr_5 = void (*)();

--- a/tests/p0315_7Test.expect
+++ b/tests/p0315_7Test.expect
@@ -21,8 +21,7 @@ class __lambda_3_29
   
   
   public:
-  // /*constexpr */ __lambda_3_29() = default;
-  
+  // /* constexpr */ __lambda_3_29() = default;
 };
 
 template<class F = __lambda_3_29>

--- a/tests/p0428Test.expect
+++ b/tests/p0428Test.expect
@@ -24,8 +24,7 @@ class __lambda_3_10
   }
   
   public:
-  // /*constexpr */ __lambda_3_10() = default;
-  
+  // /* constexpr */ __lambda_3_10() = default;
 };
 
 __lambda_3_10 l = __lambda_3_10{};

--- a/tests/p0780Test.cerr
+++ b/tests/p0780Test.cerr
@@ -7,8 +7,4 @@
 .tmp.cpp:22:9: error: only function and template parameters can be parameter packs
    22 |     auto... args;
       |         ^
-error: templates cannot be declared inside of a local class
-.tmp.cpp:30:19: error: initializer contains unexpanded parameter pack 'args'
-   30 |   } __lambda_13_12{std::move(f), std::move(args)};
-      |                   ^                        ~~~~
-5 errors generated.
+3 errors generated.

--- a/tests/p0780Test.expect
+++ b/tests/p0780Test.expect
@@ -17,19 +17,12 @@ auto delay_invoke(F f, Args... args)
       return std::invoke(f, args... );
     }
     
-    private: 
+    // private: 
     auto f;
     auto... args;
-    
-    public:
-    __lambda_13_12(auto _f, auto const &... _args)
-    : f{_f}
-    , args{_args...}
-    {}
-    
-  } __lambda_13_12{std::move(f), std::move(args)};
+  };
   
-  return __lambda_13_12;
+  return __lambda_13_12{std::move(f), std::move(args)...};
 }
 
 #ifdef INSIGHTS_USE_TEMPLATE
@@ -45,25 +38,15 @@ __lambda_13_12 delay_invoke<void (*)(int, int, int, int), int, int, int, int>(vo
       return std::invoke(f, __args1, __args2, __args3, __args4);
     }
     
-    private: 
+    // private: 
     void (*f)(int, int, int, int);
     int __args1;
     int __args2;
     int __args3;
     int __args4;
-    
-    public:
-    __lambda_13_12(void (*_f)(int, int, int, int), int && ___args1, int && ___args2, int && ___args3, int && ___args4)
-    : f{_f}
-    , __args1{std::move(___args1)}
-    , __args2{std::move(___args2)}
-    , __args3{std::move(___args3)}
-    , __args4{std::move(___args4)}
-    {}
-    
-  } __lambda_13_12{std::move(f), std::move(__args1), std::move(__args2), std::move(__args3), std::move(__args4)};
+  };
   
-  return __lambda_13_12;
+  return __lambda_13_12{std::move(f), std::move(__args1), std::move(__args2), std::move(__args3), std::move(__args4)};
 }
 #endif
 

--- a/tests/p0780_2Test.cerr
+++ b/tests/p0780_2Test.cerr
@@ -7,24 +7,20 @@
 .tmp.cpp:24:9: error: only function and template parameters can be parameter packs
    24 |     auto... targs;
       |         ^
-error: templates cannot be declared inside of a local class
-.tmp.cpp:32:19: error: initializer contains unexpanded parameter pack 'args'
-   32 |   } __lambda_15_12{std::move(f), std::move(args)};
-      |                   ^                        ~~~~
-.tmp.cpp:39:1: error: unknown type name '__lambda_15_12'
-   39 | __lambda_15_12 delay_invoke<void (*)(int, int, int, int), int, int, int, int>(void (*f)(int, int, int, int), int __args1, int __args2, int __args3, int __args4)
+.tmp.cpp:32:1: error: unknown type name '__lambda_15_12'
+   32 | __lambda_15_12 delay_invoke<void (*)(int, int, int, int), int, int, int, int>(void (*f)(int, int, int, int), int __args1, int __args2, int __args3, int __args4)
       | ^
-.tmp.cpp:45:27: error: no template named 'invoke_result_t'; did you mean 'std::invoke_result_t'?
-   45 |     inline /*constexpr */ invoke_result_t<void (*const &)(int, int, int, int), const int &, const int &, const int &, const int &> operator()() const
+.tmp.cpp:38:27: error: no template named 'invoke_result_t'; did you mean 'std::invoke_result_t'?
+   38 |     inline /*constexpr */ invoke_result_t<void (*const &)(int, int, int, int), const int &, const int &, const int &, const int &> operator()() const
       |                           ^~~~~~~~~~~~~~~
       |                           std::invoke_result_t
 ... invoke.h:387:1: note: 'std::invoke_result_t' declared here
   387 | using invoke_result_t = __invoke_result_t<_Fn, _Args...>;
       | ^
-.tmp.cpp:68:10: error: no viable conversion from returned value of type 'class __lambda_15_12' to function return type 'int'
-   68 |   return __lambda_15_12;
-      |          ^~~~~~~~~~~~~~
-.tmp.cpp:75:3: error: unknown type name '__lambda_15_12'
-   75 |   __lambda_15_12 df = delay_invoke(Func, 2, 3, 4, 5);
+.tmp.cpp:51:10: error: no viable conversion from returned value of type '__lambda_15_12' to function return type 'int'
+   51 |   return __lambda_15_12{std::move(f), std::move(__args1), std::move(__args2), std::move(__args3), std::move(__args4)};
+      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.tmp.cpp:58:3: error: unknown type name '__lambda_15_12'
+   58 |   __lambda_15_12 df = delay_invoke(Func, 2, 3, 4, 5);
       |   ^
-9 errors generated.
+7 errors generated.

--- a/tests/p0780_2Test.expect
+++ b/tests/p0780_2Test.expect
@@ -19,19 +19,12 @@ auto delay_invoke(F f, Args... args)
       return std::invoke(f, targs... );
     }
     
-    private: 
+    // private: 
     auto f;
     auto... targs;
-    
-    public:
-    __lambda_15_12(auto _f, auto const &... _targs)
-    : f{_f}
-    , targs{_targs...}
-    {}
-    
-  } __lambda_15_12{std::move(f), std::move(args)};
+  };
   
-  return __lambda_15_12;
+  return __lambda_15_12{std::move(f), std::move(args)...};
 }
 
 #ifdef INSIGHTS_USE_TEMPLATE
@@ -47,25 +40,15 @@ __lambda_15_12 delay_invoke<void (*)(int, int, int, int), int, int, int, int>(vo
       return std::invoke(f, __targs1, __targs2, __targs3, __targs4);
     }
     
-    private: 
+    // private: 
     void (*f)(int, int, int, int);
     int __targs1;
     int __targs2;
     int __targs3;
     int __targs4;
-    
-    public:
-    __lambda_15_12(void (*_f)(int, int, int, int), int && ___targs1, int && ___targs2, int && ___targs3, int && ___targs4)
-    : f{_f}
-    , __targs1{std::move(___targs1)}
-    , __targs2{std::move(___targs2)}
-    , __targs3{std::move(___targs3)}
-    , __targs4{std::move(___targs4)}
-    {}
-    
-  } __lambda_15_12{std::move(f), std::move(__args1), std::move(__args2), std::move(__args3), std::move(__args4)};
+  };
   
-  return __lambda_15_12;
+  return __lambda_15_12{std::move(f), std::move(__args1), std::move(__args2), std::move(__args3), std::move(__args4)};
 }
 #endif
 

--- a/tests/p1102Test.expect
+++ b/tests/p1102Test.expect
@@ -8,14 +8,8 @@ class __lambda_4_15
     ++s2;
   }
   
-  private: 
+  // private: 
   int s2;
-  
-  public:
-  __lambda_4_15(int & _s2)
-  : s2{_s2}
-  {}
-  
 };
 
 __lambda_4_15 noSean = __lambda_4_15{x};

--- a/tests/p1169Test.expect
+++ b/tests/p1169Test.expect
@@ -13,8 +13,7 @@ class __lambda_3_13
     return operator();
   };
   
-  // /*constexpr */ __lambda_3_13() = default;
-  
+  // /* constexpr */ __lambda_3_13() = default;
 };
 
 __lambda_3_13 four = __lambda_3_13{};

--- a/tests/p2662Test.expect
+++ b/tests/p2662Test.expect
@@ -46,11 +46,10 @@ class __lambda_12_12
   }
   
   public:
-  // /*constexpr */ __lambda_12_12() = default;
-  
-} __lambda_12_12{};
+  // /* constexpr */ __lambda_12_12() = default;
+};
 
-int res = __lambda_12_12.operator()(0, 3.1400000000000001, 'c');
+int res = __lambda_12_12{}.operator()(0, 3.1400000000000001, 'c');
 
 int main()
 {


### PR DESCRIPTION
The prior version requires not only a lot more code but was showing constructors of lambdas. Technically this was incorrect, because the standard requires direct initialization of all captures.

The new implementation swallows the pill making the caputures public and by that get the aggregate behavior.

GCC does something similiar in its implementation. They create an aggregate first and later switch it to a class:

https://github.com/gcc-mirror/gcc/blob/62a80185db84f20f3efb05c81598bffa95bcd63d/gcc/cp/lambda.cc#L121